### PR TITLE
Remove duplicate delay key

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -57,12 +57,11 @@ class CausalGraph:
             },
             "edges": [
                 {
-                    "from": e.source, 
-                    "to": e.target, 
+                    "from": e.source,
+                    "to": e.target,
                     "delay": e.delay,
                     "attenuation": e.attenuation,
                     "density": e.density,
-                    "delay": e.delay,
                     "phase_shift": e.phase_shift
                 }
                 for e in self.edges


### PR DESCRIPTION
## Summary
- fix duplicate `delay` key in `CausalGraph.to_dict`

## Testing
- `python -m py_compile Causal_Web/engine/graph.py`

------
https://chatgpt.com/codex/tasks/task_e_6875152db4808325a143607c6a6d7e74