### PR TITLE
Add node propagation logging and runtime state

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -18,26 +18,22 @@ class Config:
     def output_path(*parts: str) -> str:
         """Return absolute path under the ``output`` directory."""
         return os.path.join(Config.output_dir, *parts)
+
     tick_rate = 1.0  # Seconds between ticks (adjustable via GUI)
     is_running = False  # Whether the simulation loop is active
     max_ticks = 100  # Stop after this many ticks unless set to 0 for infinite
+    tick_limit = 10000
+    allow_tick_override = True
     current_tick = 0  # Counter to display progress
 
     # Global rhythmic forcing parameters
-    phase_jitter = {
-        "amplitude": 0.0,  # radians
-        "period": 20      # ticks
-    }
-    coherence_wave = {
-        "amplitude": 0.0,  # threshold modulation
-        "period": 30
-    }
+    phase_jitter = {"amplitude": 0.0, "period": 20}  # radians  # ticks
+    coherence_wave = {"amplitude": 0.0, "period": 30}  # threshold modulation
     # interval for saving runtime snapshots of the graph
     snapshot_interval = 10
 
     # tick seeding configuration
     seeding = {
         "strategy": "static",  # static or probabilistic
-        "probability": 0.1,   # used when strategy == "probabilistic"
+        "probability": 0.1,  # used when strategy == "probabilistic"
     }
-

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -27,9 +27,22 @@ class CausalGraph:
         refractory_period=2,
         base_threshold=0.5,
         phase=0.0,
+        *,
+        origin_type="seed",
+        generation_tick=0,
+        parent_ids=None,
     ):
         self.nodes[node_id] = Node(
-            node_id, x, y, frequency, refractory_period, base_threshold, phase
+            node_id,
+            x,
+            y,
+            frequency,
+            refractory_period,
+            base_threshold,
+            phase,
+            origin_type=origin_type,
+            generation_tick=generation_tick,
+            parent_ids=parent_ids,
         )
 
     def add_edge(
@@ -248,6 +261,9 @@ class CausalGraph:
                     "trust_profile": n.trust_profile,
                     "phase_confidence": n.phase_confidence_index,
                     "goals": n.goals,
+                    "origin_type": n.origin_type,
+                    "generation_tick": n.generation_tick,
+                    "parent_ids": n.parent_ids,
                     "node_type": n.node_type.value,
                     "coherence_credit": n.coherence_credit,
                     "decoherence_debt": n.decoherence_debt,
@@ -303,6 +319,9 @@ class CausalGraph:
                 refractory_period=node_data.get("refractory_period", 2.0),
                 base_threshold=node_data.get("base_threshold", 0.5),
                 phase=node_data.get("phase", 0.0),
+                origin_type=node_data.get("origin_type", "seed"),
+                generation_tick=node_data.get("generation_tick", 0),
+                parent_ids=node_data.get("parent_ids"),
             )
             goals = node_data.get("goals")
             if goals is not None:

--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -43,6 +43,10 @@ class Node:
         refractory_period=2,
         base_threshold=0.5,
         phase=0.0,
+        *,
+        origin_type: str = "seed",
+        generation_tick: int = 0,
+        parent_ids: Optional[List[str]] = None,
     ):
         self.id = node_id
         self.x = x
@@ -74,6 +78,12 @@ class Node:
         self.decoherence_debt: float = 0.0
         self.phase_lock: bool = False
         self.collapse_pressure: float = 0.0
+
+        # ---- Propagation metadata ----
+        self.origin_type = origin_type
+        self.generation_tick = generation_tick
+        self.parent_ids = parent_ids or []
+        self.sip_streak = 0
 
         # ---- Phase 4 additions ----
         self.memory_window = 20
@@ -148,6 +158,11 @@ class Node:
             self.phase_confidence_index = 1.0 - float(np.var(self.memory["coherence"]))
         else:
             self.phase_confidence_index = 1.0
+
+        if coherence > 0.9:
+            self.sip_streak += 1
+        else:
+            self.sip_streak = 0
 
     def _adapt_behavior(self) -> None:
         if self.memory["coherence"]:

--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -2,43 +2,47 @@ import os
 import dearpygui.dearpygui as dpg
 from ..config import Config
 from ..engine.tick_engine import simulation_loop
-from ..engine.tick_engine import graph, build_graph
+from ..engine.tick_engine import graph, build_graph, _update_simulation_state
 import threading
 
 # Tick stores for visual update
 node_colors = {
     "A1": (100, 149, 237),  # Cornflower Blue
-    "A2": (60, 179, 113),   # Medium Sea Green
-    "C":  (220, 20, 60)     # Crimson
+    "A2": (60, 179, 113),  # Medium Sea Green
+    "C": (220, 20, 60),  # Crimson
 }
-node_positions = {
-    "A1": (100, 200),
-    "A2": (100, 300),
-    "C":  (400, 250)
-}
+node_positions = {"A1": (100, 200), "A2": (100, 300), "C": (400, 250)}
 node_tags = {}
 tick_counters = {}
+
 
 def pause_resume_callback():
     Config.is_running = not Config.is_running
     if dpg.does_item_exist("pause_button"):
         dpg.set_value("pause_button", "Pause" if Config.is_running else "Resume")
+    _update_simulation_state(not Config.is_running, False, Config.current_tick, None)
+
 
 def tick_rate_changed(sender, app_data):
     Config.tick_rate = app_data
 
+
 def max_ticks_changed(sender, app_data):
     Config.max_ticks = app_data
+
 
 def start_sim_callback():
     if not Config.is_running:
         Config.is_running = True
         simulation_loop()
         dpg.configure_item("start_button", enabled=False)
+        _update_simulation_state(False, False, Config.current_tick, None)
+
 
 def update_display():
     if dpg.does_item_exist("tick_counter"):
         dpg.set_value("tick_counter", f"Tick: {Config.current_tick}")
+
 
 def update_graph_visuals():
     # for node_id in graph.nodes:
@@ -63,30 +67,46 @@ def update_graph_visuals():
         tick_count = len(node.tick_history)
         vel = getattr(node, "coherence_velocity", 0.0)
 
-        color = (100, 149, 237) if "A1" in node_id else (60, 179, 113) if "A2" in node_id else (220, 20, 60)
+        color = (
+            (100, 149, 237)
+            if "A1" in node_id
+            else (60, 179, 113) if "A2" in node_id else (220, 20, 60)
+        )
 
-        dpg.draw_circle(center=(x, y), radius=30, color=color, fill=color, parent="graph_drawlist")
+        dpg.draw_circle(
+            center=(x, y), radius=30, color=color, fill=color, parent="graph_drawlist"
+        )
 
         label = f"{node_id}\nTicks: {tick_count}\nVel:{vel:.2f}"
         if node_id in cluster_map:
             label += f"\nC{cluster_map[node_id]}"
-        dpg.draw_text(pos=(x - 30, y - 15), text=label, size=15, color=(255, 255, 255), parent="graph_drawlist")
+        dpg.draw_text(
+            pos=(x - 30, y - 15),
+            text=label,
+            size=15,
+            color=(255, 255, 255),
+            parent="graph_drawlist",
+        )
 
     # Draw edges with curvature overlays
     for edge in graph.edges:
         from_node = graph.nodes[edge.source]
         to_node = graph.nodes[edge.target]
 
-        delay = edge.adjusted_delay(from_node.law_wave_frequency, to_node.law_wave_frequency)
+        delay = edge.adjusted_delay(
+            from_node.law_wave_frequency, to_node.law_wave_frequency
+        )
         thickness = 2 + delay * 0.2
         intensity = min(255, int(50 + delay * 20))
         color = (200, 200 - intensity if 200 - intensity > 0 else 0, 200)
 
-        dpg.draw_arrow(p1=(from_node.x, from_node.y),
-                       p2=(to_node.x, to_node.y),
-                       color=color,
-                       thickness=thickness,
-                       parent="graph_drawlist")
+        dpg.draw_arrow(
+            p1=(from_node.x, from_node.y),
+            p2=(to_node.x, to_node.y),
+            color=color,
+            thickness=thickness,
+            parent="graph_drawlist",
+        )
 
 
 def refresh():
@@ -95,8 +115,10 @@ def refresh():
         dpg.set_value("tick_counter", f"Tick: {Config.current_tick}")
     dpg.render_dearpygui_frame()
 
+
 def launch():
     dashboard()
+
 
 def gui_update_callback():
     update_graph_visuals()
@@ -105,42 +127,75 @@ def gui_update_callback():
     next_frame = dpg.get_frame_count() + 1
     dpg.set_frame_callback(next_frame, gui_update_callback)
 
+
 def dashboard():
     build_graph()
     dpg.create_context()
 
     with dpg.font_registry():
-        font_path = os.path.join(os.path.dirname(__file__), "..", "assets", "fonts", "consola.ttf")
+        font_path = os.path.join(
+            os.path.dirname(__file__), "..", "assets", "fonts", "consola.ttf"
+        )
         default_font = dpg.add_font(font_path, 20)
 
     dpg.bind_font(default_font)
     dpg.create_viewport(title="CWT Simulation Dashboard", width=800, height=800)
 
     with dpg.window(label="Control Panel", width=800, height=200):
-        dpg.add_slider_float(label="Tick Rate (sec)", default_value=Config.tick_rate,
-                             min_value=0.1, max_value=2.0, callback=tick_rate_changed, tag="tick_rate_slider")
-        dpg.add_input_int(label="Max Ticks", default_value=Config.max_ticks,
-                          callback=max_ticks_changed, tag="max_ticks_input")
-        dpg.add_button(label="Pause", callback=pause_resume_callback, tag="pause_button")
-        dpg.add_button(label="Start Simulation", callback=start_sim_callback, tag="start_button")
+        dpg.add_slider_float(
+            label="Tick Rate (sec)",
+            default_value=Config.tick_rate,
+            min_value=0.1,
+            max_value=2.0,
+            callback=tick_rate_changed,
+            tag="tick_rate_slider",
+        )
+        dpg.add_input_int(
+            label="Max Ticks",
+            default_value=Config.max_ticks,
+            callback=max_ticks_changed,
+            tag="max_ticks_input",
+        )
+        dpg.add_button(
+            label="Pause", callback=pause_resume_callback, tag="pause_button"
+        )
+        dpg.add_button(
+            label="Start Simulation", callback=start_sim_callback, tag="start_button"
+        )
         dpg.add_text("Tick: 0", tag="tick_counter")
 
     with dpg.window(label="Causal Graph", width=800, height=460):
         with dpg.drawlist(width=600, height=400, tag="graph_drawlist"):
             for node_id, (x, y) in node_positions.items():
                 color = node_colors[node_id]
-                node_tag = dpg.draw_circle(center=(x, y), radius=30, color=color, fill=color)
-                label_tag = dpg.draw_text((x - 25, y - 10), f"{node_id}\\nTicks: 0", size=15, tag=f"{node_id}_label")
+                node_tag = dpg.draw_circle(
+                    center=(x, y), radius=30, color=color, fill=color
+                )
+                label_tag = dpg.draw_text(
+                    (x - 25, y - 10),
+                    f"{node_id}\\nTicks: 0",
+                    size=15,
+                    tag=f"{node_id}_label",
+                )
                 node_tags[node_id] = node_tag
                 tick_counters[node_id] = label_tag
 
             # Draw directed edges
-            dpg.draw_arrow(p1=node_positions["A1"], p2=node_positions["C"], color=(150, 150, 150), thickness=2)
-            dpg.draw_arrow(p1=node_positions["A2"], p2=node_positions["C"], color=(150, 150, 150), thickness=2)
+            dpg.draw_arrow(
+                p1=node_positions["A1"],
+                p2=node_positions["C"],
+                color=(150, 150, 150),
+                thickness=2,
+            )
+            dpg.draw_arrow(
+                p1=node_positions["A2"],
+                p2=node_positions["C"],
+                color=(150, 150, 150),
+                thickness=2,
+            )
 
     dpg.setup_dearpygui()
     dpg.show_viewport()
     dpg.set_frame_callback(1, gui_update_callback)
     dpg.start_dearpygui()
     dpg.destroy_context()
-


### PR DESCRIPTION
## Summary
- extend Node to track origin metadata and SIP streak
- track new fields when saving/loading graphs
- implement SIP-based node spawning and growth logging
- persist simulation state and tick limit in configuration
- update dashboard controls to write simulation state

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ace6826c8325b404ff32a6a9cfc0