### PR TITLE
Implement dynamic bridge lifecycle with logging

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -15,4 +15,6 @@ class Config:
         "amplitude": 0.0,  # threshold modulation
         "period": 30
     }
+    # interval for saving runtime snapshots of the graph
+    snapshot_interval = 10
 

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -21,9 +21,23 @@ class CausalGraph:
         self.edges.append(Edge(source_id, target_id, attenuation, density, delay, phase_shift))
 
     def add_bridge(self, node_a_id, node_b_id, bridge_type="braided", phase_offset=0.0,
-               drift_tolerance=None, decoherence_limit=None):
-        self.bridges.append(Bridge(node_a_id, node_b_id, bridge_type, phase_offset,
-                               drift_tolerance, decoherence_limit))
+               drift_tolerance=None, decoherence_limit=None, initial_strength=1.0,
+               medium_type="standard", mutable=True, seeded=True, formed_at_tick=0):
+        self.bridges.append(
+            Bridge(
+                node_a_id,
+                node_b_id,
+                bridge_type,
+                phase_offset,
+                drift_tolerance,
+                decoherence_limit,
+                initial_strength,
+                medium_type,
+                mutable,
+                seeded,
+                formed_at_tick,
+            )
+        )
 
     def get_node(self, node_id):
         return self.nodes.get(node_id)
@@ -184,6 +198,7 @@ class CausalGraph:
                 }
                 for e in self.edges
             ],
+            "bridges": [b.to_dict() for b in self.bridges],
             "tick_sources": self.tick_sources
         }
 
@@ -228,7 +243,12 @@ class CausalGraph:
                 bridge_type=bridge.get("bridge_type", "braided"),
                 phase_offset=bridge.get("phase_offset", 0.0),
                 drift_tolerance=bridge.get("drift_tolerance"),
-                decoherence_limit=bridge.get("decoherence_limit")
+                decoherence_limit=bridge.get("decoherence_limit"),
+                initial_strength=bridge.get("initial_strength", 1.0),
+                medium_type=bridge.get("medium_type", "standard"),
+                mutable=bridge.get("mutable", True),
+                seeded=True,
+                formed_at_tick=0,
             )
 
         self.tick_sources = data.get("tick_sources", [])


### PR DESCRIPTION
## Summary
- add snapshot interval configuration
- extend `Bridge` with dynamic lifecycle fields
- track bridge dynamics and log formation, rupture, recovery
- include bridges in graph snapshots and runtime snapshots
- generate bridge metrics in manifest

## Testing
- `python -m compileall Causal_Web`

------
https://chatgpt.com/codex/tasks/task_e_6875d24255888325b284f26f41e7a3f9