### PR TITLE
Fix max tick override

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -750,10 +750,13 @@ def simulation_loop():
                 running = Config.is_running
                 Config.current_tick = global_tick
                 rate = Config.tick_rate
+                # ``allow_tick_override`` enables the ``max_ticks`` setting to
+                # control runtime duration. When disabled a fixed ``tick_limit``
+                # acts as the ceiling.
                 limit = (
-                    Config.tick_limit
+                    Config.max_ticks
                     if Config.allow_tick_override
-                    else Config.max_ticks
+                    else Config.tick_limit
                 )
             if not running:
                 time.sleep(0.1)

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -99,7 +99,10 @@ def main() -> None:
         with Config.state_lock:
             Config.is_running = True
         tick_engine.simulation_loop()
-        limit = Config.tick_limit if Config.allow_tick_override else Config.max_ticks
+        # ``allow_tick_override`` lets command line flags override the default
+        # ``max_ticks`` setting. When disabled we fall back to ``tick_limit`` as
+        # a hard upper bound.
+        limit = Config.max_ticks if Config.allow_tick_override else Config.tick_limit
         try:
             while True:
                 with Config.state_lock:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ simulation headless for 20 ticks you can use:
 python -m Causal_Web.main --no-gui --max_ticks 20
 ```
 
+The `max_ticks` value takes effect when `allow_tick_override` is enabled in
+the configuration (the default behaviour).
+
 Only keys matching attributes on `Causal_Web.config.Config` are applied. Nested
 dictionaries merge with the existing values.
 


### PR DESCRIPTION
## Summary
- ensure max_ticks is used when overrides are allowed
- document max_ticks override behaviour in README

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687bfb2a960083259db713319c03efbf