### PR TITLE
Fix output persistence

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -5,6 +5,7 @@ from .graph import CausalGraph
 from .observer import Observer
 import json
 import numpy as np
+import os
 
 # Global graph instance
 graph = CausalGraph()
@@ -12,7 +13,19 @@ observers = []
 kappa = 0.5  # curvature strength for refraction fields
 _law_wave_stability = {}
 
+
+def clear_output_directory():
+    """Remove or truncate JSON output files from previous runs."""
+    out_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "output"))
+    if not os.path.isdir(out_dir):
+        return
+    for name in os.listdir(out_dir):
+        if name == "__init__.py":
+            continue
+        open(os.path.join(out_dir, name), "w").close()
+
 def build_graph():
+    clear_output_directory()
     graph.load_from_file("input/graph.json")
 
 def add_observer(observer: Observer):


### PR DESCRIPTION
## Summary
- clear JSON output files on startup
- call helper from `build_graph`

## Testing
- `python -m py_compile Causal_Web/engine/tick_engine.py`
- `python -m py_compile Causal_Web/gui/dashboard.py Causal_Web/engine/node.py Causal_Web/engine/graph.py`

------
https://chatgpt.com/codex/tasks/task_e_68756da349c88325876b38e7f7708fb0