### PR TITLE
Implement hierarchical clusters

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -243,6 +243,8 @@ def dynamic_bridge_management(global_tick):
                 continue
             if (a.id, b.id) in existing:
                 continue
+            if a.cluster_ids.get(0) != b.cluster_ids.get(0):
+                continue
             drift = abs((a.phase - b.phase + math.pi) % (2 * math.pi) - math.pi)
             if (
                 drift < drift_thresh
@@ -659,8 +661,8 @@ def log_metrics_per_tick(global_tick):
         debt_log[node_id] = round(debt, 3)
         type_log[node_id] = ntype
 
-    clusters = graph.detect_clusters()
-    graph.create_meta_nodes(clusters)
+    clusters = graph.hierarchical_clusters()
+    graph.create_meta_nodes(clusters.get(0, []))
 
     log_json(Config.output_path("cluster_log.json"), {str(global_tick): clusters})
 

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -1,0 +1,19 @@
+import math
+from Causal_Web.engine.graph import CausalGraph
+from Causal_Web.engine.node import Node
+
+
+def test_hierarchical_cluster_assignment():
+    g = CausalGraph()
+    g.add_node("A")
+    g.add_node("B")
+    g.nodes["A"].law_wave_frequency = 1.0
+    g.nodes["B"].law_wave_frequency = 1.02
+    g.nodes["A"].coherence = 0.95
+    g.nodes["B"].coherence = 0.95
+    clusters = g.hierarchical_clusters()
+    a_cluster = g.nodes["A"].cluster_ids.get(0)
+    b_cluster = g.nodes["B"].cluster_ids.get(0)
+    assert a_cluster == b_cluster
+    assert 0 in g.nodes["A"].cluster_ids
+    assert 1 in clusters


### PR DESCRIPTION
## Summary
- add `cluster_ids` to `Node`
- restrict tick fanout to same cluster
- assign clusters and compute hierarchical clusters in `CausalGraph`
- prevent bridge formation across clusters and log hierarchical clusters each tick
- add unit test for clustering

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878142fbf148325908b46e6c93c9bc3