### PR TITLE
Fix Graph View resize freeze

### DIFF
--- a/Causal_Web/gui/canvas.py
+++ b/Causal_Web/gui/canvas.py
@@ -60,9 +60,9 @@ class GraphCanvas:
         with dpg.item_handler_registry(tag=f"{self.window_tag}_handlers") as wh:
             dpg.add_item_resize_handler(callback=self._resize_drawlist)
         dpg.bind_item_handler_registry(self.window_tag, f"{self.window_tag}_handlers")
-        self._resize_drawlist(None, None)
+        self._resize_drawlist(None, None, None)
 
-    def _resize_drawlist(self, sender, app_data) -> None:
+    def _resize_drawlist(self, sender, app_data, user_data) -> None:
         """Adjust drawlist dimensions to match the window size."""
         width = dpg.get_item_width(self.window_tag)
         height = dpg.get_item_height(self.window_tag) - 25

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Node dragging now remains responsive after resizing the window thanks to using
 For troubleshooting, the canvas now prints debug messages to the console whenever
 nodes are clicked or dragged.
 The Graph View window now resizes correctly, keeping graph elements interactive.
+A resize handler bug that halted GUI updates after resizing has been fixed.
 
 ### Analysing the output
 


### PR DESCRIPTION
## Summary
- avoid TypeError in GraphCanvas resize callback
- document Graph View resize bug fix

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e81cfa6d48325b680a9cc6c774154