### PR TITLE
Handle external ticks and improve threshold logging

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -150,6 +150,8 @@ class CausalGraph:
     def reset_ticks(self):
         for node in self.nodes.values():
             node.tick_history.clear()
+            node.emitted_tick_times.clear()
+            node.received_tick_times.clear()
             node._tick_phase_lookup.clear()
             node._phase_cache.clear()
             node._coherence_cache.clear()


### PR DESCRIPTION
## Summary
- track emitted vs received ticks separately
- ignore duplicates for incoming ticks
- bypass refractory check on first tick
- base threshold comparison uses coherence
- log magnitude info when tick suppression occurs

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791c64bdf4832589e369fbe92404a7