### PR TITLE
Add Tick object pooling

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -29,6 +29,8 @@ class Config:
     tick_limit = 10000
     allow_tick_override = True
     current_tick = 0  # Counter to display progress
+    # Preallocated ticks for object pool
+    TICK_POOL_SIZE = 10000
 
     # Global rhythmic forcing parameters
     phase_jitter = {"amplitude": 0.0, "period": 20}  # radians  # ticks

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from .bridge import Bridge
 from .node import Node, Edge, NodeType
+from .tick import GLOBAL_TICK_POOL
 from .meta_node import MetaNode
 from ..config import Config
 import json
@@ -199,6 +200,8 @@ class CausalGraph:
 
     def reset_ticks(self):
         for node in self.nodes.values():
+            for t in node.tick_history:
+                GLOBAL_TICK_POOL.release(t)
             node.tick_history.clear()
             node.emitted_tick_times.clear()
             node.received_tick_times.clear()

--- a/Causal_Web/engine/tick.py
+++ b/Causal_Web/engine/tick.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from collections import deque
+from typing import Deque
+
+from ..config import Config
+
+
+@dataclass
+class Tick:
+    """Discrete causal pulse with layer metadata."""
+
+    origin: str
+    time: float
+    amplitude: float
+    phase: float
+    layer: str = "tick"
+    trace_id: str = ""
+
+
+class TickPool:
+    """Reusable pool of :class:`Tick` objects."""
+
+    def __init__(self, size: int = 0) -> None:
+        self._pool: Deque[Tick] = deque(Tick("", 0.0, 0.0, 0.0) for _ in range(size))
+
+    def acquire(self) -> Tick:
+        """Return a tick instance from the pool or create a new one."""
+        if self._pool:
+            return self._pool.popleft()
+        return Tick("", 0.0, 0.0, 0.0)
+
+    def release(self, tick: Tick) -> None:
+        """Reset *tick* and put it back into the pool."""
+        tick.origin = ""
+        tick.time = 0.0
+        tick.amplitude = 0.0
+        tick.phase = 0.0
+        tick.layer = "tick"
+        tick.trace_id = ""
+        self._pool.append(tick)
+
+
+def create_global_pool() -> TickPool:
+    """Instantiate the global tick pool using :data:`Config.TICK_POOL_SIZE`."""
+
+    size = getattr(Config, "TICK_POOL_SIZE", 10000)
+    return TickPool(size)
+
+
+# Shared pool used across the simulation
+GLOBAL_TICK_POOL = create_global_pool()


### PR DESCRIPTION
## Summary
- introduce `TickPool` in `engine/tick.py`
- reuse Tick instances via `GLOBAL_TICK_POOL` in `Node`
- release tick objects when resetting the graph
- expose `TICK_POOL_SIZE` setting in `Config`

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687938d4d57c83259be92d3519cd112d