### PR TITLE
Add stable frequency logging and advanced notebook analyses

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -603,6 +603,7 @@ def log_metrics_per_tick(global_tick):
     classical_state = {}
     coherence_velocity = {}
     law_wave_log = {}
+    stable_frequency_log = {}
     interference_log = {}
     credit_log = {}
     debt_log = {}
@@ -648,6 +649,9 @@ def log_metrics_per_tick(global_tick):
             )
             record["stable"] = 0
 
+        if record["stable"] >= 5:
+            stable_frequency_log[node_id] = round(np.mean(record["freqs"]), 4)
+
         decoherence_log[node_id] = round(decoherence, 4)
         coherence_log[node_id] = round(coherence, 4)
         classical_state[node_id] = getattr(node, "is_classical", False)
@@ -664,6 +668,11 @@ def log_metrics_per_tick(global_tick):
     log_json(Config.output_path("cluster_log.json"), {str(global_tick): clusters})
 
     log_json(Config.output_path("law_wave_log.json"), {str(global_tick): law_wave_log})
+    if stable_frequency_log:
+        log_json(
+            Config.output_path("stable_frequency_log.json"),
+            {str(global_tick): stable_frequency_log},
+        )
 
     log_json(
         Config.output_path("decoherence_log.json"), {str(global_tick): decoherence_log}

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The simulation writes many JSON files to `output/`.
 - `interference_log.json` – interference classification per node.
 - `law_drift_log.json` – refractory period adjustments.
 - `law_wave_log.json` – node law-wave frequencies.
+- `stable_frequency_log.json` – nodes with converged law-wave frequency values.
 - `layer_transition_log.json` – tick transitions between LCCM layers.
 - `layer_transition_events.json` – counts of layer transitions per node.
 - `magnitude_failure_log.json` – ticks rejected for low magnitude.

--- a/notebooks/log_analysis.ipynb
+++ b/notebooks/log_analysis.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "1925b0af",
    "metadata": {},
    "source": [
     "# Causal Web - Analysis Notebook\n",
@@ -11,6 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c6978ead",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,6 +30,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d716b9fc",
    "metadata": {},
    "source": [
     "## 2. Configuration & Data Loading\n",
@@ -37,6 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "72932702",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,11 +63,17 @@
     "structural_growth_df = load_log_file(LOG_DIR / 'structural_growth_log.json')\n",
     "collapse_chain_df = load_log_file(LOG_DIR / 'collapse_chain_log.json')\n",
     "law_wave_log_df = load_log_file(LOG_DIR / 'law_wave_log.json')\n",
-    "failure_log_df = load_log_file(LOG_DIR / 'propagation_failure_log.json')"
+    "failure_log_df = load_log_file(LOG_DIR / 'propagation_failure_log.json')\n",
+    "stable_freq_df = load_log_file(LOG_DIR / 'stable_frequency_log.json')\n",
+    "classical_map_df = load_log_file(LOG_DIR / 'classicalization_map.json')\n",
+    "node_state_df = load_log_file(LOG_DIR / 'node_state_log.json')\n",
+    "coherence_log_df = load_log_file(LOG_DIR / 'coherence_log.json')\n",
+    "cluster_log_df = load_log_file(LOG_DIR / 'cluster_log.json')"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "9e9c5bcb",
    "metadata": {},
    "source": [
     "## 3. Overall Simulation Health Dashboard 📈\n",
@@ -73,6 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b489bf07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,6 +110,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "53d238d0",
    "metadata": {},
    "source": [
     "## 4. Emergence & Evolution Analysis 🧠"
@@ -107,6 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "31402c50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,6 +141,154 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c2f84b9a",
+   "metadata": {},
+   "source": [
+    "## 4a. Law-Wave Speciation and Dominance 🔬\n",
+    "This plot shows how many distinct stable frequencies exist at each tick."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3df71c6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "if not stable_freq_df.empty:\n",
+    "    diversity_records = []\n",
+    "    for rec in stable_freq_df.itertuples(index=False):\n",
+    "        tick, data = list(rec._asdict().items())[0]\n",
+    "        tick = int(tick)\n",
+    "        unique = len(set(data.values()))\n",
+    "        diversity_records.append({'tick': tick, 'diversity': unique})\n",
+    "    df_div = pd.DataFrame(diversity_records).sort_values('tick')\n",
+    "    fig = px.line(df_div, x='tick', y='diversity', title='Stable Frequency Diversity Over Time', labels={'diversity':'Unique Frequencies'})\n",
+    "    fig.show()\n",
+    "else:\n",
+    "    print('stable_frequency_log.json not found or empty')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "236f2a2a",
+   "metadata": {},
+   "source": [
+    "## 4b. The Classicalization Front 🌍\n",
+    "Visualise how coherent regions collapse over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58695f6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "if not classical_map_df.empty and not node_state_df.empty:\n",
+    "    with open(LOG_DIR / 'runtime_graph_snapshots/graph_0.json') as f:\n",
+    "        base_graph = json.load(f)\n",
+    "    positions = {n['id']:(n['x'], n['y']) for n in base_graph['nodes']}\n",
+    "    sample_ticks = sorted(classical_map_df.columns[:5]) if len(classical_map_df.columns)>0 else []\n",
+    "    for tick in sample_ticks:\n",
+    "        state = classical_map_df[str(tick)] if str(tick) in classical_map_df else {}\n",
+    "        debt = node_state_df.get(str(tick), {}).get('debt', {}) if isinstance(node_state_df, dict) else node_state_df.loc[str(tick),'debt'] if str(tick) in node_state_df.index else {}\n",
+    "        data = []\n",
+    "        for nid, pos in positions.items():\n",
+    "            if str(tick) in classical_map_df and nid in classical_map_df[str(tick)]:\n",
+    "                collapsed = classical_map_df[str(tick)][nid]\n",
+    "            else:\n",
+    "                collapsed = False\n",
+    "            d = debt.get(nid, 0) if isinstance(debt, dict) else (debt[nid] if nid in debt else 0)\n",
+    "            if collapsed:\n",
+    "                color = 'red'\n",
+    "            elif d > 0.5:\n",
+    "                color = 'yellow'\n",
+    "            else:\n",
+    "                color = 'blue'\n",
+    "            data.append({'x':pos[0],'y':pos[1],'color':color,'id':nid})\n",
+    "        df = pd.DataFrame(data)\n",
+    "        fig = px.scatter(df, x='x', y='y', color='color', title=f'Classicalization Front at tick {tick}', color_discrete_map={'blue':'blue','yellow':'yellow','red':'red'})\n",
+    "        fig.update_traces(marker=dict(size=12))\n",
+    "        fig.show()\n",
+    "else:\n",
+    "    print('Required logs for classicalization front not available')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b98a466e",
+   "metadata": {},
+   "source": [
+    "## 4c. The Creative Cycle (SIP vs. CSP)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ee7ed32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "if not coherence_log_df.empty and not structural_growth_df.empty:\n",
+    "    avg_coh = []\n",
+    "    for rec in coherence_log_df.itertuples(index=False):\n",
+    "        tick, values = list(rec._asdict().items())[0]\n",
+    "        tick = int(tick)\n",
+    "        avg = sum(values.values())/len(values)\n",
+    "        avg_coh.append({'tick':tick,'coherence':avg})\n",
+    "    coh_df = pd.DataFrame(avg_coh).sort_values('tick')\n",
+    "    sg = structural_growth_df\n",
+    "    sg['ratio'] = sg.apply(lambda r: (r['sip_success'] or 0)/(r['csp_success'] or 1), axis=1)\n",
+    "    fig = make_subplots(specs=[[{\"secondary_y\": True}]])\n",
+    "    fig.add_trace(go.Scatter(x=coh_df['tick'], y=coh_df['coherence'], name='Avg Coherence'), secondary_y=False)\n",
+    "    fig.add_trace(go.Scatter(x=sg['tick'], y=sg['ratio'], name='SIP/CSP Ratio', line=dict(color='orange')), secondary_y=True)\n",
+    "    fig.update_layout(title='Creative Cycle Dynamics')\n",
+    "    fig.update_yaxes(title_text='Average Coherence', secondary_y=False)\n",
+    "    fig.update_yaxes(title_text='SIP/CSP Ratio', secondary_y=True)\n",
+    "    fig.show()\n",
+    "else:\n",
+    "    print('coherence_log or structural_growth_log not available')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d52518e4",
+   "metadata": {},
+   "source": [
+    "## 4d. Causal Genetics and Lineage Tracing 🧬"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c06f568",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "if not stable_freq_df.empty and not emergence_log_df.empty:\n",
+    "    latest_tick = max(int(t) for t in stable_freq_df.columns)\n",
+    "    stable_nodes = stable_freq_df[str(latest_tick)].keys()\n",
+    "    parent_map = {row['id']: row['parents'] for _, row in emergence_log_df.iterrows()}\n",
+    "    def lineage(nid):\n",
+    "        chain = [nid]\n",
+    "        while nid in parent_map and parent_map[nid]:\n",
+    "            nid = parent_map[nid][0]\n",
+    "            chain.append(nid)\n",
+    "        return ' -> '.join(chain)\n",
+    "    for nid in list(stable_nodes)[:5]:\n",
+    "        print(f\"Lineage for {nid}: {lineage(nid)}\")\n",
+    "else:\n",
+    "    print('Insufficient data for lineage tracing')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b81d04b",
    "metadata": {},
    "source": [
     "## 5. Causal Chain Forensics 🕵️"
@@ -136,6 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "02d55d04",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,10 +333,12 @@
     "\n",
     "if not collapse_chain_df.empty:\n",
     "    example_chain_id = collapse_chain_df['chain_id'].iloc[0]\n",
-    "    print(f'\n--- Visualizing example collapse chain: {example_chain_id} ---')\n",
+    "    print(f'\n",
+    "--- Visualizing example collapse chain: {example_chain_id} ---')\n",
     "    visualize_collapse_chain(example_chain_id)\n",
     "else:\n",
-    "    print('\nCould not run visualization example because collapse log is empty.')"
+    "    print('\n",
+    "Could not run visualization example because collapse log is empty.')"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- record `stable_frequency_log.json` during metrics logging
- document new log file in README
- expand `log_analysis.ipynb` with analyses for law-wave speciation, classicalization front, creative cycle and lineage tracing

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794c78738c8325aba821ad9324e48b