### PR TITLE
Fix refractory state after reset

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -158,6 +158,7 @@ class CausalGraph:
             node.current_tick = 0
             node.subjective_ticks = 0
             node.last_emission_tick = None
+            node.last_tick_time = -math.inf
             node.coherence = 1.0
             node.decoherence = 0.0
 


### PR DESCRIPTION
## Summary
- ensure `reset_ticks` clears last tick time for nodes

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878236538a083258e7e52a554ad7f34