### PR TITLE
Add numpy directive to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,5 @@
 - **Syntax check**: Execute `python -m compileall Causal_Web` to ensure files compile.
 - **Docstrings**: Add docstrings for any new public functions or classes.
 - **Manual run**: The simulation GUI starts with `python -m Causal_Web.main`.
+- **Dependencies**: Install `numpy` with `pip install numpy` before running tests.
 


### PR DESCRIPTION
## Summary
- mention that numpy must be installed before running tests

## Testing
- `python -m compileall Causal_Web`

------
https://chatgpt.com/codex/tasks/task_e_68780996e3c48325ade98cc805ded6cf