### PR TITLE
Remove duplicate cluster logging

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -133,11 +133,6 @@ def log_metrics_per_tick(global_tick):
     with open("output/law_wave_log.json", "a") as f:
         f.write(json.dumps({str(global_tick): law_wave_log}) + "\n")
 
-    clusters = graph.detect_clusters()
-
-    with open("output/cluster_log.json", "a") as f:
-        f.write(json.dumps({str(global_tick): clusters}) + "\n")
-
     with open("output/decoherence_log.json", "a") as f:
         f.write(json.dumps({str(global_tick): decoherence_log}) + "\n")
     with open("output/coherence_log.json", "a") as f:


### PR DESCRIPTION
## Summary
- clean up cluster detection in `tick_engine`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68756da1f2548325848b94a2974c9ff0