### PR TITLE
Fix QAction import location

### DIFF
--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Optional
 
 from PySide6.QtCore import QObject, Qt, QEvent
+from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (
-    QAction,
     QComboBox,
     QDockWidget,
     QDoubleSpinBox,


### PR DESCRIPTION
## Summary
- fix import of QAction in PySide6 toolbar builder
- run formatters and tests

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687fd37a25a88325b8f7bf53e97e3df5