### PR TITLE
Add overlay rendering and advanced logging

### DIFF
--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -71,11 +71,21 @@ def update_graph_visuals():
             label += f"\nC{cluster_map[node_id]}"
         dpg.draw_text(pos=(x - 30, y - 15), text=label, size=15, color=(255, 255, 255), parent="graph_drawlist")
 
-    # Draw edges
+    # Draw edges with curvature overlays
     for edge in graph.edges:
         from_node = graph.nodes[edge.source]
         to_node = graph.nodes[edge.target]
-        dpg.draw_arrow(p1=(from_node.x, from_node.y), p2=(to_node.x, to_node.y), color=(200, 200, 200), thickness=2, parent="graph_drawlist")
+
+        delay = edge.adjusted_delay(from_node.law_wave_frequency, to_node.law_wave_frequency)
+        thickness = 2 + delay * 0.2
+        intensity = min(255, int(50 + delay * 20))
+        color = (200, 200 - intensity if 200 - intensity > 0 else 0, 200)
+
+        dpg.draw_arrow(p1=(from_node.x, from_node.y),
+                       p2=(to_node.x, to_node.y),
+                       color=color,
+                       thickness=thickness,
+                       parent="graph_drawlist")
 
 
 def refresh():

--- a/Causal_Web/gui/graph_panel.py
+++ b/Causal_Web/gui/graph_panel.py
@@ -40,9 +40,15 @@ def gui_loop():
                 node_tags[node_id] = node_tag
                 tick_counters[node_id] = label_tag
 
-            # Draw directed edges
-            dpg.draw_arrow(p1=node_positions["A1"], p2=node_positions["C"], color=(150, 150, 150), thickness=2)
-            dpg.draw_arrow(p1=node_positions["A2"], p2=node_positions["C"], color=(150, 150, 150), thickness=2)
+            # Draw directed edges with curvature overlays
+            for edge in graph.edges:
+                from_node = graph.nodes[edge.source]
+                to_node = graph.nodes[edge.target]
+                delay = edge.adjusted_delay(from_node.law_wave_frequency, to_node.law_wave_frequency)
+                thickness = 2 + delay * 0.2
+                intensity = min(255, int(50 + delay * 20))
+                color = (150, 150 - intensity if 150 - intensity > 0 else 0, 150)
+                dpg.draw_arrow(p1=(from_node.x, from_node.y), p2=(to_node.x, to_node.y), color=color, thickness=thickness)
 
         dpg.add_button(label="Start Simulation", callback=start_sim)
         dpg.add_text("Tick: 0", tag="tick_counter")


### PR DESCRIPTION
## Summary
- visualize curvature via edge thickness and color
- log consolidated meta-node ticks
- track observer disagreement with actual state
- record depth of collapse chains
- export curvature map in D3-friendly format

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687566904a4083258c4c7076520dce46