### PR TITLE
Fix missing tick delivery log in bundles

### DIFF
--- a/bundle_run.py
+++ b/bundle_run.py
@@ -29,6 +29,7 @@ DEFAULT_KEEP_FILES = [
     "interference_log.json",
     "tick_density_map.json",
     "tick_seed_log.json",
+    "tick_delivery_log.json",
     "refraction_log.json",
     "collapse_front_log.json",
     "collapse_chain_log.json",


### PR DESCRIPTION
## Summary
- keep `tick_delivery_log.json` when bundling run outputs

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687925f4eb348325b8d95267e3ca7907