### PR TITLE
Refactor main window layout

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QMainWindow,
     QPushButton,
     QSlider,
+    QToolBar,
     QWidget,
 )
 
@@ -36,8 +37,11 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("CWT Simulation Dashboard")
         self.resize(800, 600)
 
+        self.setCentralWidget(QWidget())
         self.canvas = CanvasWidget(self)
-        self.setCentralWidget(self.canvas)
+        self.canvas_dock = QDockWidget("Graph View", self)
+        self.canvas_dock.setWidget(self.canvas)
+        self.addDockWidget(Qt.LeftDockWidgetArea, self.canvas_dock)
         self.canvas.load_model(get_graph())
 
         self._undo_shortcut = QShortcut(QKeySequence("Ctrl+Z"), self)
@@ -46,6 +50,7 @@ class MainWindow(QMainWindow):
         self._redo_shortcut.activated.connect(self.canvas.redo)
 
         self._create_menus()
+        self._create_toolbars()
         self._create_docks()
 
     # ---- UI setup ----
@@ -65,6 +70,40 @@ class MainWindow(QMainWindow):
         new_action = QAction("New", self)
         new_action.triggered.connect(self.new_graph)
         file_menu.addAction(new_action)
+
+    def _create_toolbars(self) -> None:
+        """Create a toolbar with graph actions."""
+
+        toolbar = QToolBar("Graph", self)
+        self.addToolBar(toolbar)
+
+        load_action = QAction("Load", self)
+        load_action.triggered.connect(self.load_graph)
+        toolbar.addAction(load_action)
+
+        save_action = QAction("Save", self)
+        save_action.triggered.connect(self.save_graph)
+        toolbar.addAction(save_action)
+
+        new_action = QAction("New", self)
+        new_action.triggered.connect(self.new_graph)
+        toolbar.addAction(new_action)
+
+        layout_action = QAction("Auto Layout", self)
+        layout_action.triggered.connect(self.canvas.auto_layout)
+        toolbar.addAction(layout_action)
+
+        undo_action = QAction("Undo", self)
+        undo_action.triggered.connect(self.canvas.undo)
+        toolbar.addAction(undo_action)
+
+        redo_action = QAction("Redo", self)
+        redo_action.triggered.connect(self.canvas.redo)
+        toolbar.addAction(redo_action)
+
+        connect_action = QAction("Connect", self)
+        connect_action.triggered.connect(self.canvas.enable_connection_mode)
+        toolbar.addAction(connect_action)
 
     def _create_docks(self) -> None:
         dock = QDockWidget("Control Panel", self)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Key modules include:
 - **`engine/observer.py`** – observers that infer hidden state from tick history.
 - **`engine/logger.py`** – centralized buffer that batches log writes to disk.
 - **`engine/tick.py`** – defines :class:`Tick` and the reusable object pool.
-- **`gui_pyside/main_window.py`** – PySide6 dashboard for interactive runs.
+- **`gui_pyside/main_window.py`** – PySide6 dashboard with a dockable canvas and
+  toolbar for interactive runs.
 - **`gui_pyside/canvas_widget.py`** – reusable ``QGraphicsView`` for graph rendering.
 - **`main.py`** – simple entry point that launches the dashboard.
 
@@ -171,6 +172,8 @@ python -m Causal_Web.main --no-gui   # headless run
 
 Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
 You can now load, save or start a new graph using the **File** menu in the dashboard.
+The graph view lives in a dock widget and a toolbar provides quick access to
+common actions like auto layout or connection mode.
 When you press **Start Simulation** the current graph is written back to
 `input/graph.json`, a new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the


### PR DESCRIPTION
## Summary
- modularize PySide dashboard
- create dockable CanvasWidget with toolbar actions
- document new dock behavior and toolbar in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687fc32e73308325aaf91039d305ff90