### PR TITLE
Implement tick energy decay

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -130,6 +130,9 @@ class Config:
     # Tick fan-out
     max_tick_fanout = 0  # limit edges a tick propagates across (0 = unlimited)
 
+    # Decay factor for stored tick energy per tick
+    tick_decay_factor = 1.0
+
     # Early formation tuning
     DRIFT_TOLERANCE_RAMP = 10
     FORMATION_REFRACTORY_RAMP = 20

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -247,14 +247,17 @@ class CausalGraph:
         for node in self.nodes.values():
             for tick, raw_phases in node.pending_superpositions.items():
                 if len(raw_phases) > 1:
+                    phases_only = [
+                        p[0] if isinstance(p, (tuple, list)) else p for p in raw_phases
+                    ]
                     # normalize each float to complex unit vector
                     complex_phase = [
-                        cmath.rect(1.0, p % (2 * math.pi)) for p in raw_phases
+                        cmath.rect(1.0, p % (2 * math.pi)) for p in phases_only
                     ]
                     vector_sum = sum(complex_phase)
                     contributors = [
                         {"phase": round(p % (2 * math.pi), 4), "magnitude": 1.0}
-                        for p in raw_phases
+                        for p in phases_only
                     ]
                     result = {
                         "tick": int(tick),

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -15,6 +15,7 @@
   "coherence_ramp_ticks": 10,
   "tick_threshold": 1,
   "refractory_period": 2.0,
+  "tick_decay_factor": 1.0,
   "edge_weight_range": [1.0, 1.0],
   "log_files": {
     "boundary_interaction_log.json": true,

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ ticks a node must receive in a single timestep before it can fire. This value
 defaults to `1` and can be overridden via CLI or the Parameters window in the
 GUI.
 
+Tick energy can dissipate between scheduling and evaluation. The
+`tick_decay_factor` parameter specifies how much stored tick energy decays per
+tick. A value of `1.0` disables decay while values below `1.0` gradually reduce
+the influence of older ticks. This setting is available via CLI and the GUI.
+
 Nodes also observe a **refractory period** after firing.  The global
 `refractory_period` setting determines how many ticks a node must wait before it
 may emit again, preventing rapid oscillation.  This value is applied when nodes

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -53,3 +53,19 @@ def test_configurable_refractory_period():
     node = Node("B")
     assert node.refractory_period == 3
     Config.refractory_period = old_period
+
+
+def test_tick_decay_factor_affects_firing():
+    old_decay = getattr(Config, "tick_decay_factor", 1.0)
+    old_thresh = getattr(Config, "tick_threshold", 1)
+    Config.tick_decay_factor = 0.5
+    Config.tick_threshold = 1
+    node = Node("A")
+    Config.current_tick = 0
+    node.schedule_tick(1, 0.0)
+    Config.current_tick = 1
+    fire, _, reason = node.should_tick(1)
+    assert not fire
+    assert reason == "count_threshold"
+    Config.tick_decay_factor = old_decay
+    Config.tick_threshold = old_thresh


### PR DESCRIPTION
## Summary
- support configurable tick energy decay via `tick_decay_factor`
- apply decay when computing coherence, decoherence and firing conditions
- document the new parameter
- test that decay prevents firing when energy falls below threshold

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9589f6e88325ad365c56f56b130f