### PR TITLE
Remove BOM bytes from engine modules

### DIFF
--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -1,4 +1,4 @@
-﻿import math
+import math
 import cmath
 from collections import defaultdict
 

--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -1,4 +1,4 @@
-﻿import time
+import time
 import threading
 from config import Config
 from .graph import CausalGraph


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM bytes from `node.py`
- strip UTF-8 BOM bytes from `tick_engine.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875153d34bc8325ba92005b5ab91d9f