### PR TITLE
Expose runtime parameters via config

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -39,6 +39,15 @@ class Config:
     forcing_ramp_ticks = 20
     # interval for saving runtime snapshots of the graph
     snapshot_interval = 10
+    random_seed: int | None = None
+    thread_count = 1
+    log_verbosity = "info"
+
+    # Node defaults
+    memory_window = 20
+    initial_coherence_threshold = 0.6
+    steady_coherence_threshold = 0.85
+    coherence_ramp_ticks = 10
 
     # tick seeding configuration
     seeding = {

--- a/Causal_Web/engine/logger.py
+++ b/Causal_Web/engine/logger.py
@@ -5,6 +5,8 @@ import time
 from collections import defaultdict
 from typing import Any, DefaultDict, List
 
+from ..config import Config
+
 
 class LogBuffer:
     """Buffer log lines and flush them asynchronously."""
@@ -45,7 +47,8 @@ class LogBuffer:
         self.flush()
 
 
-logger = LogBuffer()
+_interval = 0.1 if getattr(Config, "log_verbosity", "info") == "debug" else 1.0
+logger = LogBuffer(flush_interval=_interval)
 
 
 def log_json(path: str, data: Any) -> None:

--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -86,7 +86,7 @@ class Node:
         self.sip_streak = 0
 
         # ---- Phase 4 additions ----
-        self.memory_window = 20
+        self.memory_window = getattr(Config, "memory_window", 20)
         self.memory: Dict[str, deque] = {
             "origins": deque(maxlen=self.memory_window),
             "coherence": deque(maxlen=self.memory_window),
@@ -98,9 +98,13 @@ class Node:
         self.goal_error: Dict[str, float] = {}
 
         # ---- Coherence threshold ramp parameters ----
-        self.initial_coherence_threshold = 0.6
-        self.steady_coherence_threshold = 0.85
-        self.coherence_ramp_ticks = 10
+        self.initial_coherence_threshold = getattr(
+            Config, "initial_coherence_threshold", 0.6
+        )
+        self.steady_coherence_threshold = getattr(
+            Config, "steady_coherence_threshold", 0.85
+        )
+        self.coherence_ramp_ticks = getattr(Config, "coherence_ramp_ticks", 10)
 
         # additional offset applied from global network constraints
         self.dynamic_offset = 0.0

--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -618,7 +618,7 @@ def log_metrics_per_tick(global_tick):
     if not hasattr(log_metrics_per_tick, "_last_coherence"):
         log_metrics_per_tick._last_coherence = {}
 
-    with ThreadPoolExecutor() as ex:
+    with ThreadPoolExecutor(max_workers=getattr(Config, "thread_count", None)) as ex:
         results = list(
             ex.map(lambda n: _compute_metrics(n, global_tick), graph.nodes.values())
         )
@@ -718,6 +718,11 @@ def simulation_loop():
 
     def run():
         global_tick = 0
+        if getattr(Config, "random_seed", None) is not None:
+            import random
+
+            random.seed(Config.random_seed)
+            np.random.seed(Config.random_seed)
         _update_simulation_state(False, False, global_tick, None)
         while True:
             with Config.state_lock:

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -4,5 +4,13 @@
   "seeding": {
     "strategy": "probabilistic",
     "probability": 0.2
-  }
+  },
+  "snapshot_interval": 5,
+  "random_seed": 42,
+  "thread_count": 4,
+  "log_verbosity": "info",
+  "memory_window": 20,
+  "initial_coherence_threshold": 0.6,
+  "steady_coherence_threshold": 0.85,
+  "coherence_ramp_ticks": 10
 }


### PR DESCRIPTION
## Summary
- allow snapshot frequency, random seeding, thread count and other knobs in `config.json`
- expose new config fields on `Config`
- read node defaults from `Config`
- seed random generators and respect thread count
- make logging flush interval depend on `log_verbosity`

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a694856b08325a03907bf897ff1b2