### PR TITLE
Fix graph editor

### DIFF
--- a/Causal_Web/graph/model.py
+++ b/Causal_Web/graph/model.py
@@ -61,6 +61,30 @@ class GraphModel:
             return None
         return node.get("x", 0.0), node.get("y", 0.0)
 
+    def add_node(
+        self,
+        node_id: str,
+        *,
+        x: float = 0.0,
+        y: float = 0.0,
+        frequency: float = 1.0,
+        refractory_period: float = 2.0,
+        base_threshold: float = 0.5,
+    ) -> None:
+        """Insert a new node into the model."""
+
+        self.nodes[node_id] = {
+            "x": x,
+            "y": y,
+            "frequency": frequency,
+            "refractory_period": refractory_period,
+            "base_threshold": base_threshold,
+            "phase": 0.0,
+            "origin_type": "seed",
+            "generation_tick": 0,
+            "parent_ids": [],
+        }
+
     def get_edges(self) -> List[Dict[str, Any]]:
         """Return a list of edges in the graph."""
         return self.edges

--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ the graph file is copied into the run's `input/` folder. This preserves the
 exact input used for each run.
 These actions operate on the `graph.json` format and update the shared in-memory model.
 The dashboard also includes a **Graph View** tab which renders the loaded graph and displays
-basic information for the currently selected node. The new **Graph Editor** window
-provides an **Add Connection** tool for creating or editing directed edges or bridges.
+basic information for the currently selected node. The **Graph Editor** window
+now includes **Add Node** and **Add Connection** tools for building the graph.
+Nodes can be repositioned directly in the **Graph View** by dragging them with
+the mouse.
 
 ### Analysing the output
 


### PR DESCRIPTION
## Summary
- add a GraphModel.add_node helper
- allow dragging nodes on the GraphCanvas
- load graph into editor and add button for inserting nodes
- document graph editor interaction in README

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy dearpygui`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e546579fc832586d55e9d3c1ee609