### PR TITLE
Add command stack and layout helpers

### DIFF
--- a/Causal_Web/gui/canvas.py
+++ b/Causal_Web/gui/canvas.py
@@ -15,6 +15,9 @@ from .state import (
     get_selected_node,
 )
 from . import connection_tool
+from .command_stack import CommandStack
+
+_commands = CommandStack()
 
 
 @dataclass
@@ -119,3 +122,18 @@ class GraphCanvas:
                 node["y"] = y
         else:
             self.dragging_node = None
+
+    def auto_layout(self) -> None:
+        """Apply a force-directed layout to the current graph."""
+
+        graph = get_graph()
+        graph.apply_spring_layout()
+        self.redraw()
+
+    def undo(self) -> None:
+        _commands.undo()
+        self.redraw()
+
+    def redo(self) -> None:
+        _commands.redo()
+        self.redraw()

--- a/Causal_Web/gui/command_stack.py
+++ b/Causal_Web/gui/command_stack.py
@@ -1,0 +1,64 @@
+"""Undo/redo command stack utilities for the GUI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+class Command:
+    """Base class for actions that can be undone and redone."""
+
+    def execute(self) -> None:  # pragma: no cover - interface
+        """Apply the command."""
+
+    def undo(self) -> None:  # pragma: no cover - interface
+        """Reverse the command."""
+
+
+@dataclass
+class CommandStack:
+    """Maintain undo and redo stacks for commands."""
+
+    undo_stack: List[Command] = field(default_factory=list)
+    redo_stack: List[Command] = field(default_factory=list)
+
+    def do(self, command: Command) -> None:
+        """Execute ``command`` and push it onto the undo stack."""
+
+        command.execute()
+        self.undo_stack.append(command)
+        self.redo_stack.clear()
+
+    def undo(self) -> None:
+        """Undo the most recent command if any."""
+
+        if not self.undo_stack:
+            return
+        cmd = self.undo_stack.pop()
+        cmd.undo()
+        self.redo_stack.append(cmd)
+
+    def redo(self) -> None:
+        """Redo the most recently undone command if any."""
+
+        if not self.redo_stack:
+            return
+        cmd = self.redo_stack.pop()
+        cmd.execute()
+        self.undo_stack.append(cmd)
+
+
+@dataclass
+class AddNodeCommand(Command):
+    """Command that inserts a new node into a :class:`GraphModel`."""
+
+    model: "GraphModel"
+    node_id: str
+    kwargs: dict
+
+    def execute(self) -> None:
+        self.model.add_node(self.node_id, **self.kwargs)
+
+    def undo(self) -> None:
+        self.model.nodes.pop(self.node_id, None)

--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -11,6 +11,8 @@ from .state import (
 )
 from . import connection_tool
 from .toolbar import add_toolbar
+from .command_stack import AddNodeCommand
+from .canvas import _commands
 from ..graph.io import save_graph, load_graph
 from ..config import Config
 from ..engine.tick_engine import (
@@ -129,7 +131,8 @@ def add_node_callback() -> None:
     idx = 1
     while f"N{idx}" in model.nodes:
         idx += 1
-    model.add_node(f"N{idx}", x=50.0 * idx, y=50.0 * idx)
+    cmd = AddNodeCommand(model, f"N{idx}", {"x": 50.0 * idx, "y": 50.0 * idx})
+    _commands.do(cmd)
     set_selected_node(f"N{idx}")
     if canvas is not None:
         canvas.redraw()

--- a/Causal_Web/gui/toolbar.py
+++ b/Causal_Web/gui/toolbar.py
@@ -1,11 +1,18 @@
 import os
 import dearpygui.dearpygui as dpg
 
+from .canvas import GraphCanvas
 from ..graph.io import load_graph, save_graph
 from .state import get_graph, set_graph, set_active_file
 from ..config import Config
 
 _last_directory = Config.input_dir
+
+
+def _get_canvas() -> GraphCanvas | None:
+    if dpg.does_item_exist("graph_canvas_drawlist"):
+        return dpg.get_item_user_data("graph_canvas_drawlist")
+    return None
 
 
 def _load_dialog_callback(sender, app_data):
@@ -47,6 +54,9 @@ def add_toolbar() -> None:
             label="Save", callback=lambda: dpg.show_item("graph_save_dialog")
         )
         dpg.add_button(label="New", callback=lambda: (_new_graph(),))
+        dpg.add_button(label="Auto Layout", callback=_auto_layout)
+        dpg.add_button(label="Undo", callback=_undo)
+        dpg.add_button(label="Redo", callback=_redo)
 
     dpg.add_file_dialog(
         directory_selector=False,
@@ -70,3 +80,21 @@ def _new_graph():
 
     set_graph(new_graph(True))
     set_active_file(None)
+
+
+def _auto_layout():
+    canvas = _get_canvas()
+    if canvas is not None:
+        canvas.auto_layout()
+
+
+def _undo():
+    canvas = _get_canvas()
+    if canvas is not None:
+        canvas.undo()
+
+
+def _redo():
+    canvas = _get_canvas()
+    if canvas is not None:
+        canvas.redo()

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project contains a small simulation engine and GUI for experimenting with c
 
 The engine models a directed network of nodes. Each node maintains its own oscillator phase and can emit "ticks" that travel along edges with delay and attenuation. Nodes accumulate incoming phases and fire when they pass a threshold, scheduling more ticks. Bridges create additional links whose strength can change over time. Observers watch the network and attempt to infer hidden state.
 
+The graph editor supports undo/redo operations, an automatic spring layout based on ``networkx`` and validation to prevent duplicate or self-loop connections.
+
 Key modules include:
 
 - **`engine/graph.py`** – container for nodes, edges and bridges. Graphs can be loaded from or written to JSON files.

--- a/tests/test_graph_model_connections.py
+++ b/tests/test_graph_model_connections.py
@@ -1,4 +1,5 @@
 from Causal_Web.graph.model import GraphModel
+import pytest
 
 
 def _sample_nodes(model: GraphModel) -> None:
@@ -13,6 +14,29 @@ def test_add_edge():
     assert model.edges[0]["from"] == "A"
     assert model.edges[0]["to"] == "B"
     assert model.edges[0]["delay"] == 2
+
+
+def test_no_self_loop():
+    model = GraphModel.blank()
+    _sample_nodes(model)
+    with pytest.raises(ValueError):
+        model.add_connection("A", "A")
+
+
+def test_duplicate_edge_disallowed():
+    model = GraphModel.blank()
+    _sample_nodes(model)
+    model.add_connection("A", "B")
+    with pytest.raises(ValueError):
+        model.add_connection("A", "B")
+
+
+def test_apply_spring_layout():
+    model = GraphModel.blank()
+    _sample_nodes(model)
+    model.add_connection("A", "B")
+    model.apply_spring_layout()
+    assert "x" in model.nodes["A"]
 
 
 def test_add_bridge_and_edit():


### PR DESCRIPTION
## Summary
- add undo/redo infrastructure and node insertion command
- validate new edges for duplicates and self-loops
- expose auto-layout and undo/redo actions via toolbar and canvas
- update README with editor improvements
- test connection validation and layout helpers

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy`
- `pip install dearpygui`
- `pip install pydantic`
- `pip install networkx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5bc85bd8832596c0b361dbca13ed