### PR TITLE
Fix simulation start in graph panel

### DIFF
--- a/Causal_Web/gui/graph_panel.py
+++ b/Causal_Web/gui/graph_panel.py
@@ -128,8 +128,13 @@ def gui_loop():
 
 
 def start_sim():
+    """Launch the simulation thread if it is not already running."""
+
     with Config.state_lock:
         if Config.is_running:
             return
         Config.is_running = True
+
+    build_graph()
+    Config.new_run()
     simulation_loop()


### PR DESCRIPTION
## Summary
- ensure the simple graph panel loads the graph and creates a run when starting
- guard start_sim with a docstring

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest dearpygui`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e832947f0832581cb5ea6aea30f50