### PR TITLE
Fix missing summary attribute in CausalAnalyst

### DIFF
--- a/Causal_Web/engine/causal_analyst.py
+++ b/Causal_Web/engine/causal_analyst.py
@@ -95,6 +95,7 @@ class CausalAnalyst:
         self.explanations: List[ExplanationEvent] = []
         self.causal_chains: List[Dict] = []
         self.params = {"window": 8}
+        self.summary: Dict[str, Dict] = {}
 
     # ------------------------------------------------------------
     def _path(self, name: str) -> str:


### PR DESCRIPTION
## Summary
- prevent runtime failure when generating bundles
- add `summary` dict to `CausalAnalyst`

## Testing
- `python -m pytest -q`
- `python bundle_run.py --output-dir Causal_Web/output --run-id test`

------
https://chatgpt.com/codex/tasks/task_e_687698f9b82c83258a071896ab411cd6