### PR TITLE
Move editor actions to File/Edit menus

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -56,6 +56,8 @@ class MainWindow(QMainWindow):
     # ---- UI setup ----
 
     def _create_menus(self) -> None:
+        """Create the File and Edit menus for graph actions."""
+
         menubar = self.menuBar()
         file_menu = menubar.addMenu("File")
 
@@ -71,35 +73,25 @@ class MainWindow(QMainWindow):
         new_action.triggered.connect(self.new_graph)
         file_menu.addAction(new_action)
 
-    def _create_toolbars(self) -> None:
-        """Create a toolbar with graph actions."""
-
-        toolbar = QToolBar("Graph", self)
-        self.addToolBar(toolbar)
-
-        load_action = QAction("Load", self)
-        load_action.triggered.connect(self.load_graph)
-        toolbar.addAction(load_action)
-
-        save_action = QAction("Save", self)
-        save_action.triggered.connect(self.save_graph)
-        toolbar.addAction(save_action)
-
-        new_action = QAction("New", self)
-        new_action.triggered.connect(self.new_graph)
-        toolbar.addAction(new_action)
+        edit_menu = menubar.addMenu("Edit")
 
         layout_action = QAction("Auto Layout", self)
         layout_action.triggered.connect(self.canvas.auto_layout)
-        toolbar.addAction(layout_action)
+        edit_menu.addAction(layout_action)
 
         undo_action = QAction("Undo", self)
         undo_action.triggered.connect(self.canvas.undo)
-        toolbar.addAction(undo_action)
+        edit_menu.addAction(undo_action)
 
         redo_action = QAction("Redo", self)
         redo_action.triggered.connect(self.canvas.redo)
-        toolbar.addAction(redo_action)
+        edit_menu.addAction(redo_action)
+
+    def _create_toolbars(self) -> None:
+        """Create the toolbar with the Connect action."""
+
+        toolbar = QToolBar("Graph", self)
+        self.addToolBar(toolbar)
 
         connect_action = QAction("Connect", self)
         connect_action.triggered.connect(self.canvas.enable_connection_mode)

--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ python -m Causal_Web.main --no-gui   # headless run
 ```
 
 Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
-You can now load, save or start a new graph using the **File** menu in the dashboard.
-The graph view lives in a dock widget and a toolbar provides quick access to
-common actions like auto layout or connection mode. The **Auto Layout** button
-now correctly arranges nodes using a spring layout.
+Use the **File** menu to load, save or start a new graph. Editing actions such
+as **Auto Layout**, **Undo** and **Redo** now live in a separate **Edit** menu
+next to **File**. The graph view lives in a dock widget and the toolbar only
+provides a shortcut for enabling connection mode. The **Auto Layout** action
+still arranges nodes using a spring layout.
 When you press **Start Simulation** the current graph is written back to
 `input/graph.json`, a new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the


### PR DESCRIPTION
## Summary
- update the PySide dashboard UI so Load, Save and New are only in the File menu
- add an Edit menu containing Auto Layout, Undo and Redo
- trim toolbar to only include the Connect action
- clarify docstrings for the menu and toolbar methods in `main_window.py`
- document the new File/Edit menus in the README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fceb0b700832585e7406fa1192abd