### PR TITLE
Implement CSP and SIP features

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -37,3 +37,20 @@ class Config:
         "strategy": "static",  # static or probabilistic
         "probability": 0.1,  # used when strategy == "probabilistic"
     }
+
+    # SIP recombination
+    SIP_RECOMB_MIN_TRUST = 0.75
+    SIP_MUTATION_SCALE = 0.005
+
+    # SIP failure
+    SIP_STABILIZATION_WINDOW = 5
+    SIP_FAILURE_ENTROPY_INJECTION = 0.1
+
+    # CSP
+    CSP_RADIUS = 80
+    CSP_MAX_NODES = 3
+    CSP_TICK_BURST = 25
+    CSP_STABILIZATION_WINDOW = 6
+    CSP_COLLAPSE_INTENSITY_THRESHOLD = 0.4
+    CSP_DECOHERENCE_THRESHOLD = 0.3
+    CSP_ENTROPY_INJECTION = 0.2


### PR DESCRIPTION
## Summary
- add Phase 8 constants for SIP recombination and CSP propagation
- track SIP/CSP propagation events and failures
- implement SIP recombination child generation
- implement collapse-seeded propagation with entropy injection
- update causal analyst with new explanation types
- trigger CSP on bridge rupture events

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b1a38f8c8325be482484cee8f2d5