### PR TITLE
Fix tick duplicate detection and log should_tick successes

### DIFF
--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -450,6 +450,10 @@ class Node:
                 False,
                 True,
             )
+            log_json(
+                Config.output_path("should_tick_log.json"),
+                {"tick": tick_time, "node": self.id, "reason": "threshold"},
+            )
             return True, resultant_phase, "threshold"
 
         merged, phase = self._resolve_interference(tick_time, raw_phases, vector_sum)
@@ -461,6 +465,10 @@ class Node:
                 False,
                 True,
                 "merged",
+            )
+            log_json(
+                Config.output_path("should_tick_log.json"),
+                {"tick": tick_time, "node": self.id, "reason": "merged"},
             )
             return True, phase, "merged"
 
@@ -508,8 +516,11 @@ class Node:
 
             te.boundary_interactions_count += 1
 
-        # Avoid duplicate ticks at the same moment
-        if any(tick.time == tick_time for tick in self.tick_history):
+        # Avoid duplicate ticks from the same origin at the same moment
+        if any(
+            tick.time == tick_time and tick.origin == origin
+            for tick in self.tick_history
+        ):
             self._log_tick_drop(tick_time, "duplicate")
             return
 


### PR DESCRIPTION
## Summary
- avoid rejecting a tick just because the node emitted on the same tick time
- temporarily log when nodes pass the eligibility check in `should_tick`

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`
- `pip install numpy dearpygui`

------
https://chatgpt.com/codex/tasks/task_e_687912aca2f88325af851d4d42979f4d