### PR TITLE
Fix GraphCanvas tag mismatch

### DIFF
--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -303,7 +303,7 @@ def dashboard():
     dpg.bind_item_handler_registry("graph_window", "graph_handlers")
 
     global canvas
-    canvas = GraphCanvas()
+    canvas = GraphCanvas(drawlist_tag="graph_drawlist", window_tag="graph_window")
 
     with dpg.window(
         label="Connection Properties",


### PR DESCRIPTION
## Summary
- make GraphCanvas use existing drawlist and window tags

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ea10de9908325a9b2373044cdd060