### PR TITLE
Fix connection modal closing

### DIFF
--- a/Causal_Web/gui/connection_tool.py
+++ b/Causal_Web/gui/connection_tool.py
@@ -96,7 +96,7 @@ def save_connection(sender, app_data, user_data):
         )
         idx = len(graph.edges) - 1 if type_key == "edge" else len(graph.bridges) - 1
         set_selected_connection((type_key, idx))
-    dpg.hide_item("connection_properties")
+    dpg.configure_item("connection_properties", show=False)
 
 
 def delete_connection(sender, app_data, user_data):
@@ -106,4 +106,4 @@ def delete_connection(sender, app_data, user_data):
     etype, idx = _edit
     graph.remove_connection(idx, etype)
     set_selected_connection(None)
-    dpg.hide_item("connection_properties")
+    dpg.configure_item("connection_properties", show=False)


### PR DESCRIPTION
## Summary
- close connection dialog with `configure_item(show=False)`
- ensure graph editor remains interactive after adding or deleting links

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e7b4113808325b64504af1c9b9526