### PR TITLE
Fix graph node dragging after resize

### DIFF
--- a/Causal_Web/gui/canvas.py
+++ b/Causal_Web/gui/canvas.py
@@ -113,12 +113,11 @@ class GraphCanvas:
 
     def _handle_mouse_down(self, sender, app_data):
         """Begin dragging the node under the cursor if any."""
-        mouse = dpg.get_mouse_pos(local=False)
-        origin = dpg.get_item_rect_min(self.drawlist_tag)
+        mouse = dpg.get_drawing_mouse_pos()
         for node_id, item in self.node_items.items():
             center = dpg.get_item_configuration(item)["center"]
-            dx = mouse[0] - (origin[0] + center[0])
-            dy = mouse[1] - (origin[1] + center[1])
+            dx = mouse[0] - center[0]
+            dy = mouse[1] - center[1]
             if dx * dx + dy * dy <= 20 * 20:
                 print(f"[GraphCanvas] Selected node {node_id}")
                 set_selected_node(node_id)
@@ -128,13 +127,12 @@ class GraphCanvas:
 
     def _handle_click(self, sender, app_data):
         """Handle mouse release events over nodes."""
-        mouse = dpg.get_mouse_pos(local=False)
-        origin = dpg.get_item_rect_min(self.drawlist_tag)
+        mouse = dpg.get_drawing_mouse_pos()
         print(f"[GraphCanvas] Click at {mouse}")
         for node_id, item in self.node_items.items():
             center = dpg.get_item_configuration(item)["center"]
-            dx = mouse[0] - (origin[0] + center[0])
-            dy = mouse[1] - (origin[1] + center[1])
+            dx = mouse[0] - center[0]
+            dy = mouse[1] - center[1]
             if dx * dx + dy * dy <= 20 * 20:
                 if connection_tool.handle_node_click(node_id):
                     print(f"[GraphCanvas] Connection tool handled click on {node_id}")
@@ -148,10 +146,9 @@ class GraphCanvas:
             return
         if dpg.is_mouse_button_down(dpg.mvMouseButton_Left):
             graph = get_graph()
-            mouse = dpg.get_mouse_pos(local=False)
-            origin = dpg.get_item_rect_min(self.drawlist_tag)
-            x = mouse[0] - origin[0]
-            y = mouse[1] - origin[1]
+            mouse = dpg.get_drawing_mouse_pos()
+            x = mouse[0]
+            y = mouse[1]
             node = graph.nodes.get(self.dragging_node)
             if node is not None:
                 node["x"] = x

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ drags work as expected. Dragging begins on mouse press, making node movement
 smooth even when the button is held down before moving.
 A startup crash caused by invalid handler parents has been fixed by registering
 mouse events through a global handler registry.
+Node dragging now remains responsive after resizing the window thanks to using
+`dpg.get_drawing_mouse_pos()` to obtain the drawing-relative mouse position.
 For troubleshooting, the canvas now prints debug messages to the console whenever
 nodes are clicked or dragged.
 


### PR DESCRIPTION
## Summary
- use `dpg.get_drawing_mouse_pos()` to compute mouse position relative to the canvas
- document Dear PyGui API usage in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e6f12fdbc8325b633633362f6ccba