### PR TITLE
Fix output path in log message

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -113,4 +113,4 @@ def write_output():
     inspection = graph.inspect_superpositions()
     with open("output/inspection_log.json", "w") as f:
         json.dump(inspection, f, indent=2)
-    print("✅ Superposition inspection saved to output/superposition_inspection.json")
+    print("✅ Superposition inspection saved to output/inspection_log.json")


### PR DESCRIPTION
## Summary
- fix path in superposition inspection log message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687550ed166c8325909a3fa10917d58a