### PR TITLE
Add dynamic bridges and law waves

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -233,3 +233,26 @@ class CausalGraph:
 
         self.tick_sources = data.get("tick_sources", [])
 
+    # ------------------------------------------------------------
+    def emit_law_wave(self, origin_id: str, tick: int, radius: int = 2) -> None:
+        """Propagate a law wave from origin node and log affected nodes."""
+        visited = {origin_id}
+        frontier = [(origin_id, 0)]
+        affected = []
+        while frontier:
+            nid, dist = frontier.pop(0)
+            if dist > radius:
+                continue
+            node = self.get_node(nid)
+            if node:
+                node.collapse_pressure += max(0.0, 1.0 - 0.5 * dist)
+                if nid != origin_id:
+                    affected.append(nid)
+            for edge in self.get_edges_from(nid):
+                if edge.target not in visited:
+                    visited.add(edge.target)
+                    frontier.append((edge.target, dist + 1))
+        if affected:
+            with open("output/law_wave_log.json", "a") as f:
+                f.write(json.dumps({"tick": tick, "origin": origin_id, "affected": affected}) + "\n")
+

--- a/bundle_run.py
+++ b/bundle_run.py
@@ -146,6 +146,21 @@ def _create_manifest(out_dir: str, run_id: str, timestamp: str) -> None:
     # refraction events
     manifest["refraction_events_logged"] = len(_load_lines(os.path.join(out_dir, "refraction_log.json")))
 
+    # bridge dynamics
+    dynamics = _load_lines(os.path.join(out_dir, "bridge_dynamics_log.json"))
+    manifest["bridge_formations"] = sum(1 for e in dynamics if e.get("from") is None)
+    manifest["ruptures_total"] = sum(1 for e in dynamics if e.get("to") == "ruptured")
+
+    # law wave propagation
+    law_wave_events = _load_lines(os.path.join(out_dir, "law_wave_log.json"))
+    manifest["law_waves_emitted"] = sum(1 for e in law_wave_events if e.get("origin"))
+    manifest["collapse_pressure_events"] = sum(len(e.get("affected", [])) for e in law_wave_events)
+
+    # node state transitions
+    transitions = _load_lines(os.path.join(out_dir, "node_state_map.json"))
+    manifest["node_state_transitions_count"] = len(transitions)
+    manifest["boundary_interactions_count"] = 0
+
     with open(os.path.join(out_dir, "manifest.json"), "w") as f:
         json.dump(manifest, f, indent=2)
 


### PR DESCRIPTION
## Summary
- add dynamic bridge creation and fatigue state transitions
- track node state changes
- generate law waves on classicalization
- extend manifest with new counters

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875cd9f827c8325a78eb6dd824abbb9