### PR TITLE
Update README with new engine modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Key modules include:
 - **`engine/log_interpreter.py`** – parses the generated logs and aggregates statistics.
 - **`engine/causal_analyst.py`** – infers causal chains and produces explanation files.
 - **`engine/meta_node.py`** – groups clusters of nodes into collapsed meta nodes.
+- **`engine/node_manager.py`** – NumPy-backed container for bulk node updates.
+- **`engine/observer.py`** – observers that infer hidden state from tick history.
+- **`engine/logger.py`** – asynchronous writer used by many modules.
+- **`engine/tick.py`** – defines :class:`Tick` and the reusable object pool.
 - **`gui/dashboard.py`** – Dear PyGui dashboard for interactive runs.
 - **`main.py`** – simple entry point that launches the dashboard.
 


### PR DESCRIPTION
## Summary
- list NodeManager, Observer, Logger and Tick classes in the README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a74d8f9388325ba1ec904aaf7cc36