### PR TITLE
Use global kappa when propagating phases

### DIFF
--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -142,7 +142,13 @@ class Node:
         # Recursive phase propagation with refraction
         for edge in graph.get_edges_from(self.id):
             target = graph.get_node(edge.target)
-            delay = edge.adjusted_delay(self.law_wave_frequency, target.law_wave_frequency)
+            # Import here to avoid circular dependency during module load
+            from .tick_engine import kappa
+            delay = edge.adjusted_delay(
+                self.law_wave_frequency,
+                target.law_wave_frequency,
+                kappa,
+            )
             attenuated = phase * edge.attenuation
             shifted = attenuated + edge.phase_shift
             target.schedule_tick(tick_time + delay, shifted)


### PR DESCRIPTION
## Summary
- update `Node.apply_tick` to use the same `kappa` constant as `log_curvature_per_tick`
- ensure delay calculations are consistent between phase propagation and curvature logging

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68756da1ad588325bf17462ff86995fb