### PR TITLE
Improve interpreter bundling

### DIFF
--- a/Causal_Web/engine/log_interpreter.py
+++ b/Causal_Web/engine/log_interpreter.py
@@ -482,8 +482,21 @@ class CWTLogInterpreter:
             print(f"⚠️ Causal analyst failed: {e}")
 
 
-def run_interpreter() -> None:
-    interpreter = CWTLogInterpreter()
+def run_interpreter(
+    output_dir: str | None = None, graph_path: str | None = None
+) -> None:
+    """Execute the multilayer log interpreter.
+
+    Parameters
+    ----------
+    output_dir:
+        Optional path to the directory containing log files. If ``None`` the
+        default package output directory is used.
+    graph_path:
+        Optional path to the input graph JSON used for the run.
+    """
+
+    interpreter = CWTLogInterpreter(output_dir=output_dir, graph_path=graph_path)
     interpreter.run()
 
 

--- a/bundle_run.py
+++ b/bundle_run.py
@@ -269,7 +269,7 @@ def bundle_run(output_dir: str, run_id: str, do_zip: bool = False) -> str:
     out_dir = os.path.abspath(output_dir)
 
     # Run interpreter chain first
-    run_interpreter()
+    run_interpreter(output_dir=out_dir)
 
     _create_manifest(out_dir, run_id, timestamp)
 


### PR DESCRIPTION
## Summary
- allow overriding output directory and graph path for the log interpreter
- propagate that parameter from `bundle_run.py`

## Testing
- `python -m compileall Causal_Web`
- `black Causal_Web`
- `pytest -q`
- `python bundle_run.py --output-dir Causal_Web/output --run-id testrun`


------
https://chatgpt.com/codex/tasks/task_e_6876c53ab2208325af5e410f87ea49a5