### PR TITLE
Implement basic layer routing and logging

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -178,7 +178,7 @@ class CausalGraph:
                 nid: {
                     "x": n.x,
                     "y": n.y,
-                    "ticks": [{"time": tick.time, "phase": tick.phase, "origin": tick.origin} for tick in n.tick_history],
+                    "ticks": [{"time": tick.time, "phase": tick.phase, "origin": tick.origin, "layer": getattr(tick, "layer", "tick"), "trace_id": getattr(tick, "trace_id", "")} for tick in n.tick_history],
                     "phase": n.phase,
                     "coherence": n.coherence,
                     "decoherence": n.decoherence,

--- a/Causal_Web/engine/log_interpreter.py
+++ b/Causal_Web/engine/log_interpreter.py
@@ -198,11 +198,17 @@ class CWTLogInterpreter:
             return
         with open(path) as f:
             data = json.load(f)
-        counts = {
-            nid: len(n.get("ticks", [])) for nid, n in data.get("nodes", {}).items()
-        }
+        counts = {nid: len(n.get("ticks", [])) for nid, n in data.get("nodes", {}).items()}
+        layer_summary: Dict[str, Dict[str, int]] = {}
+        for nid, n in data.get("nodes", {}).items():
+            for tick in n.get("ticks", []):
+                layer = tick.get("layer", "tick")
+                layer_summary.setdefault(nid, {}).setdefault(layer, 0)
+                layer_summary[nid][layer] += 1
         if counts:
             self.summary["tick_counts"] = counts
+        if layer_summary:
+            self.summary["layer_summary"] = layer_summary
 
     # ------------------------------------------------------------
     def interpret_inspection(self) -> None:

--- a/Causal_Web/engine/tick_router.py
+++ b/Causal_Web/engine/tick_router.py
@@ -1,0 +1,38 @@
+class TickRouter:
+    """Route ticks across LCCM layers"""
+    LAYERS = [
+        "tick",
+        "phase",
+        "collapse",
+        "bridge",
+        "coherence",
+        "decoherence",
+        "law-wave",
+    ]
+
+    @classmethod
+    def next_layer(cls, current: str) -> str:
+        try:
+            idx = cls.LAYERS.index(current)
+            if idx < len(cls.LAYERS) - 1:
+                return cls.LAYERS[idx + 1]
+        except ValueError:
+            pass
+        return cls.LAYERS[-1]
+
+    @classmethod
+    def route_tick(cls, node, tick):
+        from ..config import Config
+        import json
+        new_layer = cls.next_layer(tick.layer)
+        if new_layer != tick.layer:
+            record = {
+                "tick": tick.time,
+                "node": node.id,
+                "from": tick.layer,
+                "to": new_layer,
+                "trace_id": tick.trace_id,
+            }
+            with open(Config.output_path("layer_transition_log.json"), "a") as f:
+                f.write(json.dumps(record) + "\n")
+            tick.layer = new_layer


### PR DESCRIPTION
## Summary
- introduce `Tick.layer` and `trace_id`
- add new `TickRouter` class for LCCM layer transitions
- route ticks in `Node` and log transitions
- export tick layer info in graph
- extend log interpreter and causal analyst for layer events

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687696d84fc883259c32c563c83d6a1c