### PR TITLE
Fix auto layout in PySide GUI

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -222,3 +222,9 @@ class CanvasWidget(QGraphicsView):
     def redo(self) -> None:
         self.command_stack.redo()
         self.load_model(self.model)
+
+    def auto_layout(self) -> None:
+        """Apply a spring layout to ``self.model`` and refresh the scene."""
+
+        self.model.apply_spring_layout()
+        self.load_model(self.model)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ python -m Causal_Web.main --no-gui   # headless run
 Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
 You can now load, save or start a new graph using the **File** menu in the dashboard.
 The graph view lives in a dock widget and a toolbar provides quick access to
-common actions like auto layout or connection mode.
+common actions like auto layout or connection mode. The **Auto Layout** button
+now correctly arranges nodes using a spring layout.
 When you press **Start Simulation** the current graph is written back to
 `input/graph.json`, a new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the


### PR DESCRIPTION
## Summary
- implement `CanvasWidget.auto_layout` for PySide GUI
- document working auto layout button in README

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687fcbf7fa208325a2a81da1bb58ca7b