### PR TITLE
Add Phase 4 cognitive features

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -6,3 +6,13 @@ class Config:
     max_ticks = 100  # Stop after this many ticks unless set to 0 for infinite
     current_tick = 0  # Counter to display progress
 
+    # Global rhythmic forcing parameters
+    phase_jitter = {
+        "amplitude": 0.0,  # radians
+        "period": 20      # ticks
+    }
+    coherence_wave = {
+        "amplitude": 0.0,  # threshold modulation
+        "period": 30
+    }
+

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -157,6 +157,9 @@ class CausalGraph:
                     "last_tick_time": n.last_tick_time,
                     "subjective_ticks": n.subjective_ticks,
                     "law_wave_frequency": n.law_wave_frequency
+                    ,"trust_profile": n.trust_profile
+                    ,"phase_confidence": n.phase_confidence_index
+                    ,"goals": n.goals
                 } for nid, n in self.nodes.items()
             },
             "superpositions": {
@@ -203,7 +206,8 @@ class CausalGraph:
                 base_threshold=node_data.get("base_threshold", 0.5),
                 phase=node_data.get("phase", 0.0)
             )
-
+            if "goals" in node_data:
+                self.nodes[node_data["id"].__str__()].goals = node_data["goals"]
         for edge in data.get("edges", []):
             self.add_edge(
                 edge["from"], 

--- a/Causal_Web/engine/observer.py
+++ b/Causal_Web/engine/observer.py
@@ -4,16 +4,34 @@ class Observer:
         self.id = observer_id
         self.window = window
         self.memory = []  # list of {'tick': int, 'events': [...]}
+        self.belief_state = {}
+        self.disagreement = []  # list of diffs per tick
 
     def observe(self, graph, tick_time: int):
         events = []
+        seen_nodes = set()
         for node in graph.nodes.values():
             if node.tick_history and node.tick_history[-1].time == tick_time:
                 events.append({
                     'node': node.id,
                     'phase': node.tick_history[-1].phase,
-                    'time': tick_time
+                    'time': tick_time,
+                    'inferred': False
                 })
+                seen_nodes.add(node.id)
+
+        # infer unseen upstream events
+        for ev in list(events):
+            upstream = graph.get_upstream_nodes(ev['node'])
+            for up in upstream:
+                if up not in seen_nodes:
+                    events.append({'node': up, 'phase': None, 'time': tick_time, 'inferred': True})
+                    seen_nodes.add(up)
+
+        self.belief_state.setdefault(tick_time, {})
+        for ev in events:
+            self.belief_state[tick_time].setdefault(ev['node'], 0)
+            self.belief_state[tick_time][ev['node']] += 1
         self.memory.append({'tick': tick_time, 'events': events})
         if len(self.memory) > self.window:
             self.memory.pop(0)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ phase value that propagates through the graph. Edges attenuate and delay phases 
 they arrive at downstream nodes. Nodes decide whether to fire based on the combined
 incoming phases and their current threshold.
 
+Phase 4 introduces memory, intention and rhythmic forcing. Nodes now keep sliding
+histories of recent coherence and learn trust scores for their neighbours. Bridges
+track ruptures and reinforcement streaks while observers attempt to infer unseen
+events. Optional global modulation fields can jitter phases or thresholds for all
+nodes.
+
 The main components are:
 
 - **`engine/graph.py`** – Defines `CausalGraph` which stores nodes and edges. Graphs can be


### PR DESCRIPTION
## Summary
- add rhythmic forcing configuration
- implement node memory, trust, and intention logic
- track adaptive bridge trust and history
- enhance observers with inference of unseen events
- enable global forcing in the tick engine
- document Phase 4 features

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import sys, time
sys.path.append('Causal_Web')
from engine import tick_engine
from config import Config
Config.max_ticks = 2
Config.is_running = True
tick_engine.build_graph()
tick_engine.add_observer(tick_engine.Observer('test', window=2))
tick_engine.simulation_loop()
while Config.is_running:
    time.sleep(0.1)
PY`

------
https://chatgpt.com/codex/tasks/task_e_687575008478832582eeeb6539372e6b