### PR TITLE
Switch GUI to event-driven updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ For troubleshooting, the canvas now prints debug messages to the console wheneve
 nodes are clicked or dragged.
 The Graph View window now resizes correctly, keeping graph elements interactive.
 A resize handler bug that halted GUI updates after resizing has been fixed.
+Rendering is now event driven so the canvas only updates when the graph changes, greatly reducing idle CPU usage.
 
 ### Analysing the output
 


### PR DESCRIPTION
## Summary
- remove frame-based drawing loop
- centralize canvas rendering in `GraphCanvas`
- redraw canvas only after graph edits and when dragging
- mention event-driven canvas in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8b3870fc83259d5b977bee1ef863