### PR TITLE
Fix start simulation in PySide dashboard

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -25,7 +25,12 @@ from PySide6.QtWidgets import (
 from ..config import Config
 from ..graph.io import load_graph, save_graph, new_graph
 from ..graph.model import GraphModel
-from ..gui.state import get_graph, set_graph, set_active_file
+from ..gui.state import (
+    get_active_file,
+    get_graph,
+    set_graph,
+    set_active_file,
+)
 from ..engine import tick_engine
 
 


### PR DESCRIPTION
## Summary
- import get_active_file in `MainWindow`
- fix NameError when starting simulation

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fb8fa3d04832594d80fe670dd2530