### PR TITLE
Fix reset logic to clear queued phases

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -155,12 +155,21 @@ class CausalGraph:
             node._coherence_cache.clear()
             node._decoherence_cache.clear()
             node.incoming_phase_queue.clear()
+            node.pending_superpositions.clear()
             node.current_tick = 0
             node.subjective_ticks = 0
             node.last_emission_tick = None
             node.last_tick_time = -math.inf
             node.coherence = 1.0
             node.decoherence = 0.0
+
+        # ensure no stale update flags remain
+        try:
+            from . import tick_engine as te
+
+            te.nodes_to_update.clear()
+        except Exception:
+            pass
 
     def inspect_superpositions(self):
         inspection_log = []


### PR DESCRIPTION
## Summary
- clear `pending_superpositions` so old phases don't linger when the graph is reset
- reset update queue to avoid evaluating stale nodes

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687825f1cd24832598dfb0a0bda26a65