### PR TITLE
Add edge_count to growth log

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -267,11 +267,16 @@ def dynamic_bridge_management(global_tick):
 
 
 def _update_growth_log(tick: int) -> None:
-    """Record structural growth per tick."""
+    """Record structural growth per tick.
+
+    This includes counts for nodes, edges (including bridges) and
+    the number of successful or failed propagation attempts.
+    """
     global _sip_success_count, _sip_failure_count, _csp_success_count, _csp_failure_count
     record = {
         "tick": tick,
         "node_count": len(graph.nodes),
+        "edge_count": len(graph.edges) + len(graph.bridges),
         "sip_success": _sip_success_count,
         "sip_failures": _sip_failure_count,
         "csp_success": _csp_success_count,

--- a/Causal_Web/output/structural_growth_log.json
+++ b/Causal_Web/output/structural_growth_log.json
@@ -1,60 +1,60 @@
-{"tick": 4, "node_count": 3, "sip_success": 0, "sip_failures": 0, "csp_success": 0, "csp_failures": 0}
-{"tick": 8, "node_count": 4, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0}
-{"tick": 8, "node_count": 5, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0}
-{"tick": 10, "node_count": 6, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0}
-{"tick": 13, "node_count": 5, "sip_success": 1, "sip_failures": 2, "csp_success": 0, "csp_failures": 0}
-{"tick": 15, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 17, "node_count": 6, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0}
-{"tick": 21, "node_count": 5, "sip_success": 1, "sip_failures": 2, "csp_success": 0, "csp_failures": 0}
-{"tick": 24, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 25, "node_count": 6, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0}
-{"tick": 29, "node_count": 5, "sip_success": 1, "sip_failures": 2, "csp_success": 0, "csp_failures": 0}
-{"tick": 33, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 37, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 41, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 45, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 49, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 53, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 57, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 61, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 65, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 69, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 73, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 77, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 81, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 85, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 89, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 93, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 97, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 101, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 105, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 109, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 113, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 117, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 121, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 125, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 129, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 133, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 137, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 141, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 145, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 149, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 153, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 157, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 161, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 165, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 169, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 173, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 177, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 181, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 185, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 189, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 193, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 197, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 201, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 205, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 209, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 213, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 217, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 221, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
-{"tick": 225, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0}
+{"tick": 4, "node_count": 3, "sip_success": 0, "sip_failures": 0, "csp_success": 0, "csp_failures": 0, "edge_count": 2}
+{"tick": 8, "node_count": 4, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0, "edge_count": 3}
+{"tick": 8, "node_count": 5, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 10, "node_count": 6, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0, "edge_count": 5}
+{"tick": 13, "node_count": 5, "sip_success": 1, "sip_failures": 2, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 15, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 17, "node_count": 6, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0, "edge_count": 5}
+{"tick": 21, "node_count": 5, "sip_success": 1, "sip_failures": 2, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 24, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 25, "node_count": 6, "sip_success": 1, "sip_failures": 0, "csp_success": 0, "csp_failures": 0, "edge_count": 5}
+{"tick": 29, "node_count": 5, "sip_success": 1, "sip_failures": 2, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 33, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 37, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 41, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 45, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 49, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 53, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 57, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 61, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 65, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 69, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 73, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 77, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 81, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 85, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 89, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 93, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 97, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 101, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 105, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 109, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 113, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 117, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 121, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 125, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 129, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 133, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 137, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 141, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 145, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 149, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 153, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 157, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 161, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 165, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 169, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 173, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 177, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 181, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 185, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 189, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 193, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 197, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 201, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 205, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 209, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 213, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 217, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 221, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}
+{"tick": 225, "node_count": 5, "sip_success": 1, "sip_failures": 1, "csp_success": 0, "csp_failures": 0, "edge_count": 4}


### PR DESCRIPTION
## Summary
- track total edges (including bridges) in the structural growth log
- regenerate sample structural growth log with the new field

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879503782248325a01ecdfc5469ece5