### PR TITLE
Remove stray turtle import

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -1,4 +1,3 @@
-from turtle import delay
 from .node import Node, Edge
 import json
 


### PR DESCRIPTION
## Summary
- drop an unused `from turtle import delay` import

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6875152367808325a80a5a97dc1677c0