### PR TITLE
Fix tick source handling and package imports

### DIFF
--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -136,7 +136,7 @@ class Bridge:
                 f.write(json.dumps({"tick": tick_time, "bridge": self.bridge_id, "strength": self.current_strength, "duration": duration}) + "\n")
             if self.current_strength == 0.0:
                 self.active = False
-                import engine.tick_engine as te
+                from . import tick_engine as te
                 te._decay_durations.append(duration)
                 self._log_dynamics(tick_time, "decayed")
 
@@ -150,7 +150,7 @@ class Bridge:
             self.coherence_at_reform = coherence
             with open("output/bridge_reformation_log.json", "a") as f:
                 f.write(json.dumps({"tick": tick_time, "bridge": self.bridge_id, "coherence": coherence}) + "\n")
-            import engine.tick_engine as te
+            from . import tick_engine as te
             te.bridges_reformed_count += 1
             self._log_event(tick_time, "bridge_reformed", coherence)
             self._log_dynamics(tick_time, "recovered", {"coherence": coherence})

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -1,7 +1,7 @@
 import cmath
 import math
 
-from engine.bridge import Bridge
+from .bridge import Bridge
 from .node import Node, Edge, NodeType
 from .meta_node import MetaNode
 import json

--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Set, List, Dict, Optional
 import numpy as np
 import json
-from config import Config
+from ..config import Config
 
 
 class NodeType(Enum):
@@ -230,7 +230,7 @@ class Node:
         if self.node_type == NodeType.NULL:
             with open("output/boundary_interaction_log.json", "a") as f:
                 f.write(json.dumps({"tick": tick_time, "void": self.id, "origin": origin}) + "\n")
-            import engine.tick_engine as te
+            from . import tick_engine as te
             te.void_absorption_events += 1
             return
 
@@ -241,7 +241,7 @@ class Node:
         if getattr(self, "boundary", False):
             with open("output/boundary_interaction_log.json", "a") as f:
                 f.write(json.dumps({"tick": tick_time, "node": self.id, "origin": origin}) + "\n")
-            import engine.tick_engine as te
+            from . import tick_engine as te
             te.boundary_interactions_count += 1
 
         if any(tick.time == tick_time for tick in self.tick_history):

--- a/Causal_Web/engine/simulation.py
+++ b/Causal_Web/engine/simulation.py
@@ -2,7 +2,7 @@
 
 import time
 from threading import Thread
-from config import Config
+from ..config import Config
 
 
 def simulation_loop():

--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -1,6 +1,6 @@
 import time
 import threading
-from config import Config
+from ..config import Config
 from .graph import CausalGraph
 from .observer import Observer
 from .log_interpreter import run_interpreter

--- a/Causal_Web/engine/tick_seeder.py
+++ b/Causal_Web/engine/tick_seeder.py
@@ -3,7 +3,7 @@ import random
 from typing import Dict, List
 
 from .graph import CausalGraph
-from config import Config
+from ..config import Config
 
 
 class TickSeeder:
@@ -32,9 +32,18 @@ class TickSeeder:
     # ------------------------------------------------------------
     def _seed_static(self, global_tick: int) -> None:
         for source in getattr(self.graph, "tick_sources", []):
-            node = self.graph.get_node(source.get("node_id"))
-            interval = source.get("tick_interval", 1)
-            phase = source.get("phase", 0.0)
+            if isinstance(source, str):
+                node_id = source
+                interval = 1
+                phase = 0.0
+            elif isinstance(source, dict):
+                node_id = source.get("node_id")
+                interval = source.get("tick_interval", 1)
+                phase = source.get("phase", 0.0)
+            else:
+                continue
+
+            node = self.graph.get_node(node_id)
             if node and not node.is_classical and global_tick % interval == 0:
                 node.apply_tick(global_tick, phase, self.graph, origin="seed")
                 self._log({

--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -1,7 +1,7 @@
 import dearpygui.dearpygui as dpg
-from config import Config
-from engine.tick_engine import simulation_loop
-from engine.tick_engine import graph, build_graph
+from ..config import Config
+from ..engine.tick_engine import simulation_loop
+from ..engine.tick_engine import graph, build_graph
 import threading
 
 # Tick stores for visual update

--- a/Causal_Web/gui/graph_panel.py
+++ b/Causal_Web/gui/graph_panel.py
@@ -1,7 +1,7 @@
 import dearpygui.dearpygui as dpg
-from config import Config
-from engine.tick_engine import simulation_loop
-from engine.tick_engine import graph
+from ..config import Config
+from ..engine.tick_engine import simulation_loop
+from ..engine.tick_engine import graph
 import threading
 
 # Tick stores for visual update

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -1,6 +1,6 @@
 # main.py
 
-from gui.dashboard import launch  # uses dashboard -> start_dearpygui internally
+from .gui.dashboard import launch  # uses dashboard -> start_dearpygui internally
 
 def main():
     launch()


### PR DESCRIPTION
## Summary
- handle tick_sources defined as strings when seeding ticks
- use relative imports inside package

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875eb047084832580ea0a777b0ded0f