### PR TITLE
Add node origin legend and CSP ripple animation

### DIFF
--- a/Causal_Web/gui/graph_panel.py
+++ b/Causal_Web/gui/graph_panel.py
@@ -2,58 +2,113 @@ import os
 import dearpygui.dearpygui as dpg
 from ..config import Config
 from ..engine.tick_engine import simulation_loop
-from ..engine.tick_engine import graph
+from ..engine.tick_engine import graph, recent_csp_failures
 import threading
 
 # Tick stores for visual update
 node_colors = {
     "A1": (100, 149, 237),  # Cornflower Blue
-    "A2": (60, 179, 113),   # Medium Sea Green
-    "C":  (220, 20, 60)     # Crimson
+    "A2": (60, 179, 113),  # Medium Sea Green
+    "C": (220, 20, 60),  # Crimson
 }
-node_positions = {
-    "A1": (100, 200),
-    "A2": (100, 300),
-    "C":  (400, 250)
+
+# Mapping of node origin types to display colors
+ORIGIN_COLORS = {
+    "SIP_BUD": node_colors["A2"],
+    "SIP_RECOMB": node_colors["A1"],
+    "CSP": node_colors["C"],
 }
+node_positions = {"A1": (100, 200), "A2": (100, 300), "C": (400, 250)}
 node_tags = {}
 tick_counters = {}
 
+
 def update_graph_visuals():
-    for node_id in graph.nodes:
-        tick_count = len(graph.get_node(node_id).tick_history)
-        dpg.set_value(f"{node_id}_label", f"{node_id}\\nTicks: {tick_count}")
+    """Redraw the graph nodes, edges and CSP failure ripples."""
+    if not dpg.does_item_exist("graph_drawlist"):
+        return
+
+    dpg.delete_item("graph_drawlist", children_only=True)
+
+    for node_id, node in graph.nodes.items():
+        color = ORIGIN_COLORS.get(
+            getattr(node, "origin_type", ""), node_colors.get(node_id, (100, 149, 237))
+        )
+        dpg.draw_circle(
+            center=(node.x, node.y),
+            radius=30,
+            color=color,
+            fill=color,
+            parent="graph_drawlist",
+        )
+
+        label = f"{node_id}\nTicks: {len(node.tick_history)}"
+        dpg.draw_text(
+            pos=(node.x - 25, node.y - 10),
+            text=label,
+            size=15,
+            parent="graph_drawlist",
+        )
+
+    for edge in graph.edges:
+        from_node = graph.nodes[edge.source]
+        to_node = graph.nodes[edge.target]
+        delay = edge.adjusted_delay(
+            from_node.law_wave_frequency, to_node.law_wave_frequency
+        )
+        thickness = 2 + delay * 0.2
+        intensity = min(255, int(50 + delay * 20))
+        color = (150, 150 - intensity if 150 - intensity > 0 else 0, 150)
+        dpg.draw_arrow(
+            p1=(from_node.x, from_node.y),
+            p2=(to_node.x, to_node.y),
+            color=color,
+            thickness=thickness,
+            parent="graph_drawlist",
+        )
+
+    now = Config.current_tick
+    for rip in list(recent_csp_failures):
+        age = now - rip["tick"]
+        if age > 10:
+            recent_csp_failures.remove(rip)
+            continue
+        radius = 10 + age * 7
+        alpha = max(0, 255 - age * 25)
+        dpg.draw_circle(
+            center=(rip["x"], rip["y"]),
+            radius=radius,
+            color=(255, 128, 128, alpha),
+            fill=(255, 128, 128, 50),
+            parent="graph_drawlist",
+        )
+
 
 def gui_loop():
     dpg.create_context()
     dpg.create_viewport(title="CWT Real-Time Causal Graph", width=640, height=480)
 
     with dpg.font_registry():
-        font_path = os.path.join(os.path.dirname(__file__), "..", "assets", "fonts", "consola.ttf")
+        font_path = os.path.join(
+            os.path.dirname(__file__), "..", "assets", "fonts", "consola.ttf"
+        )
         default_font = dpg.add_font(font_path, 18)
     dpg.bind_font(default_font)
 
     with dpg.window(label="Causal Graph", width=620, height=460):
-        with dpg.drawlist(width=600, height=400):
-            for node_id, (x, y) in node_positions.items():
-                color = node_colors[node_id]
-                node_tag = dpg.draw_circle(center=(x, y), radius=30, color=color, fill=color)
-                label_tag = dpg.draw_text((x - 25, y - 10), f"{node_id}\\nTicks: 0", size=15)
-                node_tags[node_id] = node_tag
-                tick_counters[node_id] = label_tag
-
-            # Draw directed edges with curvature overlays
-            for edge in graph.edges:
-                from_node = graph.nodes[edge.source]
-                to_node = graph.nodes[edge.target]
-                delay = edge.adjusted_delay(from_node.law_wave_frequency, to_node.law_wave_frequency)
-                thickness = 2 + delay * 0.2
-                intensity = min(255, int(50 + delay * 20))
-                color = (150, 150 - intensity if 150 - intensity > 0 else 0, 150)
-                dpg.draw_arrow(p1=(from_node.x, from_node.y), p2=(to_node.x, to_node.y), color=color, thickness=thickness)
-
+        with dpg.drawlist(width=600, height=400, tag="graph_drawlist"):
+            pass
         dpg.add_button(label="Start Simulation", callback=start_sim)
         dpg.add_text("Tick: 0", tag="tick_counter")
+
+    with dpg.window(label="Legend", width=180, height=100, pos=(450, 10)):
+        dpg.add_text(
+            "\u2b1b SIP_BUD — Stable propagation", color=ORIGIN_COLORS["SIP_BUD"]
+        )
+        dpg.add_text(
+            "\u2b1b SIP_RECOMB — Recombination", color=ORIGIN_COLORS["SIP_RECOMB"]
+        )
+        dpg.add_text("\u2b1b CSP — Collapse-seeded", color=ORIGIN_COLORS["CSP"])
 
     dpg.setup_dearpygui()
     dpg.show_viewport()
@@ -67,6 +122,7 @@ def gui_loop():
     threading.Thread(target=refresh, daemon=True).start()
     dpg.start_dearpygui()
     dpg.destroy_context()
+
 
 def start_sim():
     if not Config.is_running:


### PR DESCRIPTION
## Summary
- visualize node origin types in graph_panel legend
- animate fading ripples on CSP failures

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b82afd4c8325856a67984300d934