### PR TITLE
Fix stray prompt in dashboard.py

### DIFF
--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -125,4 +125,3 @@ def dashboard():
     dpg.start_dearpygui()
     dpg.destroy_context()
 
-    


### PR DESCRIPTION
## Summary
- remove stray shell prompt from `dashboard.py`
- keep newline at EOF

## Testing
- `python -m py_compile Causal_Web/gui/dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68751514c8408325b5caf7fd0c7cfcda