### PR TITLE
Add engine unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ This command loads the logs and generates several summary files:
 - **`causal_timeline.json`** – ordered timeline of notable events.
 
 The raw logs (`tick_trace.json`, `coherence_log.json`, `event_log.json`, etc.) remain in `output/` for detailed inspection. For convenience, running `bundle_run.py` packages the important files with a manifest describing the run.
+
+## Testing
+
+Basic unit tests cover some of the utility methods inside the engine. They verify
+phase interference detection, cluster formation logic, edge delay adjustment and
+several node behaviours. Run them with:
+
+```bash
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure package import for tests
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,35 @@
+import math
+from Causal_Web.engine.graph import CausalGraph
+from Causal_Web.engine.node import Node
+from Causal_Web.engine.node import Edge
+
+
+def test_interference_type_constructive():
+    g = CausalGraph()
+    phases = [0.0, 0.05]
+    assert g._interference_type(phases) == "constructive"
+
+
+def test_interference_type_destructive():
+    g = CausalGraph()
+    phases = [0.0, math.pi]
+    assert g._interference_type(phases) == "destructive"
+
+
+def test_detect_clusters():
+    g = CausalGraph()
+    for nid, freq in {"A":1.0, "B":1.02, "C":1.5}.items():
+        g.nodes[nid] = Node(nid)
+        g.nodes[nid].law_wave_frequency = freq
+        g.nodes[nid].coherence = 0.95
+    clusters = g.detect_clusters(coherence_threshold=0.9, freq_tolerance=0.05)
+    assert [sorted(c) for c in clusters] == [["A", "B"]]
+
+
+def test_edge_adjusted_delay():
+    edge = Edge("A", "B", attenuation=1.0, density=0.5, delay=2)
+    # with zero freq difference sin term is zero -> delay = delay + int(density)
+    assert edge.adjusted_delay(1.0, 1.0, kappa=1.0) == 2 + int(0.5)
+    # with frequency difference effect
+    delay = edge.adjusted_delay(1.0, 1.5, kappa=1.0)
+    assert delay >= 1

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,23 @@
+import math
+import os
+import tempfile
+from Causal_Web.engine.node import Node
+from Causal_Web.config import Config
+
+
+def test_coherence_and_decoherence_calculation():
+    node = Node("A")
+    node.pending_superpositions[1] = [0.0, math.pi / 2]
+    coh = node.compute_coherence_level(1)
+    dec = node.compute_decoherence_field(1)
+    assert 0 <= coh <= 1
+    assert dec >= 0
+
+
+def test_update_classical_state(tmp_path):
+    old_dir = Config.output_dir
+    Config.output_dir = tmp_path
+    node = Node("A")
+    node.update_classical_state(0.5, tick_time=1, graph=None, threshold=0.4, streak_required=1)
+    assert node.is_classical
+    Config.output_dir = old_dir


### PR DESCRIPTION
## Summary
- add tests for cluster detection, interference classification and node logic
- document the new tests in the README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769f57d37883258b252381f8966f5f