### PR TITLE
Improve tick seeding with phase offsets and coherence logs

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -36,6 +36,7 @@ class Config:
     seeding = {
         "strategy": "static",  # static or probabilistic
         "probability": 0.1,  # used when strategy == "probabilistic"
+        "phase_offsets": {},  # per-node phase offsets when strategy == "static"
     }
 
     # SIP recombination


### PR DESCRIPTION
## Summary
- allow per-node phase offsets for static tick seeding via `phase_offsets` config
- compute final phase using node frequency + configured offset
- log coherence results immediately after seeding including failure reasons

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877dbc0ccf88325ae89738dfa58c942