### PR TITLE
Phase 4 engine upgrades

### DIFF
--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -95,11 +95,13 @@ class Bridge:
         decoherence_a = node_a.compute_decoherence_field(tick_time)
         decoherence_b = node_b.compute_decoherence_field(tick_time)
         avg_decoherence = (decoherence_a + decoherence_b) / 2
+        debt_influence = (node_a.decoherence_debt + node_b.decoherence_debt) / 6.0
+        rupture_chance = avg_decoherence + debt_influence
         self.decoherence_exposure.append(avg_decoherence)
         if len(self.decoherence_exposure) > 20:
             self.decoherence_exposure.pop(0)
 
-        if self.probabilistic_bridge_failure(avg_decoherence):
+        if self.probabilistic_bridge_failure(rupture_chance):
             self.last_rupture_tick = tick_time
             self._log_event(tick_time, "bridge_ruptured", avg_decoherence)
             self.rupture_history.append((tick_time, avg_decoherence))

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -160,6 +160,10 @@ class CausalGraph:
                     ,"trust_profile": n.trust_profile
                     ,"phase_confidence": n.phase_confidence_index
                     ,"goals": n.goals
+                    ,"node_type": n.node_type.value
+                    ,"coherence_credit": n.coherence_credit
+                    ,"decoherence_debt": n.decoherence_debt
+                    ,"phase_lock": n.phase_lock
                 } for nid, n in self.nodes.items()
             },
             "superpositions": {


### PR DESCRIPTION
## Summary
- implement `NodeType` and credit/debt tracking
- log interference density and node state per tick
- allow simple refraction behaviour when targets are decoherent
- couple bridge rupture probability to node decoherence debt
- extend bundle manifest with new metrics and keep extra logs

## Testing
- `python -m py_compile Causal_Web/engine/node.py Causal_Web/engine/tick_engine.py Causal_Web/engine/bridge.py Causal_Web/engine/graph.py bundle_run.py`

------
https://chatgpt.com/codex/tasks/task_e_6875b384fa5c83259d8878c4ed8c9102