### PR TITLE
Add CLI config overrides and headless mode

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -1,22 +1,107 @@
 # main.py
 
-"""Entry point for launching the Causal Web simulation GUI."""
+"""Entry point for launching the Causal Web simulation or GUI."""
+
+from __future__ import annotations
 
 import argparse
-from .gui.dashboard import launch
+import json
+import os
+import time
+from typing import Any
+
 from .config import Config
 
 
+def _add_config_args(
+    parser: argparse.ArgumentParser, data: dict[str, Any], prefix: str = ""
+) -> None:
+    """Recursively add CLI flags based on ``data`` keys."""
+    for key, value in data.items():
+        arg_name = f"--{prefix}{key}"
+        dest = f"{prefix}{key}".replace(".", "_")
+        if isinstance(value, dict):
+            _add_config_args(parser, value, prefix=f"{key}.")
+            continue
+        arg_type = type(value)
+        if isinstance(value, bool):
+            parser.add_argument(arg_name, type=lambda x: x.lower() == "true", dest=dest)
+        else:
+            parser.add_argument(arg_name, type=arg_type, dest=dest)
+
+
+def _apply_overrides(
+    args: argparse.Namespace, data: dict[str, Any], prefix: str = ""
+) -> None:
+    """Apply CLI overrides back onto :class:`Config`."""
+    for key, value in data.items():
+        full = f"{prefix}{key}"
+        dest = full.replace(".", "_")
+        override = getattr(args, dest, None)
+        if override is not None:
+            parts = full.split(".")
+            target = Config
+            for part in parts[:-1]:
+                target = getattr(target, part)
+            if isinstance(target, dict):
+                target[parts[-1]] = override
+            else:
+                setattr(target, parts[-1], override)
+        elif isinstance(value, dict):
+            _apply_overrides(args, value, prefix=f"{key}.")
+
+
 def main() -> None:
-    """Parse CLI arguments and start the GUI."""
-    parser = argparse.ArgumentParser(description="Run Causal Web simulation")
-    parser.add_argument("--config", help="Path to JSON configuration file")
+    """Parse CLI arguments and run the simulation or GUI."""
+    initial = argparse.ArgumentParser(add_help=False)
+    initial.add_argument(
+        "--config",
+        default=Config.input_path("config.json"),
+        help="Path to JSON configuration file",
+    )
+    initial.add_argument(
+        "--no-gui",
+        action="store_true",
+        help="Run simulation without launching the GUI",
+    )
+    known, remaining = initial.parse_known_args()
+
+    config_data: dict[str, Any] = {}
+    if known.config and os.path.exists(known.config):
+        with open(known.config) as f:
+            config_data = json.load(f)
+        Config.load_from_file(known.config)
+
+    parser = argparse.ArgumentParser(
+        parents=[initial], description="Run Causal Web simulation"
+    )
+    _add_config_args(parser, config_data)
     args = parser.parse_args()
 
-    if args.config:
-        Config.load_from_file(args.config)
+    _apply_overrides(args, config_data)
 
-    launch()
+    if args.no_gui:
+        from .engine import tick_engine
+
+        tick_engine.build_graph()
+        with Config.state_lock:
+            Config.is_running = True
+        tick_engine.simulation_loop()
+        limit = Config.tick_limit if Config.allow_tick_override else Config.max_ticks
+        try:
+            while True:
+                with Config.state_lock:
+                    running = Config.is_running
+                    tick = Config.current_tick
+                if not running and (not limit or tick >= limit):
+                    break
+                time.sleep(0.1)
+        except KeyboardInterrupt:
+            pass
+    else:
+        from .gui.dashboard import launch
+
+        launch()
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -30,10 +30,18 @@ Graphs are stored in `input/graph.json` inside the package. Paths are resolved r
 
 Runtime parameters such as tick rate or seeding strategy can be overridden by
 providing a JSON configuration file. Invoke the module with the `--config`
-argument:
+argument and optionally override individual keys via CLI flags:
 
 ```bash
 python -m Causal_Web.main --config Causal_Web/input/config.json
+```
+
+Flags take the form `--<key>` where `<key>` matches an entry in the
+configuration file (nested keys use dot notation). For example to run the
+simulation headless for 20 ticks you can use:
+
+```bash
+python -m Causal_Web.main --no-gui --max_ticks 20
 ```
 
 Only keys matching attributes on `Causal_Web.config.Config` are applied. Nested
@@ -105,10 +113,11 @@ Example:
 1. Install the dependencies (`dearpygui` is required for the GUI).
    An X11-compatible display is needed to create the window. If running on a
    headless server consider using a virtual frame buffer such as Xvfb.
-2. Launch the dashboard:
+2. Launch the dashboard or run headless:
 
 ```bash
-python -m Causal_Web.main
+python -m Causal_Web.main            # with GUI
+python -m Causal_Web.main --no-gui   # headless run
 ```
 
 Use the on-screen controls to start or pause the simulation and adjust the tick rate. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.


### PR DESCRIPTION
## Summary
- allow passing CLI flags to override config.json values
- add `--no-gui` option for running the simulation headless
- update docs on new CLI features

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy dearpygui`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8c7989708325b575b86e0a64833c