### PR TITLE
Fix tick engine indentation error

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -42,7 +42,7 @@ _csp_failure_count = 0
 _recent_node_counts: list[int] = []
 _dynamic_coherence_offset: float = 0.0
 
-  _spawn_counts = {}
+_spawn_counts = {}
 _spawn_tick = -1
 
 


### PR DESCRIPTION
## Summary
- fix indentation on `_spawn_counts` in tick_engine

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fdd6690c8325a9a6400eea6f7446