### PR TITLE
Make file paths independent of CWD

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -1,6 +1,23 @@
 # config.py
 
+import os
+
+
 class Config:
+    # Base directories for package resources
+    base_dir = os.path.abspath(os.path.dirname(__file__))
+    input_dir = os.path.join(base_dir, "input")
+    output_dir = os.path.join(base_dir, "output")
+
+    @staticmethod
+    def input_path(*parts: str) -> str:
+        """Return absolute path under the ``input`` directory."""
+        return os.path.join(Config.input_dir, *parts)
+
+    @staticmethod
+    def output_path(*parts: str) -> str:
+        """Return absolute path under the ``output`` directory."""
+        return os.path.join(Config.output_dir, *parts)
     tick_rate = 1.0  # Seconds between ticks (adjustable via GUI)
     is_running = False  # Whether the simulation loop is active
     max_ticks = 100  # Stop after this many ticks unless set to 0 for infinite

--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -3,6 +3,7 @@ import math
 from random import random
 from typing import Optional
 import json
+from ..config import Config
 
 from enum import Enum
 
@@ -83,7 +84,7 @@ class Bridge:
         }
         if conditions is not None:
             record["conditions"] = conditions
-        with open("output/bridge_dynamics_log.json", "a") as f:
+        with open(Config.output_path("bridge_dynamics_log.json"), "a") as f:
             f.write(json.dumps(record) + "\n")
 
     def update_state(self, tick: int) -> None:
@@ -115,7 +116,7 @@ class Bridge:
             target=self.node_b_id,
             coherence_at_event=value
         )
-        with open("output/event_log.json", "a") as f:
+        with open(Config.output_path("event_log.json"), "a") as f:
             f.write(json.dumps(event.__dict__) + "\n")
 
     def probabilistic_bridge_failure(self, decoherence_strength, rupture_threshold=0.3, rupture_prob=0.9):
@@ -132,7 +133,7 @@ class Bridge:
         if tick_time - self.last_active_tick >= inactive_threshold and self.current_strength > 0:
             self.current_strength = max(0.0, self.current_strength - 0.1)
             duration = tick_time - self.last_active_tick
-            with open("output/bridge_decay_log.json", "a") as f:
+            with open(Config.output_path("bridge_decay_log.json"), "a") as f:
                 f.write(json.dumps({"tick": tick_time, "bridge": self.bridge_id, "strength": self.current_strength, "duration": duration}) + "\n")
             if self.current_strength == 0.0:
                 self.active = False
@@ -148,7 +149,7 @@ class Bridge:
             self.active = True
             self.last_reform_tick = tick_time
             self.coherence_at_reform = coherence
-            with open("output/bridge_reformation_log.json", "a") as f:
+            with open(Config.output_path("bridge_reformation_log.json"), "a") as f:
                 f.write(json.dumps({"tick": tick_time, "bridge": self.bridge_id, "coherence": coherence}) + "\n")
             from . import tick_engine as te
             te.bridges_reformed_count += 1

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -4,6 +4,7 @@ import math
 from .bridge import Bridge
 from .node import Node, Edge, NodeType
 from .meta_node import MetaNode
+from ..config import Config
 import json
 
 class CausalGraph:
@@ -322,9 +323,9 @@ class CausalGraph:
                 if other and other.node_type == NodeType.NULL:
                     print(f"[WARNING] Bridge {nid}<->{b} connected to NULL node")
         if self.void_nodes:
-            with open("output/void_node_map.json", "w") as f:
+            with open(Config.output_path("void_node_map.json"), "w") as f:
                 json.dump(self.void_nodes, f, indent=2)
-        with open("output/connectivity_log.json", "w") as f:
+        with open(Config.output_path("connectivity_log.json"), "w") as f:
             json.dump(connectivity_log, f, indent=2)
 
     # ------------------------------------------------------------
@@ -347,6 +348,6 @@ class CausalGraph:
                     visited.add(edge.target)
                     frontier.append((edge.target, dist + 1))
         if affected:
-            with open("output/law_wave_log.json", "a") as f:
+            with open(Config.output_path("law_wave_log.json"), "a") as f:
                 f.write(json.dumps({"tick": tick, "origin": origin_id, "affected": affected}) + "\n")
 

--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -175,7 +175,7 @@ class Node:
             self.is_classical = True
             if tick_time is not None:
                 record = {"tick": tick_time, "node": self.id, "event": "collapse_start"}
-                with open("output/collapse_front_log.json", "a") as f:
+                with open(Config.output_path("collapse_front_log.json"), "a") as f:
                     f.write(json.dumps(record) + "\n")
                 if graph is not None:
                     graph.emit_law_wave(self.id, tick_time)
@@ -194,7 +194,7 @@ class Node:
             self.node_type = NodeType.NORMAL
 
         if old != self.node_type:
-            with open("output/node_state_map.json", "a") as f:
+            with open(Config.output_path("node_state_map.json"), "a") as f:
                 rec = {"node": self.id, "from": old.value, "to": self.node_type.value}
                 f.write(json.dumps(rec) + "\n")
         self.prev_node_type = old
@@ -228,7 +228,7 @@ class Node:
 
     def apply_tick(self, tick_time, phase, graph, origin="self"):
         if self.node_type == NodeType.NULL:
-            with open("output/boundary_interaction_log.json", "a") as f:
+            with open(Config.output_path("boundary_interaction_log.json"), "a") as f:
                 f.write(json.dumps({"tick": tick_time, "void": self.id, "origin": origin}) + "\n")
             from . import tick_engine as te
             te.void_absorption_events += 1
@@ -239,7 +239,7 @@ class Node:
             return
 
         if getattr(self, "boundary", False):
-            with open("output/boundary_interaction_log.json", "a") as f:
+            with open(Config.output_path("boundary_interaction_log.json"), "a") as f:
                 f.write(json.dumps({"tick": tick_time, "node": self.id, "origin": origin}) + "\n")
             from . import tick_engine as te
             te.boundary_interactions_count += 1
@@ -262,7 +262,7 @@ class Node:
         self.update_node_type()
 
         if origin != "self" and any(e.target == origin for e in graph.get_edges_from(self.id)):
-            with open("output/refraction_log.json", "a") as f:
+            with open(Config.output_path("refraction_log.json"), "a") as f:
                 f.write(json.dumps({"tick": tick_time, "recursion_from": origin, "node": self.id}) + "\n")
         
         # Recursive phase propagation with refraction
@@ -285,7 +285,7 @@ class Node:
                     alt_delay = alt.adjusted_delay(target.law_wave_frequency, alt_tgt.law_wave_frequency, kappa)
                     alt_tgt.schedule_tick(tick_time + delay + alt_delay, shifted)
                     target.node_type = NodeType.REFRACTIVE
-                    with open("output/refraction_log.json", "a") as f:
+                    with open(Config.output_path("refraction_log.json"), "a") as f:
                         f.write(json.dumps({"tick": tick_time, "from": self.id, "via": target.id, "to": alt_tgt.id}) + "\n")
                     continue
 
@@ -316,14 +316,14 @@ class Node:
                 chain.extend(other.propagate_collapse(tick_time, graph, threshold, depth + 1, visited))
         if chain:
             record = {"tick": tick_time, "source": self.id, "chain": chain}
-            with open("output/collapse_front_log.json", "a") as f:
+            with open(Config.output_path("collapse_front_log.json"), "a") as f:
                 f.write(json.dumps(record) + "\n")
         return chain
 
     def _log_collapse_chain(self, tick_time, collapsed):
         """Log collapse propagation events to file with depth info."""
         record = {"tick": tick_time, "source": self.id, "collapsed": collapsed}
-        with open("output/collapse_chain_log.json", "a") as f:
+        with open(Config.output_path("collapse_chain_log.json"), "a") as f:
             f.write(json.dumps(record) + "\n")
 
 

--- a/Causal_Web/engine/tick_seeder.py
+++ b/Causal_Web/engine/tick_seeder.py
@@ -9,10 +9,10 @@ from ..config import Config
 class TickSeeder:
     """Injects ticks into the graph under configurable strategies."""
 
-    def __init__(self, graph: CausalGraph, config: Dict = None, log_path: str = "output/tick_seed_log.json"):
+    def __init__(self, graph: CausalGraph, config: Dict = None, log_path: str = None):
         self.graph = graph
         self.config = config or getattr(Config, "seeding", {"strategy": "static"})
-        self.log_path = log_path
+        self.log_path = log_path or Config.output_path("tick_seed_log.json")
         self.seed_count = 0
 
     # ------------------------------------------------------------

--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -1,3 +1,4 @@
+import os
 import dearpygui.dearpygui as dpg
 from ..config import Config
 from ..engine.tick_engine import simulation_loop
@@ -109,7 +110,8 @@ def dashboard():
     dpg.create_context()
 
     with dpg.font_registry():
-        default_font = dpg.add_font("assets/fonts/consola.ttf", 20)
+        font_path = os.path.join(os.path.dirname(__file__), "..", "assets", "fonts", "consola.ttf")
+        default_font = dpg.add_font(font_path, 20)
 
     dpg.bind_font(default_font)
     dpg.create_viewport(title="CWT Simulation Dashboard", width=800, height=800)

--- a/Causal_Web/gui/graph_panel.py
+++ b/Causal_Web/gui/graph_panel.py
@@ -1,3 +1,4 @@
+import os
 import dearpygui.dearpygui as dpg
 from ..config import Config
 from ..engine.tick_engine import simulation_loop
@@ -28,7 +29,8 @@ def gui_loop():
     dpg.create_viewport(title="CWT Real-Time Causal Graph", width=640, height=480)
 
     with dpg.font_registry():
-        default_font = dpg.add_font("assets/fonts/consola.ttf", 18)
+        font_path = os.path.join(os.path.dirname(__file__), "..", "assets", "fonts", "consola.ttf")
+        default_font = dpg.add_font(font_path, 18)
     dpg.bind_font(default_font)
 
     with dpg.window(label="Causal Graph", width=620, height=460):

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ nodes, propagates phases along edges and records the results to
 starting, pausing and adjusting the tick rate while visualising the graph in real time.
 - **`main.py`** – Entry point that simply launches the dashboard.
 
-Graphs are expected to be defined in `input/graph.json` which is loaded when the GUI
-starts. Simulation output is written to the `output` directory when the run finishes.
+Graphs are expected to be defined in `input/graph.json` inside the package. The
+code now resolves this path relative to the package location so the module can
+be executed from any working directory. Simulation output is written to the
+`output` folder located next to the code.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- add helpers in `Config` for absolute input/output paths
- use these helpers throughout engine code
- update GUI modules to load fonts via absolute path
- clarify README on graph file location

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875ec8f41fc8325b32af91cd1d1ff7b