### PR TITLE
Add database init option

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -150,6 +150,16 @@ class Config:
     # Range for per-edge weights influencing delay/attenuation
     edge_weight_range = [1.0, 1.0]
 
+    # Database connection details
+    database = {
+        "type": "postgres",
+        "host": "localhost",
+        "port": 5432,
+        "user": "sim_user",
+        "password": "secret_password",
+        "dbname": "cwt_simulation",
+    }
+
     @classmethod
     def load_from_file(cls, path: str) -> None:
         """Load configuration values from a JSON file.
@@ -178,3 +188,14 @@ class Config:
                 current.update(value)
             else:
                 setattr(cls, key, value)
+
+
+def load_config(path: str | None = None) -> dict:
+    """Load configuration from ``path`` and return the data."""
+    if path is None:
+        path = Config.input_path("config.json")
+    Config.load_from_file(path)
+    import json
+
+    with open(path) as f:
+        return json.load(f)

--- a/Causal_Web/database/__init__.py
+++ b/Causal_Web/database/__init__.py
@@ -1,0 +1,5 @@
+"""Database utilities for the Causal Web project."""
+
+from .db_setup import initialize_database
+
+__all__ = ["initialize_database"]

--- a/Causal_Web/database/db_setup.py
+++ b/Causal_Web/database/db_setup.py
@@ -1,0 +1,110 @@
+"""Database initialization utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg2
+
+SCHEMA_SQL = """
+-- Table 1: events
+CREATE TABLE IF NOT EXISTS events (
+    log_id TEXT PRIMARY KEY,
+    tick INTEGER NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    correlation_id TEXT,
+    event_type TEXT NOT NULL,
+    subject_id TEXT,
+    payload JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_events_tick ON events (tick);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events (event_type);
+CREATE INDEX IF NOT EXISTS idx_events_subject ON events (subject_id);
+CREATE INDEX IF NOT EXISTS idx_events_payload ON events USING GIN (payload);
+
+-- Table 2: tick_events
+CREATE TABLE IF NOT EXISTS tick_events (
+    log_id TEXT PRIMARY KEY,
+    tick INTEGER NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    correlation_id TEXT,
+    event_type TEXT NOT NULL,
+    subject_id TEXT,
+    payload JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_tick_events_tick ON tick_events (tick);
+CREATE INDEX IF NOT EXISTS idx_tick_events_subject ON tick_events (subject_id);
+CREATE INDEX IF NOT EXISTS idx_tick_events_payload ON tick_events USING GIN (payload);
+
+-- Table 3: node_state_history
+CREATE TABLE IF NOT EXISTS node_state_history (
+    log_id TEXT PRIMARY KEY,
+    tick INTEGER NOT NULL,
+    node_id TEXT NOT NULL,
+    is_classicalized BOOLEAN,
+    coherence REAL,
+    decoherence REAL,
+    frequency REAL,
+    payload JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_node_state_tick_node ON node_state_history (tick, node_id);
+CREATE INDEX IF NOT EXISTS idx_node_state_payload ON node_state_history USING GIN (payload);
+
+-- Table 4: bridge_state_history
+CREATE TABLE IF NOT EXISTS bridge_state_history (
+    log_id TEXT PRIMARY KEY,
+    tick INTEGER NOT NULL,
+    bridge_id TEXT NOT NULL,
+    strength REAL,
+    trust_score REAL,
+    status TEXT,
+    payload JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_bridge_state_tick_bridge ON bridge_state_history (tick, bridge_id);
+CREATE INDEX IF NOT EXISTS idx_bridge_state_payload ON bridge_state_history USING GIN (payload);
+
+-- Table 5: system_state_history
+CREATE TABLE IF NOT EXISTS system_state_history (
+    log_id TEXT PRIMARY KEY,
+    tick INTEGER NOT NULL,
+    node_count INTEGER,
+    edge_count INTEGER,
+    avg_coherence REAL,
+    payload JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_system_state_tick ON system_state_history (tick);
+CREATE INDEX IF NOT EXISTS idx_system_state_payload ON system_state_history USING GIN (payload);
+
+-- Table 6: causal_analysis_results
+CREATE TABLE IF NOT EXISTS causal_analysis_results (
+    log_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    result_type TEXT NOT NULL,
+    payload JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_analysis_run_id ON causal_analysis_results (run_id);
+CREATE INDEX IF NOT EXISTS idx_analysis_payload ON causal_analysis_results USING GIN (payload);
+"""
+
+
+def initialize_database(config: dict[str, Any]) -> None:
+    """Create required PostgreSQL tables and indexes if they do not exist.
+
+    Parameters
+    ----------
+    config:
+        Mapping containing connection parameters such as ``host``, ``port``,
+        ``user``, ``password`` and ``dbname``.
+    """
+
+    conn = None
+    try:
+        conn = psycopg2.connect(**config)
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_SQL)
+    except Exception as exc:  # pragma: no cover - networked operation
+        raise RuntimeError("Failed to initialize database") from exc
+    finally:
+        if conn is not None:
+            conn.close()

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -19,6 +19,14 @@
   "total_max_concurrent_firings": 0,
   "max_concurrent_firings_per_cluster": 0,
   "edge_weight_range": [1.0, 1.0],
+  "database": {
+    "type": "postgres",
+    "host": "localhost",
+    "port": 5432,
+    "user": "sim_user",
+    "password": "secret_password",
+    "dbname": "cwt_simulation"
+  },
   "log_files": {
     "boundary_interaction_log.json": true,
     "bridge_decay_log.json": true,

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -10,7 +10,7 @@ import os
 import time
 from typing import Any
 
-from .config import Config
+from .config import Config, load_config
 
 
 def _add_config_args(
@@ -64,6 +64,11 @@ def main() -> None:
         action="store_true",
         help="Run simulation without launching the GUI",
     )
+    initial.add_argument(
+        "--init-db",
+        action="store_true",
+        help="Initialize PostgreSQL schema and exit.",
+    )
     known, remaining = initial.parse_known_args()
 
     config_data: dict[str, Any] = {}
@@ -79,6 +84,13 @@ def main() -> None:
     args = parser.parse_args()
 
     _apply_overrides(args, config_data)
+
+    if args.init_db:
+        from .database import initialize_database
+
+        load_config(args.config)
+        initialize_database(Config.database)
+        return
 
     if args.no_gui:
         from .engine import tick_engine

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ python -m Causal_Web.main --no-gui --max_ticks 20
 Only keys matching attributes on `Causal_Web.config.Config` are applied. Nested
 dictionaries merge with the existing values.
 
+To set up a PostgreSQL database using the credentials in the configuration file,
+invoke the module with the `--init-db` flag. The application will create the
+required tables and then exit without starting the simulation.
+
 The configuration now includes a `tick_threshold` option controlling how many
 ticks a node must receive in a single timestep before it can fire. This value
 defaults to `1` and can be overridden via CLI or the Parameters window in the


### PR DESCRIPTION
## Summary
- add new database module with schema initialization
- extend config with database settings and helper function
- update config.json sample to include database credentials
- expose `--init-db` CLI flag in `main.py`
- document database initialization in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bf9b4d4d88325bd28396f17185aa1