### PR TITLE
Fix GUI start button and clean parameter panel

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -437,7 +437,10 @@ class CausalGraph:
             "nodes": node_list,
             "superpositions": {
                 nid: {
-                    str(t): [round(float(p), 4) for p in node.pending_superpositions[t]]
+                    str(t): [
+                        round(float(p[0] if isinstance(p, (tuple, list)) else p), 4)
+                        for p in node.pending_superpositions[t]
+                    ]
                     for t in node.pending_superpositions
                 }
                 for nid, node in self.nodes.items()

--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -255,8 +255,10 @@ def dashboard():
     with open(Config.input_path("config.json")) as f:
         config_data = json.load(f)
 
-    # remove log file settings from parameter controls
+    # remove settings duplicated elsewhere in the GUI
     config_data.pop("log_files", None)
+    config_data.pop("tick_rate", None)
+    config_data.pop("max_ticks", None)
 
     with dpg.font_registry():
         font_path = os.path.join(

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ python -m Causal_Web.main            # with GUI
 python -m Causal_Web.main --no-gui   # headless run
 ```
 
-Use the on-screen controls to start or pause the simulation and adjust the tick rate. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
+Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
 
 ### Analysing the output
 


### PR DESCRIPTION
## Summary
- handle tuple records when exporting superpositions to JSON
- remove duplicate tick settings from the parameters window
- note control panel changes in the README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9bd649cc8325a0e81af71c7d18b8