### PR TITLE
Fix interpreter handling of empty curvature logs

### DIFF
--- a/Causal_Web/engine/log_interpreter.py
+++ b/Causal_Web/engine/log_interpreter.py
@@ -46,11 +46,15 @@ class CWTLogInterpreter:
 
     # ------------------------------------------------------------
     def interpret_curvature(self) -> None:
-        path = os.path.join(self.output_dir, "curvature_map.json")
-        if not os.path.exists(path):
+        """Aggregate curvature statistics from the log file."""
+        path = self._path("curvature_map.json")
+        if not os.path.exists(path) or os.path.getsize(path) == 0:
             return
-        with open(path) as f:
-            records = json.load(f)
+        try:
+            with open(path) as f:
+                records = json.load(f)
+        except json.JSONDecodeError:
+            return
         stats: Dict[str, Dict[str, float]] = {}
         for entry in records:
             for edge in entry.get("edges", []):


### PR DESCRIPTION
## Summary
- use `_path` helper in `interpret_curvature`
- skip parsing if the curvature log is missing or empty
- catch `JSONDecodeError` when loading curvature data

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876bc65650483258eef41d8513d9a47