### PR TITLE
Enable starting simulation from PySide6 GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Example:
 
 ## Running the simulation
 
-1. Install the dependencies (`dearpygui==2.1.0` is required for the GUI).
+1. Install the dependencies (`pyside6` is required for the GUI).
    An X11-compatible display is needed to create the window. If running on a
    headless server consider using a virtual frame buffer such as Xvfb.
    The dashboard automatically designates the *Causal Graph* window as the


### PR DESCRIPTION
## Summary
- hook up tick rate slider and Start Simulation button in the PySide6 GUI
- call the engine to launch the simulation
- document PySide6 as the GUI dependency

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb758f578832588addd579d210698