### PR TITLE
Fix GUI non-interactive windows

### DIFF
--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -354,6 +354,7 @@ def dashboard():
 
     dpg.setup_dearpygui()
     dpg.show_viewport()
+    dpg.set_primary_window("graph_window", True)
     graph_resize_callback(None, None, None)
     dpg.set_frame_callback(1, gui_update_callback)
     dpg.start_dearpygui()

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Example:
 1. Install the dependencies (`dearpygui` is required for the GUI).
    An X11-compatible display is needed to create the window. If running on a
    headless server consider using a virtual frame buffer such as Xvfb.
+   The dashboard automatically designates the *Causal Graph* window as the
+   primary viewport so all windows remain interactive.
 2. Launch the dashboard or run headless:
 
 ```bash


### PR DESCRIPTION
## Summary
- designate a primary window so DearPyGui windows can be interacted with
- document that the graph window is set as the primary viewport

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a98da6f888325872712e10a8ee752