### PR TITLE
Fix pending_superpositions cleanup

### DIFF
--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -128,7 +128,8 @@ class Node:
             else:
                 print(f"[{self.id}] Interference at {global_tick} cancelled tick")
             del self.incoming_phase_queue[global_tick]
-            # del self.pending_superpositions[global_tick]  # Clear resolved state
+            if global_tick in self.pending_superpositions:
+                del self.pending_superpositions[global_tick]
         else:
             self.current_threshold = max(self.base_threshold, self.current_threshold - 0.01)
 


### PR DESCRIPTION
## Summary
- clean up `pending_superpositions` once a tick resolves

## Testing
- `python3 -m py_compile Causal_Web/engine/node.py`


------
https://chatgpt.com/codex/tasks/task_e_687550f543dc8325a77373ace8d32893