### PR TITLE
Fix output cleanup for new runs

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -8,6 +8,7 @@ from .tick_seeder import TickSeeder
 import json
 import numpy as np
 import os
+import shutil
 from concurrent.futures import ThreadPoolExecutor
 import math
 
@@ -45,7 +46,11 @@ def clear_output_directory():
     for name in os.listdir(out_dir):
         if name == "__init__.py":
             continue
-        open(os.path.join(out_dir, name), "w").close()
+        path = os.path.join(out_dir, name)
+        if os.path.isfile(path):
+            open(path, "w").close()
+        elif os.path.isdir(path):
+            shutil.rmtree(path)
 
 def build_graph():
     clear_output_directory()


### PR DESCRIPTION
## Summary
- remove old runtime snapshot directories when clearing output

## Testing
- `python - <<'PY'
import sys, time
sys.path.append('.')
from Causal_Web.engine.tick_engine import build_graph, simulation_loop, graph
from Causal_Web.config import Config

build_graph()
Config.is_running = True
Config.max_ticks = 3
simulation_loop()
while Config.is_running:
    time.sleep(0.1)
print([ (n.id, len(n.tick_history)) for n in graph.nodes.values()])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6876756c79048325a202962bae2877b7