### PR TITLE
Add command stack and connection tool

### DIFF
--- a/Causal_Web/command_stack.py
+++ b/Causal_Web/command_stack.py
@@ -1,0 +1,118 @@
+"""Undo/redo command stack utilities without GUI dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from .graph.model import GraphModel
+
+
+class Command:
+    """Base class for actions that can be undone and redone."""
+
+    def execute(self) -> None:  # pragma: no cover - interface
+        """Apply the command."""
+
+    def undo(self) -> None:  # pragma: no cover - interface
+        """Reverse the command."""
+
+
+@dataclass
+class CommandStack:
+    """Maintain undo and redo stacks for commands."""
+
+    undo_stack: List[Command] = field(default_factory=list)
+    redo_stack: List[Command] = field(default_factory=list)
+
+    def do(self, command: Command) -> None:
+        """Execute ``command`` and push it onto the undo stack."""
+
+        command.execute()
+        self.undo_stack.append(command)
+        self.redo_stack.clear()
+
+    def undo(self) -> None:
+        """Undo the most recent command if any."""
+
+        if not self.undo_stack:
+            return
+        cmd = self.undo_stack.pop()
+        cmd.undo()
+        self.redo_stack.append(cmd)
+
+    def redo(self) -> None:
+        """Redo the most recently undone command if any."""
+
+        if not self.redo_stack:
+            return
+        cmd = self.redo_stack.pop()
+        cmd.execute()
+        self.undo_stack.append(cmd)
+
+
+@dataclass
+class AddNodeCommand(Command):
+    """Command that inserts a new node into a :class:`GraphModel`."""
+
+    model: GraphModel
+    node_id: str
+    kwargs: dict
+
+    def execute(self) -> None:
+        self.model.add_node(self.node_id, **self.kwargs)
+
+    def undo(self) -> None:
+        self.model.nodes.pop(self.node_id, None)
+
+
+@dataclass
+class DeleteEdgeCommand(Command):
+    """Command that removes an edge from a :class:`GraphModel`."""
+
+    model: GraphModel
+    index: int
+    connection_type: str = "edge"
+    _removed: dict | None = None
+
+    def execute(self) -> None:
+        target_list = (
+            self.model.edges if self.connection_type == "edge" else self.model.bridges
+        )
+        if self.index < 0 or self.index >= len(target_list):
+            return
+        self._removed = target_list[self.index]
+        self.model.remove_connection(self.index, self.connection_type)
+
+    def undo(self) -> None:
+        if self._removed is None:
+            return
+        target_list = (
+            self.model.edges if self.connection_type == "edge" else self.model.bridges
+        )
+        target_list.insert(self.index, self._removed)
+
+
+@dataclass
+class MoveNodeCommand(Command):
+    """Command that changes a node's ``(x, y)`` position."""
+
+    model: GraphModel
+    node_id: str
+    new_pos: Tuple[float, float]
+    _old_pos: Tuple[float, float] | None = None
+
+    def execute(self) -> None:
+        node = self.model.nodes.get(self.node_id)
+        if node is None:
+            return
+        self._old_pos = (node.get("x", 0.0), node.get("y", 0.0))
+        node["x"], node["y"] = self.new_pos
+
+    def undo(self) -> None:
+        if self._old_pos is None:
+            return
+        node = self.model.nodes.get(self.node_id)
+        if node is None:
+            return
+        node["x"], node["y"] = self._old_pos

--- a/Causal_Web/gui/canvas.py
+++ b/Causal_Web/gui/canvas.py
@@ -22,7 +22,7 @@ from .state import (
     get_selected_node,
 )
 from . import connection_tool
-from .command_stack import CommandStack
+from ..command_stack import CommandStack
 
 _commands = CommandStack()
 

--- a/Causal_Web/gui/command_stack.py
+++ b/Causal_Web/gui/command_stack.py
@@ -1,64 +1,17 @@
-"""Undo/redo command stack utilities for the GUI."""
+"""Compatibility wrapper importing command utilities."""
 
-from __future__ import annotations
+from ..command_stack import (
+    Command,
+    CommandStack,
+    AddNodeCommand,
+    DeleteEdgeCommand,
+    MoveNodeCommand,
+)
 
-from dataclasses import dataclass, field
-from typing import List
-
-
-class Command:
-    """Base class for actions that can be undone and redone."""
-
-    def execute(self) -> None:  # pragma: no cover - interface
-        """Apply the command."""
-
-    def undo(self) -> None:  # pragma: no cover - interface
-        """Reverse the command."""
-
-
-@dataclass
-class CommandStack:
-    """Maintain undo and redo stacks for commands."""
-
-    undo_stack: List[Command] = field(default_factory=list)
-    redo_stack: List[Command] = field(default_factory=list)
-
-    def do(self, command: Command) -> None:
-        """Execute ``command`` and push it onto the undo stack."""
-
-        command.execute()
-        self.undo_stack.append(command)
-        self.redo_stack.clear()
-
-    def undo(self) -> None:
-        """Undo the most recent command if any."""
-
-        if not self.undo_stack:
-            return
-        cmd = self.undo_stack.pop()
-        cmd.undo()
-        self.redo_stack.append(cmd)
-
-    def redo(self) -> None:
-        """Redo the most recently undone command if any."""
-
-        if not self.redo_stack:
-            return
-        cmd = self.redo_stack.pop()
-        cmd.execute()
-        self.undo_stack.append(cmd)
-
-
-@dataclass
-class AddNodeCommand(Command):
-    """Command that inserts a new node into a :class:`GraphModel`."""
-
-    model: "GraphModel"
-    node_id: str
-    kwargs: dict
-
-    def execute(self) -> None:
-        self.model.add_node(self.node_id, **self.kwargs)
-
-    def undo(self) -> None:
-        self.model.nodes.pop(self.node_id, None)
+__all__ = [
+    "Command",
+    "CommandStack",
+    "AddNodeCommand",
+    "DeleteEdgeCommand",
+    "MoveNodeCommand",
+]

--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -11,7 +11,7 @@ from .state import (
 )
 from . import connection_tool
 from .toolbar import add_toolbar
-from .command_stack import AddNodeCommand
+from ..command_stack import AddNodeCommand
 from .canvas import _commands
 from ..graph.io import save_graph, load_graph
 from ..config import Config

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction
+from PySide6.QtGui import QAction, QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QApplication,
     QDockWidget,
@@ -39,6 +39,11 @@ class MainWindow(QMainWindow):
         self.canvas = CanvasWidget(self)
         self.setCentralWidget(self.canvas)
         self.canvas.load_model(get_graph())
+
+        self._undo_shortcut = QShortcut(QKeySequence("Ctrl+Z"), self)
+        self._undo_shortcut.activated.connect(self.canvas.undo)
+        self._redo_shortcut = QShortcut(QKeySequence("Ctrl+Y"), self)
+        self._redo_shortcut.activated.connect(self.canvas.redo)
 
         self._create_menus()
         self._create_docks()

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This project contains a small simulation engine and GUI for experimenting with c
 
 The engine models a directed network of nodes. Each node maintains its own oscillator phase and can emit "ticks" that travel along edges with delay and attenuation. Nodes accumulate incoming phases and fire when they pass a threshold, scheduling more ticks. Bridges create additional links whose strength can change over time. Observers watch the network and attempt to infer hidden state.
 
-The graph editor supports undo/redo operations, an automatic spring layout based on ``networkx`` and validation to prevent duplicate or self-loop connections.
+The graph editor supports undo/redo operations via ``Ctrl+Z``/``Ctrl+Y``,
+allows connecting nodes by dragging between them, applies an automatic spring
+layout based on ``networkx`` and validates connections to prevent duplicates or
+self-loops.
 
 Key modules include:
 


### PR DESCRIPTION
## Summary
- move `command_stack` out of GUI package and extend with delete/move commands
- provide backward compat shim
- add undo/redo shortcuts and node connection drag support in PySide canvas
- document drag linking and keyboard shortcuts in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbefbe43c8325a6e075bebeff5cda