### PR TITLE
Add runtime config loading

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -79,3 +79,32 @@ class Config:
 
     # Spatial partitioning
     SPATIAL_GRID_SIZE = 50
+
+    @classmethod
+    def load_from_file(cls, path: str) -> None:
+        """Load configuration values from a JSON file.
+
+        Only keys that already exist as attributes on ``Config`` will be
+        assigned. Nested dictionaries are merged recursively when the existing
+        attribute is also a ``dict``.
+
+        Parameters
+        ----------
+        path:
+            Path to the JSON configuration file.
+        """
+        import json
+
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+        with open(path) as f:
+            data = json.load(f)
+
+        for key, value in data.items():
+            if not hasattr(cls, key):
+                continue
+            current = getattr(cls, key)
+            if isinstance(current, dict) and isinstance(value, dict):
+                current.update(value)
+            else:
+                setattr(cls, key, value)

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -1,0 +1,8 @@
+{
+  "tick_rate": 0.5,
+  "max_ticks": 50,
+  "seeding": {
+    "strategy": "probabilistic",
+    "probability": 0.2
+  }
+}

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -1,9 +1,21 @@
 # main.py
 
-from .gui.dashboard import launch  # uses dashboard -> start_dearpygui internally
+"""Entry point for launching the Causal Web simulation GUI."""
+
+import argparse
+from .gui.dashboard import launch
+from .config import Config
 
 
-def main():
+def main() -> None:
+    """Parse CLI arguments and start the GUI."""
+    parser = argparse.ArgumentParser(description="Run Causal Web simulation")
+    parser.add_argument("--config", help="Path to JSON configuration file")
+    args = parser.parse_args()
+
+    if args.config:
+        Config.load_from_file(args.config)
+
     launch()
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ Key modules include:
 - **`main.py`** – simple entry point that launches the dashboard.
 
 Graphs are stored in `input/graph.json` inside the package. Paths are resolved relative to the package so the module can be run from any working directory. All output is written next to the code in the `output` directory.
+
+## Configuration
+
+Runtime parameters such as tick rate or seeding strategy can be overridden by
+providing a JSON configuration file. Invoke the module with the `--config`
+argument:
+
+```bash
+python -m Causal_Web.main --config Causal_Web/input/config.json
+```
+
+Only keys matching attributes on `Causal_Web.config.Config` are applied. Nested
+dictionaries merge with the existing values.
 ## Graph format
 
 Graphs are defined by a JSON file with `nodes`, `edges`, optional `bridges`, `tick_sources` and `observers`. Each node defines its position, frequency and thresholds. Edges specify delays and attenuation. Tick sources seed periodic activity and observers describe which metrics to record.


### PR DESCRIPTION
## Summary
- enable loading config overrides from JSON
- expose `--config` CLI argument
- document usage in README
- add example configuration file

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879bac068b083258bd445bb6246c56d