### PR TITLE
Add global refractory period configuration

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -97,6 +97,8 @@ class Config:
     coherence_ramp_ticks = 10
     # minimum number of incoming ticks required for activation
     tick_threshold = 1
+    # ticks a node must wait after firing before it can fire again
+    refractory_period = 2.0
 
     # tick seeding configuration
     seeding = {

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -31,7 +31,7 @@ class CausalGraph:
         x=0.0,
         y=0.0,
         frequency=1.0,
-        refractory_period=2,
+        refractory_period: float | None = None,
         base_threshold=0.5,
         phase=0.0,
         *,
@@ -40,6 +40,8 @@ class CausalGraph:
         parent_ids=None,
     ):
         x, y = self._non_overlapping_position(x, y)
+        if refractory_period is None:
+            refractory_period = getattr(Config, "refractory_period", 2.0)
         self.nodes[node_id] = Node(
             node_id,
             x,
@@ -479,7 +481,9 @@ class CausalGraph:
                 x=node_data.get("x", 0.0),
                 y=node_data.get("y", 0.0),
                 frequency=node_data.get("frequency", 1.0),
-                refractory_period=node_data.get("refractory_period", 2.0),
+                refractory_period=node_data.get(
+                    "refractory_period", getattr(Config, "refractory_period", 2.0)
+                ),
                 base_threshold=node_data.get("base_threshold", 0.5),
                 phase=node_data.get("phase", 0.0),
                 origin_type=node_data.get("origin_type", "seed"),

--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -29,7 +29,7 @@ class Node:
         x=0.0,
         y=0.0,
         frequency=1.0,
-        refractory_period=2,
+        refractory_period: float | None = None,
         base_threshold=0.5,
         phase=0.0,
         *,
@@ -59,6 +59,8 @@ class Node:
         self.current_tick = 0
         self.subjective_ticks = 0  # For relativistic tracking
         self.last_emission_tick = None
+        if refractory_period is None:
+            refractory_period = getattr(Config, "refractory_period", 2.0)
         self.refractory_period = refractory_period
         self.last_tick_time: Optional[float] = None
         self.base_threshold = base_threshold

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -14,6 +14,7 @@
   "steady_coherence_threshold": 0.85,
   "coherence_ramp_ticks": 10,
   "tick_threshold": 1,
+  "refractory_period": 2.0,
   "log_files": {
     "boundary_interaction_log.json": true,
     "bridge_decay_log.json": true,

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ The configuration now includes a `tick_threshold` option controlling how many
 ticks a node must receive in a single timestep before it can fire. This value
 defaults to `1` and can be overridden via CLI or the Parameters window in the
 GUI.
+
+Nodes also observe a **refractory period** after firing.  The global
+`refractory_period` setting determines how many ticks a node must wait before it
+may emit again, preventing rapid oscillation.  This value is applied when nodes
+are created unless a specific period is provided in the graph file and can be
+adjusted through the CLI or GUI.
 ## Graph format
 
 Graphs are defined by a JSON file with `nodes`, `edges`, optional `bridges`, `tick_sources` and `observers`. Each node defines its position, frequency and thresholds. Edges specify delays and attenuation. Tick sources seed periodic activity and observers describe which metrics to record.

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -2,6 +2,7 @@ import math
 import os
 import tempfile
 from Causal_Web.engine.node import Node
+from Causal_Web.engine.graph import CausalGraph
 from Causal_Web.config import Config
 
 
@@ -41,3 +42,14 @@ def test_tick_threshold(tmp_path):
     assert reason in {"threshold", "merged"}
     Config.tick_threshold = old_thresh
     Config.output_dir = old_dir
+
+
+def test_configurable_refractory_period():
+    old_period = getattr(Config, "refractory_period", 2)
+    Config.refractory_period = 3
+    g = CausalGraph()
+    g.add_node("A")
+    assert g.get_node("A").refractory_period == 3
+    node = Node("B")
+    assert node.refractory_period == 3
+    Config.refractory_period = old_period


### PR DESCRIPTION
## Summary
- add `refractory_period` setting to `Config` and default config file
- respect the new setting when creating nodes
- mention refractory period in docs
- test configurable refractory period

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9311942c83258e7b046566c48908