### PR TITLE
Add ramp for jitter and global forcing

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -29,6 +29,8 @@ class Config:
     # Global rhythmic forcing parameters
     phase_jitter = {"amplitude": 0.0, "period": 20}  # radians  # ticks
     coherence_wave = {"amplitude": 0.0, "period": 30}  # threshold modulation
+    # ticks over which to ramp up global forcing effects
+    forcing_ramp_ticks = 20
     # interval for saving runtime snapshots of the graph
     snapshot_interval = 10
 

--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -103,11 +103,15 @@ class Node:
         self.coherence_ramp_ticks = 10
 
     def compute_phase(self, tick_time):
+        """Return phase value incorporating time-dependent global jitter."""
         base = 2 * math.pi * self.frequency * tick_time
         jitter = Config.phase_jitter
         if jitter["amplitude"] and jitter.get("period", 0):
-            base += jitter["amplitude"] * math.sin(
-                2 * math.pi * tick_time / jitter["period"]
+            ramp = min(tick_time / max(1, Config.forcing_ramp_ticks), 1.0)
+            base += (
+                ramp
+                * jitter["amplitude"]
+                * math.sin(2 * math.pi * tick_time / jitter["period"])
             )
         return base
 

--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -43,16 +43,21 @@ SIP_DECOHERENCE_THRESHOLD = 0.5
 
 
 def apply_global_forcing(tick: int) -> None:
-    """Apply rhythmic modulation to all nodes."""
+    """Apply rhythmic modulation to all nodes with a startup ramp."""
     jitter = Config.phase_jitter
     wave = Config.coherence_wave
+    ramp = min(tick / max(1, Config.forcing_ramp_ticks), 1.0)
     for node in graph.nodes.values():
         if jitter["amplitude"] and jitter.get("period", 0):
-            node.phase += jitter["amplitude"] * math.sin(
-                2 * math.pi * tick / jitter["period"]
+            node.phase += (
+                ramp
+                * jitter["amplitude"]
+                * math.sin(2 * math.pi * tick / jitter["period"])
             )
         if wave["amplitude"] and wave.get("period", 0):
-            mod = wave["amplitude"] * math.sin(2 * math.pi * tick / wave["period"])
+            mod = (
+                ramp * wave["amplitude"] * math.sin(2 * math.pi * tick / wave["period"])
+            )
             node.current_threshold = max(0.1, node.current_threshold - mod)
 
 


### PR DESCRIPTION
## Summary
- introduce `forcing_ramp_ticks` in `Config`
- gradually apply jitter in `Node.compute_phase`
- ramp up global forcing waves in `apply_global_forcing`

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877dbaf12a0832592e28623ef6e163b