### PR TITLE
Improve logging detail for seeding, nodes and bridges

### DIFF
--- a/Causal_Web/engine/tick_seeder.py
+++ b/Causal_Web/engine/tick_seeder.py
@@ -71,6 +71,7 @@ class TickSeeder:
                         "phase": final_phase,
                         "strategy": "static",
                         "coherence": round(coherence, 4),
+                        "threshold": round(threshold, 4),
                         "success": success,
                         "failure_reason": reason,
                     }
@@ -101,6 +102,7 @@ class TickSeeder:
                         "phase": phase,
                         "strategy": "probabilistic",
                         "coherence": round(coherence, 4),
+                        "threshold": round(threshold, 4),
                         "success": success,
                         "failure_reason": reason,
                     }


### PR DESCRIPTION
## Summary
- add coherence threshold info to seeding logs
- log node tick evaluations and dropped ticks with coherence, threshold, and reasons
- log bridge rupture details including reason, coherence and fatigue

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877debc3cd48325b05dbe51f2629743