### PR TITLE
Fix canvas handler types

### DIFF
--- a/Causal_Web/gui/canvas.py
+++ b/Causal_Web/gui/canvas.py
@@ -41,7 +41,7 @@ class GraphCanvas:
     dragging_node: Optional[str] = field(default=None, init=False)
 
     def __post_init__(self) -> None:
-        """Bind event handlers to the provided drawlist."""
+        """Bind item-specific event handlers to the provided drawlist."""
         self.node_items: Dict[str, int] = {}
         self.label_items: Dict[str, int] = {}
         self.edge_items: Dict[int, int] = {}
@@ -51,10 +51,10 @@ class GraphCanvas:
 
         # attach handlers that only fire when the mouse is over the canvas
         with dpg.item_handler_registry(tag=f"{self.drawlist_tag}_handlers") as h:
-            dpg.add_mouse_click_handler(
+            dpg.add_item_clicked_handler(
                 button=dpg.mvMouseButton_Left, callback=self._handle_click
             )
-            dpg.add_mouse_drag_handler(
+            dpg.add_item_drag_handler(
                 button=dpg.mvMouseButton_Left, callback=self._update_drag
             )
 


### PR DESCRIPTION
## Summary
- fix item handlers on GraphCanvas by using item-level functions
- document updated usage in `__post_init__`

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fa97ef6ac8325a2704ee85460890f