### PR TITLE
Fix DearPyGui drag handler

### DIFF
--- a/Causal_Web/gui/canvas.py
+++ b/Causal_Web/gui/canvas.py
@@ -41,7 +41,12 @@ class GraphCanvas:
     dragging_node: Optional[str] = field(default=None, init=False)
 
     def __post_init__(self) -> None:
-        """Bind item-specific event handlers to the provided drawlist."""
+        """Bind mouse event handlers to the provided drawlist.
+
+        The handlers are attached via an :func:`dearpygui.add_mouse_drag_handler`
+        and :func:`dearpygui.add_mouse_click_handler` within an item handler
+        registry so callbacks only fire when the cursor is over the canvas.
+        """
         self.node_items: Dict[str, int] = {}
         self.label_items: Dict[str, int] = {}
         self.edge_items: Dict[int, int] = {}
@@ -51,10 +56,10 @@ class GraphCanvas:
 
         # attach handlers that only fire when the mouse is over the canvas
         with dpg.item_handler_registry(tag=f"{self.drawlist_tag}_handlers") as h:
-            dpg.add_item_clicked_handler(
+            dpg.add_mouse_click_handler(
                 button=dpg.mvMouseButton_Left, callback=self._handle_click
             )
-            dpg.add_item_drag_handler(
+            dpg.add_mouse_drag_handler(
                 button=dpg.mvMouseButton_Left, callback=self._update_drag
             )
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Example:
 
 ## Running the simulation
 
-1. Install the dependencies (`dearpygui` is required for the GUI).
+1. Install the dependencies (`dearpygui==2.1.0` is required for the GUI).
    An X11-compatible display is needed to create the window. If running on a
    headless server consider using a virtual frame buffer such as Xvfb.
    The dashboard automatically designates the *Causal Graph* window as the


### PR DESCRIPTION
## Summary
- update GraphCanvas to use `add_mouse_*_handler` calls for DearPyGui 2.1
- document dearpygui 2.1.0 requirement

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fac04a29c8325ab05f43da23a381e