### PR TITLE
Implement deferred logging with buffer flush thread

### DIFF
--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -4,6 +4,7 @@ from random import random
 from typing import Optional
 import json
 from ..config import Config
+from .logger import log_json
 
 from enum import Enum
 
@@ -100,8 +101,7 @@ class Bridge:
         }
         if conditions is not None:
             record["conditions"] = conditions
-        with open(Config.output_path("bridge_dynamics_log.json"), "a") as f:
-            f.write(json.dumps(record) + "\n")
+        log_json(Config.output_path("bridge_dynamics_log.json"), record)
 
     def update_state(self, tick: int) -> None:
         old = self.state
@@ -146,8 +146,7 @@ class Bridge:
             target=self.node_b_id,
             coherence_at_event=value,
         )
-        with open(Config.output_path("event_log.json"), "a") as f:
-            f.write(json.dumps(event.__dict__) + "\n")
+        log_json(Config.output_path("event_log.json"), event.__dict__)
 
     def _log_rupture(self, tick, reason, coherence):
         record = {
@@ -159,8 +158,7 @@ class Bridge:
             "coherence": round(coherence, 4) if coherence is not None else None,
             "fatigue": round(self.fatigue, 3),
         }
-        with open(Config.output_path("bridge_rupture_log.json"), "a") as f:
-            f.write(json.dumps(record) + "\n")
+        log_json(Config.output_path("bridge_rupture_log.json"), record)
 
     def probabilistic_bridge_failure(
         self, decoherence_strength, rupture_threshold=0.3, rupture_prob=0.9
@@ -183,18 +181,15 @@ class Bridge:
         ):
             self.current_strength = max(0.0, self.current_strength - 0.1)
             duration = tick_time - self.last_active_tick
-            with open(Config.output_path("bridge_decay_log.json"), "a") as f:
-                f.write(
-                    json.dumps(
-                        {
-                            "tick": tick_time,
-                            "bridge": self.bridge_id,
-                            "strength": self.current_strength,
-                            "duration": duration,
-                        }
-                    )
-                    + "\n"
-                )
+            log_json(
+                Config.output_path("bridge_decay_log.json"),
+                {
+                    "tick": tick_time,
+                    "bridge": self.bridge_id,
+                    "strength": self.current_strength,
+                    "duration": duration,
+                },
+            )
             if self.current_strength == 0.0:
                 self.active = False
                 from . import tick_engine as te
@@ -214,17 +209,14 @@ class Bridge:
             self.active = True
             self.last_reform_tick = tick_time
             self.coherence_at_reform = coherence
-            with open(Config.output_path("bridge_reformation_log.json"), "a") as f:
-                f.write(
-                    json.dumps(
-                        {
-                            "tick": tick_time,
-                            "bridge": self.bridge_id,
-                            "coherence": coherence,
-                        }
-                    )
-                    + "\n"
-                )
+            log_json(
+                Config.output_path("bridge_reformation_log.json"),
+                {
+                    "tick": tick_time,
+                    "bridge": self.bridge_id,
+                    "coherence": coherence,
+                },
+            )
             from . import tick_engine as te
 
             te.bridges_reformed_count += 1

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -6,6 +6,7 @@ from .node import Node, Edge, NodeType
 from .meta_node import MetaNode
 from ..config import Config
 import json
+from .logger import log_json
 
 
 class CausalGraph:
@@ -434,10 +435,7 @@ class CausalGraph:
                     visited.add(edge.target)
                     frontier.append((edge.target, dist + 1))
         if affected:
-            with open(Config.output_path("law_wave_log.json"), "a") as f:
-                f.write(
-                    json.dumps(
-                        {"tick": tick, "origin": origin_id, "affected": affected}
-                    )
-                    + "\n"
-                )
+            log_json(
+                Config.output_path("law_wave_log.json"),
+                {"tick": tick, "origin": origin_id, "affected": affected},
+            )

--- a/Causal_Web/engine/logger.py
+++ b/Causal_Web/engine/logger.py
@@ -1,0 +1,53 @@
+import json
+import os
+import threading
+import time
+from collections import defaultdict
+from typing import Any, DefaultDict, List
+
+
+class LogBuffer:
+    """Buffer log lines and flush them asynchronously."""
+
+    def __init__(self, flush_interval: float = 1.0) -> None:
+        self.flush_interval = flush_interval
+        self._buffers: DefaultDict[str, List[str]] = defaultdict(list)
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def log(self, path: str, line: str) -> None:
+        """Append a raw line to the buffer for ``path``."""
+        with self._lock:
+            self._buffers[path].append(line)
+
+    def flush(self) -> None:
+        """Write all buffered lines to disk."""
+        with self._lock:
+            buffers = dict(self._buffers)
+            self._buffers.clear()
+        for path, lines in buffers.items():
+            if not lines:
+                continue
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "a") as f:
+                f.writelines(lines)
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            time.sleep(self.flush_interval)
+            self.flush()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join()
+        self.flush()
+
+
+logger = LogBuffer()
+
+
+def log_json(path: str, data: Any) -> None:
+    """Buffer a JSON serialisable object as a newline delimited record."""
+    logger.log(path, json.dumps(data) + "\n")

--- a/Causal_Web/engine/tick_router.py
+++ b/Causal_Web/engine/tick_router.py
@@ -1,5 +1,6 @@
 class TickRouter:
     """Route ticks across LCCM layers"""
+
     LAYERS = [
         "tick",
         "phase",
@@ -24,6 +25,8 @@ class TickRouter:
     def route_tick(cls, node, tick):
         from ..config import Config
         import json
+        from .logger import log_json
+
         new_layer = cls.next_layer(tick.layer)
         if new_layer != tick.layer:
             record = {
@@ -33,6 +36,5 @@ class TickRouter:
                 "to": new_layer,
                 "trace_id": tick.trace_id,
             }
-            with open(Config.output_path("layer_transition_log.json"), "a") as f:
-                f.write(json.dumps(record) + "\n")
+            log_json(Config.output_path("layer_transition_log.json"), record)
             tick.layer = new_layer

--- a/Causal_Web/engine/tick_seeder.py
+++ b/Causal_Web/engine/tick_seeder.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 from .graph import CausalGraph
 from ..config import Config
+from .logger import log_json
 
 
 class TickSeeder:
@@ -25,8 +26,7 @@ class TickSeeder:
 
     # ------------------------------------------------------------
     def _log(self, record: Dict) -> None:
-        with open(self.log_path, "a") as f:
-            f.write(json.dumps(record) + "\n")
+        log_json(self.log_path, record)
         self.seed_count += 1
 
     # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `LogBuffer` class for asynchronous logging
- replace direct log writes with `log_json` buffer helper in engine modules
- stop logging thread during final output generation

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fa4ee628832587cd5bad31c7710b