### PR TITLE
Fix dashboard draw_circle parent

### DIFF
--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -234,13 +234,18 @@ def dashboard():
             for node_id, (x, y) in node_positions.items():
                 color = node_colors[node_id]
                 node_tag = dpg.draw_circle(
-                    center=(x, y), radius=30, color=color, fill=color
+                    center=(x, y),
+                    radius=30,
+                    color=color,
+                    fill=color,
+                    parent="graph_drawlist",
                 )
                 label_tag = dpg.draw_text(
                     (x - 25, y - 10),
                     f"{node_id}\\nTicks: 0",
                     size=15,
                     tag=f"{node_id}_label",
+                    parent="graph_drawlist",
                 )
                 node_tags[node_id] = node_tag
                 tick_counters[node_id] = label_tag
@@ -251,12 +256,14 @@ def dashboard():
                 p2=node_positions["C"],
                 color=(150, 150, 150),
                 thickness=2,
+                parent="graph_drawlist",
             )
             dpg.draw_arrow(
                 p1=node_positions["A2"],
                 p2=node_positions["C"],
                 color=(150, 150, 150),
                 thickness=2,
+                parent="graph_drawlist",
             )
 
     with dpg.window(label="Legend", width=180, height=120, pos=(610, 260)):

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Example:
 ## Running the simulation
 
 1. Install the dependencies (`dearpygui` is required for the GUI).
+   An X11-compatible display is needed to create the window. If running on a
+   headless server consider using a virtual frame buffer such as Xvfb.
 2. Launch the dashboard:
 
 ```bash


### PR DESCRIPTION
## Summary
- fix graph element parenting so `draw_circle` uses the drawlist
- note that the dashboard requires an X11 display for GUI

## Testing
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a7b6fd5088325bba302e6ffcc0e9e