### PR TITLE
Fix typo in node.py comment

### DIFF
--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -10,7 +10,7 @@ class Node:
         self.frequency = frequency
         self.tick_history = []  # [(tick_time, phase)]
         self.incoming_phase_queue = defaultdict(list)  # tick_time -> [phase_i]
-        self.pending_superpositions = defaultdict(list) # for logging and anaysis
+        self.pending_superpositions = defaultdict(list) # for logging and analysis
         self.current_tick = 0
         self.subjective_ticks = 0  # For relativistic tracking
         self.last_emission_tick = None


### PR DESCRIPTION
## Summary
- fix a minor typo 'anaysis' -> 'analysis'

## Testing
- `grep -n "analysis" -n Causal_Web/engine/node.py`

------
https://chatgpt.com/codex/tasks/task_e_68751537f8f083259ad5a4dd239cecfd