### PR TITLE
Fix CSP edges referencing bridge ids

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -472,7 +472,14 @@ def _process_csp_seeds(tick: int) -> None:
                 generation_tick=tick,
                 parent_ids=[seed["parent"]],
             )
-            graph.add_edge(seed["parent"], node_id)
+            parent_id = seed["parent"]
+            if "->" in parent_id:
+                src, tgt = parent_id.split("->", 1)
+                for pid in (src, tgt):
+                    if pid in graph.nodes:
+                        graph.add_edge(pid, node_id)
+            else:
+                graph.add_edge(parent_id, node_id)
             log_json(
                 Config.output_path("node_emergence_log.json"),
                 {

--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -114,8 +114,10 @@ def update_graph_visuals():
 
     # Draw edges with curvature overlays
     for edge in graph.edges:
-        from_node = graph.nodes[edge.source]
-        to_node = graph.nodes[edge.target]
+        from_node = graph.nodes.get(edge.source)
+        to_node = graph.nodes.get(edge.target)
+        if from_node is None or to_node is None:
+            continue
 
         delay = edge.adjusted_delay(
             from_node.law_wave_frequency, to_node.law_wave_frequency


### PR DESCRIPTION
## Summary
- avoid KeyErrors when drawing edges for CSP nodes
- connect collapse nodes spawned from bridges back to real nodes

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`
- `pip install numpy dearpygui`

------
https://chatgpt.com/codex/tasks/task_e_68781245d5fc83258e2a7eaef50f6288