### PR TITLE
Fix double scheduling in tick propagation

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -19,11 +19,15 @@ def emit_ticks(global_tick):
             node.apply_tick(global_tick, phase, graph, origin="source")
 
 def propagate_phases(global_tick):
-    for edge in graph.edges:
-        source_node = graph.get_node(edge.source)
-        for tick in source_node.tick_history:
-            if tick.time + edge.adjusted_delay() == global_tick:
-                edge.propagate_phase(tick.phase, global_tick, graph)
+    """Propagate phases scheduled during node ticks.
+
+    Previous versions walked through each node's ``tick_history`` and
+    rescheduled downstream ticks on every global step. This caused phases to
+    arrive after twice the intended edge delay. Node.apply_tick now schedules
+    outgoing phases directly, so this function no longer performs any work but
+    is kept for API compatibility.
+    """
+    pass
 
 def evaluate_nodes(global_tick):
     for node in graph.nodes.values():


### PR DESCRIPTION
## Summary
- prevent duplicate tick scheduling by disabling history-based propagation
- keep Node.apply_tick as the source for sending ticks downstream

## Testing
- `python - <<'PY'
from engine.tick_engine import build_graph, graph, simulation_loop
from config import Config
import time

build_graph()
graph.tick_sources.append({"node_id":"A1","tick_interval":1,"phase":0.0})
Config.max_ticks = 3
Config.tick_rate = 0
Config.is_running = True
simulation_loop()
while Config.is_running:
    time.sleep(0.1)
node_c = graph.get_node('C')
print('C tick times:', [tick.time for tick in node_c.tick_history])
PY`

------
https://chatgpt.com/codex/tasks/task_e_687550d776ec8325ac0e0acc23ed86e7