### PR TITLE
Fix GUI freeze when resizing windows

### DIFF
--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -267,7 +267,7 @@ def gui_update_callback():
         file = get_active_file() or "<unsaved>"
         selected = get_selected_node() or "none"
         dpg.set_value("graph_status_bar", f"File: {file}  Selected: {selected}")
-    next_frame = dpg.get_frame_count() + 1
+    next_frame = dpg.get_frame_count()
     dpg.set_frame_callback(next_frame, gui_update_callback)
 
 
@@ -275,8 +275,11 @@ def graph_resize_callback(sender, app_data, user_data):
     """Resize graph canvas to match its window."""
     width = dpg.get_item_width("graph_window") - 10
     height = dpg.get_item_height("graph_window") - 40
-    dpg.configure_item("graph_child", width=width, height=height)
-    dpg.configure_item("graph_drawlist", width=width, height=height)
+    child_width = dpg.get_item_width("graph_child")
+    child_height = dpg.get_item_height("graph_child")
+    if width != child_width or height != child_height:
+        dpg.configure_item("graph_child", width=width, height=height)
+        dpg.configure_item("graph_drawlist", width=width, height=height)
 
 
 def dashboard():

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ python -m Causal_Web.main            # with GUI
 python -m Causal_Web.main --no-gui   # headless run
 ```
 
-Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
+Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
 You can now load, save or start a new graph using the **File** menu in the dashboard.
 When you press **Start Simulation** the current graph is written back to
 `input/graph.json`, a new run directory is created via `Config.new_run()` and


### PR DESCRIPTION
## Summary
- prevent freeze by avoiding missed frame callbacks in gui update
- resize callbacks now skip redundant updates to avoid recursion
- document improved resizing behaviour

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7dc0bd088325b6fae63eef8216ba