### PR TITLE
Fix cluster crash when nodes are removed

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -399,12 +399,7 @@ def _check_sip_failures(tick: int) -> None:
         success = node and len(node.tick_history) > 0 and node.coherence > 0.5
         if not success:
             if node:
-                graph.edges = [
-                    e
-                    for e in graph.edges
-                    if e.source != child_id and e.target != child_id
-                ]
-                del graph.nodes[child_id]
+                graph.remove_node(child_id)
             for pid in parents:
                 p = graph.get_node(pid)
                 if p:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -18,7 +18,7 @@ def test_interference_type_destructive():
 
 def test_detect_clusters():
     g = CausalGraph()
-    for nid, freq in {"A":1.0, "B":1.02, "C":1.5}.items():
+    for nid, freq in {"A": 1.0, "B": 1.02, "C": 1.5}.items():
         g.nodes[nid] = Node(nid)
         g.nodes[nid].law_wave_frequency = freq
         g.nodes[nid].coherence = 0.95
@@ -33,3 +33,20 @@ def test_edge_adjusted_delay():
     # with frequency difference effect
     delay = edge.adjusted_delay(1.0, 1.5, kappa=1.0)
     assert delay >= 1
+
+
+def test_remove_node_cleans_references():
+    g = CausalGraph()
+    g.add_node("A")
+    g.add_node("B")
+    g.add_edge("A", "B")
+
+    g.remove_node("B")
+
+    assert "B" not in g.nodes
+    assert "B" not in g.edges_from
+    assert "B" not in g.edges_to
+    assert all("B" not in (e.source, e.target) for e in g.edges)
+
+    # should not raise when computing clusters
+    g.hierarchical_clusters()


### PR DESCRIPTION
## Summary
- add `remove_node` helper to `CausalGraph`
- use `remove_node` when SIP offspring fail to stabilize
- test that node removal cleans edge references

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687920dde12c8325b0fee46192e0d0b5