### PR TITLE
Add Qt toolbar builder with property panels

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -12,7 +12,6 @@ from PySide6.QtWidgets import (
     QMainWindow,
     QPushButton,
     QSlider,
-    QToolBar,
     QWidget,
 )
 
@@ -26,6 +25,8 @@ from ..gui.state import (
     set_active_file,
 )
 from .canvas_widget import CanvasWidget
+from .toolbar_builder import build_toolbar
+from ..command_stack import AddNodeCommand
 from ..engine import tick_engine
 
 
@@ -50,7 +51,7 @@ class MainWindow(QMainWindow):
         self._redo_shortcut.activated.connect(self.canvas.redo)
 
         self._create_menus()
-        self._create_toolbars()
+        build_toolbar(self)
         self._create_docks()
 
     # ---- UI setup ----
@@ -70,40 +71,6 @@ class MainWindow(QMainWindow):
         new_action = QAction("New", self)
         new_action.triggered.connect(self.new_graph)
         file_menu.addAction(new_action)
-
-    def _create_toolbars(self) -> None:
-        """Create a toolbar with graph actions."""
-
-        toolbar = QToolBar("Graph", self)
-        self.addToolBar(toolbar)
-
-        load_action = QAction("Load", self)
-        load_action.triggered.connect(self.load_graph)
-        toolbar.addAction(load_action)
-
-        save_action = QAction("Save", self)
-        save_action.triggered.connect(self.save_graph)
-        toolbar.addAction(save_action)
-
-        new_action = QAction("New", self)
-        new_action.triggered.connect(self.new_graph)
-        toolbar.addAction(new_action)
-
-        layout_action = QAction("Auto Layout", self)
-        layout_action.triggered.connect(self.canvas.auto_layout)
-        toolbar.addAction(layout_action)
-
-        undo_action = QAction("Undo", self)
-        undo_action.triggered.connect(self.canvas.undo)
-        toolbar.addAction(undo_action)
-
-        redo_action = QAction("Redo", self)
-        redo_action.triggered.connect(self.canvas.redo)
-        toolbar.addAction(redo_action)
-
-        connect_action = QAction("Connect", self)
-        connect_action.triggered.connect(self.canvas.enable_connection_mode)
-        toolbar.addAction(connect_action)
 
     def _create_docks(self) -> None:
         dock = QDockWidget("Control Panel", self)
@@ -179,6 +146,20 @@ class MainWindow(QMainWindow):
         set_graph(model)
         set_active_file(None)
         self.canvas.load_model(model)
+
+    def add_node(self) -> None:
+        """Insert a new node and refresh the canvas."""
+        model = get_graph()
+        idx = 1
+        while f"N{idx}" in model.nodes:
+            idx += 1
+        cmd = AddNodeCommand(model, f"N{idx}", {"x": 50.0 * idx, "y": 50.0 * idx})
+        self.canvas.command_stack.do(cmd)
+        self.canvas.load_model(model)
+
+    def start_add_connection(self) -> None:
+        """Enable interactive connection mode."""
+        self.canvas.enable_connection_mode()
 
 
 def launch() -> None:

--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -1,0 +1,178 @@
+"""Utility for constructing toolbars and property panels for the Qt GUI."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PySide6.QtCore import QObject, Qt, QEvent
+from PySide6.QtWidgets import (
+    QAction,
+    QComboBox,
+    QDockWidget,
+    QDoubleSpinBox,
+    QFormLayout,
+    QToolBar,
+    QWidget,
+)
+
+from ..gui.state import get_graph, set_selected_node
+
+
+class _FocusWatcher(QObject):
+    """Call a function when the watched widget loses focus."""
+
+    def __init__(self, callback):
+        super().__init__()
+        self.callback = callback
+
+    def eventFilter(self, obj, event):  # type: ignore[override]
+        if event.type() == QEvent.FocusOut:
+            self.callback()
+        return False
+
+
+class NodePanel(QDockWidget):
+    """Dock widget for editing node attributes."""
+
+    def __init__(self, main_window):
+        super().__init__("Node", main_window)
+        self.main_window = main_window
+        self.current: Optional[str] = None
+        widget = QWidget()
+        layout = QFormLayout(widget)
+        self.inputs = {}
+        for field in ["x", "y", "frequency", "refractory_period", "base_threshold"]:
+            spin = QDoubleSpinBox()
+            spin.setDecimals(3)
+            layout.addRow(field, spin)
+            self.inputs[field] = spin
+        widget.installEventFilter(_FocusWatcher(self.commit))
+        self.setWidget(widget)
+
+    def show_node(self, node_id: str) -> None:
+        model = get_graph()
+        data = model.nodes.get(node_id)
+        if data is None:
+            return
+        self.current = node_id
+        for key, spin in self.inputs.items():
+            spin.setValue(float(data.get(key, 0.0)))
+        self.show()
+
+    def commit(self) -> None:
+        if not self.current:
+            return
+        model = get_graph()
+        node = model.nodes.get(self.current)
+        if node is None:
+            return
+        for key, spin in self.inputs.items():
+            node[key] = float(spin.value())
+        self.main_window.canvas.load_model(model)
+        set_selected_node(self.current)
+        self.hide()
+        self.current = None
+
+
+class ConnectionPanel(QDockWidget):
+    """Dock widget for adding a connection between two nodes."""
+
+    def __init__(self, main_window):
+        super().__init__("Connection", main_window)
+        self.main_window = main_window
+        self.source: Optional[str] = None
+        self.target: Optional[str] = None
+        widget = QWidget()
+        layout = QFormLayout(widget)
+        self.type_combo = QComboBox()
+        self.type_combo.addItems(["Edge", "Bridge"])
+        self.delay_spin = QDoubleSpinBox()
+        self.delay_spin.setValue(1.0)
+        self.atten_spin = QDoubleSpinBox()
+        self.atten_spin.setValue(1.0)
+        layout.addRow("Type", self.type_combo)
+        layout.addRow("Delay", self.delay_spin)
+        layout.addRow("Attenuation", self.atten_spin)
+        widget.installEventFilter(_FocusWatcher(self.commit))
+        self.setWidget(widget)
+
+    def open_for(self, source: str, target: str) -> None:
+        self.source = source
+        self.target = target
+        self.type_combo.setCurrentIndex(0)
+        self.delay_spin.setValue(1.0)
+        self.atten_spin.setValue(1.0)
+        self.show()
+
+    def commit(self) -> None:
+        if not self.source or not self.target:
+            return
+        model = get_graph()
+        try:
+            model.add_connection(
+                self.source,
+                self.target,
+                delay=float(self.delay_spin.value()),
+                attenuation=float(self.atten_spin.value()),
+                connection_type=(
+                    "edge" if self.type_combo.currentText() == "Edge" else "bridge"
+                ),
+            )
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            print(f"Failed to add connection: {exc}")
+        else:
+            self.main_window.canvas.load_model(model)
+        self.hide()
+        self.source = self.target = None
+
+
+def build_toolbar(main_window) -> QToolBar:
+    """Create the graph toolbar and attach property panels."""
+
+    toolbar = QToolBar("Graph", main_window)
+    main_window.addToolBar(toolbar)
+
+    load_action = QAction("Load", main_window)
+    load_action.triggered.connect(main_window.load_graph)
+    toolbar.addAction(load_action)
+
+    save_action = QAction("Save", main_window)
+    save_action.triggered.connect(main_window.save_graph)
+    toolbar.addAction(save_action)
+
+    new_action = QAction("New", main_window)
+    new_action.triggered.connect(main_window.new_graph)
+    toolbar.addAction(new_action)
+
+    layout_action = QAction("Auto Layout", main_window)
+    layout_action.triggered.connect(main_window.canvas.auto_layout)
+    toolbar.addAction(layout_action)
+
+    undo_action = QAction("Undo", main_window)
+    undo_action.triggered.connect(main_window.canvas.undo)
+    toolbar.addAction(undo_action)
+
+    redo_action = QAction("Redo", main_window)
+    redo_action.triggered.connect(main_window.canvas.redo)
+    toolbar.addAction(redo_action)
+
+    add_node_action = QAction("Add Node", main_window)
+    add_node_action.triggered.connect(main_window.add_node)
+    toolbar.addAction(add_node_action)
+
+    add_conn_action = QAction("Add Connection", main_window)
+    add_conn_action.triggered.connect(main_window.start_add_connection)
+    toolbar.addAction(add_conn_action)
+
+    main_window.node_panel = NodePanel(main_window)
+    main_window.addDockWidget(Qt.RightDockWidgetArea, main_window.node_panel)
+    main_window.node_panel.hide()
+
+    main_window.connection_panel = ConnectionPanel(main_window)
+    main_window.addDockWidget(Qt.RightDockWidgetArea, main_window.connection_panel)
+    main_window.connection_panel.hide()
+
+    main_window.canvas.node_selected.connect(main_window.node_panel.show_node)
+    main_window.canvas.connection_request.connect(main_window.connection_panel.open_for)
+
+    return toolbar

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ These actions operate on the `graph.json` format and update the shared in-memory
 The dashboard also includes a **Graph View** tab which renders the loaded graph and displays
 basic information for the currently selected node. The **Graph Editor** window
 now includes **Add Node** and **Add Connection** tools for building the graph.
+Selecting a node shows a docked panel where its attributes can be edited. When two nodes are
+chosen for a new connection a connection panel allows its type and parameters to be configured.
 Nodes can be repositioned directly in the **Graph View** by dragging them with
 the mouse. Interaction is handled by :class:`CanvasWidget`, a reusable
 ``QGraphicsView`` subclass that supports selection, dragging, zooming and panning.


### PR DESCRIPTION
## Summary
- create `toolbar_builder.py` for constructing toolbars and property docks
- emit selection and connection signals from `CanvasWidget`
- use toolbar builder in the PySide dashboard and expose new add node/connection methods
- document new editing panels in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest dearpygui`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd0e94198832581a53f8df4545cb4