### PR TITLE
Fix canvas mouse handler parent

### DIFF
--- a/Causal_Web/gui/canvas.py
+++ b/Causal_Web/gui/canvas.py
@@ -48,10 +48,12 @@ class GraphCanvas:
             dpg.add_mouse_down_handler(
                 button=dpg.mvMouseButton_Left,
                 callback=self._handle_mouse_down,
+                parent=h,
             )
             dpg.add_mouse_release_handler(
                 button=dpg.mvMouseButton_Left,
                 callback=self._handle_click,
+                parent=h,
             )
         dpg.bind_item_handler_registry(self.drawlist_tag, h)
 


### PR DESCRIPTION
## Summary
- hook mouse handlers onto item handler registry to avoid DPG exception

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687e6b6176848325b37becd77b1cf509