### PR TITLE
Implement graph save/load and run integration

### DIFF
--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -1,8 +1,10 @@
 import os
 import dearpygui.dearpygui as dpg
 from .canvas import GraphCanvas
-from .state import get_active_file, get_selected_node
+from .state import get_active_file, get_selected_node, get_graph
 from . import connection_tool
+from .toolbar import add_toolbar
+from ..graph.io import save_graph
 from ..config import Config
 from ..engine.tick_engine import (
     simulation_loop,
@@ -115,6 +117,11 @@ def _add_param_controls(data: dict, prefix: str = "") -> None:
 
 
 def start_sim_callback():
+    path = get_active_file() or Config.input_path("graph.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    save_graph(path, get_graph())
+    Config.new_run()
+    build_graph()
     with Config.state_lock:
         if Config.is_running:
             return
@@ -323,6 +330,7 @@ def dashboard():
         _add_param_controls(config_data)
 
     with dpg.window(label="Graph Editor", width=200, height=150, pos=(610, 120)):
+        add_toolbar()
         dpg.add_button(
             label="Add Connection",
             callback=connection_tool.start_add_connection,

--- a/Causal_Web/gui/toolbar.py
+++ b/Causal_Web/gui/toolbar.py
@@ -1,0 +1,72 @@
+import os
+import dearpygui.dearpygui as dpg
+
+from ..graph.io import load_graph, save_graph
+from .state import get_graph, set_graph, set_active_file
+from ..config import Config
+
+_last_directory = Config.input_dir
+
+
+def _load_dialog_callback(sender, app_data):
+    global _last_directory
+    path = app_data["file_path_name"]
+    if not path:
+        return
+    _last_directory = os.path.dirname(path)
+    try:
+        graph = load_graph(path)
+    except Exception as exc:
+        print(f"Failed to load graph: {exc}")
+        return
+    set_graph(graph)
+    set_active_file(path)
+
+
+def _save_dialog_callback(sender, app_data):
+    global _last_directory
+    path = app_data["file_path_name"]
+    if not path:
+        return
+    _last_directory = os.path.dirname(path)
+    try:
+        save_graph(path, get_graph())
+    except Exception as exc:
+        print(f"Failed to save graph: {exc}")
+        return
+    set_active_file(path)
+
+
+def add_toolbar() -> None:
+    """Create toolbar buttons for load/save/new graph actions."""
+    with dpg.group(horizontal=True, tag="graph_toolbar"):
+        dpg.add_button(
+            label="Load", callback=lambda: dpg.show_item("graph_load_dialog")
+        )
+        dpg.add_button(
+            label="Save", callback=lambda: dpg.show_item("graph_save_dialog")
+        )
+        dpg.add_button(label="New", callback=lambda: (_new_graph(),))
+
+    dpg.add_file_dialog(
+        directory_selector=False,
+        show=False,
+        callback=_load_dialog_callback,
+        tag="graph_load_dialog",
+        default_path=_last_directory,
+    )
+    dpg.add_file_dialog(
+        directory_selector=False,
+        show=False,
+        callback=_save_dialog_callback,
+        tag="graph_save_dialog",
+        default_filename="graph.json",
+        default_path=_last_directory,
+    )
+
+
+def _new_graph():
+    from ..graph.io import new_graph
+
+    set_graph(new_graph(True))
+    set_active_file(None)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ python -m Causal_Web.main --no-gui   # headless run
 
 Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
 You can now load, save or start a new graph using the **File** menu in the dashboard.
+When you press **Start Simulation** the current graph is written back to
+`input/graph.json`, a new run directory is created via `Config.new_run()` and
+the graph file is copied into the run's `input/` folder. This preserves the
+exact input used for each run.
 These actions operate on the `graph.json` format and update the shared in-memory model.
 The dashboard also includes a **Graph View** tab which renders the loaded graph and displays
 basic information for the currently selected node. The new **Graph Editor** window

--- a/tests/test_run_integration.py
+++ b/tests/test_run_integration.py
@@ -1,0 +1,25 @@
+import os
+from Causal_Web.config import Config
+from Causal_Web.graph.io import save_graph, load_graph
+from Causal_Web.graph.model import GraphModel
+
+
+def test_new_run_copies_graph(tmp_path, monkeypatch):
+    input_dir = tmp_path / "input"
+    runs_dir = tmp_path / "runs"
+    input_dir.mkdir()
+    runs_dir.mkdir()
+    monkeypatch.setattr(Config, "input_dir", str(input_dir))
+    monkeypatch.setattr(Config, "runs_dir", str(runs_dir))
+    monkeypatch.setattr(Config, "config_file", str(input_dir / "config.json"))
+
+    graph = GraphModel.blank(True)
+    graph_path = input_dir / "graph.json"
+    save_graph(str(graph_path), graph)
+    (input_dir / "config.json").write_text("{}")
+
+    run_dir = Config.new_run("test")
+    copied = os.path.join(run_dir, "input", "graph.json")
+    assert os.path.exists(copied)
+    loaded = load_graph(copied)
+    assert loaded.nodes


### PR DESCRIPTION
## Summary
- add GUI toolbar with Load/Save/New actions
- persist graph on simulation start and create run directory
- document workflow linking run directories
- test that `Config.new_run()` copies the current graph

## Testing
- `black Causal_Web tests/test_run_integration.py`
- `python -m compileall Causal_Web`
- `pip install numpy dearpygui`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e509d4b2c83258e0435846307fd68