### PR TITLE
Fix dragging detection in graph canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ now includes **Add Node** and **Add Connection** tools for building the graph.
 Nodes can be repositioned directly in the **Graph View** by dragging them with
 the mouse.
 Node interaction now correctly accounts for the window position so clicks and
-drags work as expected.
+drags work as expected. Dragging begins on mouse press, making node movement
+smooth even when the button is held down before moving.
 For troubleshooting, the canvas now prints debug messages to the console whenever
 nodes are clicked or dragged.
 


### PR DESCRIPTION
## Summary
- detect mouse press on graph canvas using a `mouse_down` handler
- start node dragging on press and handle release separately
- clarify in README that dragging starts on mouse press

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6478f1988325be51956a1126028b