### PR TITLE
Enhance CWT engine with tick sources & persistence

### DIFF
--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -81,6 +81,7 @@ class Bridge:
                 drift = abs((phase_a - phase_b + math.pi) % (2 * math.pi) - math.pi)
                 if drift > self.drift_tolerance:
                     print(f"[BRIDGE] Drift too high at tick {tick_time}: {drift:.2f} > {self.drift_tolerance}")
+                    self._log_event(tick_time, "bridge_drift", drift)
                     return
 
         decoherence_a = node_a.compute_decoherence_field(tick_time)


### PR DESCRIPTION
## Summary
- add Tick dataclass and extend Node with phase/coherence fields
- block emissions after collapse
- load tick sources from graph config and emit based on them
- store coherence and decoherence for each node
- log bridge drift events

## Testing
- `python - <<'PY'
from engine.tick_engine import build_graph, simulation_loop
from config import Config
build_graph(); Config.max_ticks=5; Config.tick_rate=0.1; Config.is_running=True
simulation_loop(); import time
while Config.is_running: time.sleep(0.1)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68752453c3f48325b7040cb410004850