### PR TITLE
Add tick threshold and parameter controls

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -95,6 +95,8 @@ class Config:
     initial_coherence_threshold = 0.6
     steady_coherence_threshold = 0.85
     coherence_ramp_ticks = 10
+    # minimum number of incoming ticks required for activation
+    tick_threshold = 1
 
     # tick seeding configuration
     seeding = {

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -13,6 +13,7 @@
   "initial_coherence_threshold": 0.6,
   "steady_coherence_threshold": 0.85,
   "coherence_ramp_ticks": 10,
+  "tick_threshold": 1,
   "log_files": {
     "boundary_interaction_log.json": true,
     "bridge_decay_log.json": true,

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ python -m Causal_Web.main --no-gui --max_ticks 20
 
 Only keys matching attributes on `Causal_Web.config.Config` are applied. Nested
 dictionaries merge with the existing values.
+
+The configuration now includes a `tick_threshold` option controlling how many
+ticks a node must receive in a single timestep before it can fire. This value
+defaults to `1` and can be overridden via CLI or the Parameters window in the
+GUI.
 ## Graph format
 
 Graphs are defined by a JSON file with `nodes`, `edges`, optional `bridges`, `tick_sources` and `observers`. Each node defines its position, frequency and thresholds. Edges specify delays and attenuation. Tick sources seed periodic activity and observers describe which metrics to record.

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -18,6 +18,26 @@ def test_update_classical_state(tmp_path):
     old_dir = Config.output_dir
     Config.output_dir = tmp_path
     node = Node("A")
-    node.update_classical_state(0.5, tick_time=1, graph=None, threshold=0.4, streak_required=1)
+    node.update_classical_state(
+        0.5, tick_time=1, graph=None, threshold=0.4, streak_required=1
+    )
     assert node.is_classical
+    Config.output_dir = old_dir
+
+
+def test_tick_threshold(tmp_path):
+    old_dir = Config.output_dir
+    old_thresh = getattr(Config, "tick_threshold", 1)
+    Config.output_dir = tmp_path
+    Config.tick_threshold = 2
+    node = Node("A")
+    node.schedule_tick(1, 0.0)
+    fire, _, reason = node.should_tick(1)
+    assert not fire
+    assert reason == "count_threshold"
+    node.schedule_tick(1, math.pi / 2)
+    fire, phase, reason = node.should_tick(1)
+    assert fire
+    assert reason in {"threshold", "merged"}
+    Config.tick_threshold = old_thresh
     Config.output_dir = old_dir


### PR DESCRIPTION
## Summary
- add `tick_threshold` config value and expose via CLI
- track incoming tick counts per node
- respect tick threshold when deciding to emit ticks
- add Parameters window in GUI with live editable config values
- document new setting and test new behavior

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a90604e5c8325805a78da83d6d3de