### PR TITLE
Update menus for PySide GUI

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -72,6 +72,20 @@ class MainWindow(QMainWindow):
         new_action.triggered.connect(self.new_graph)
         file_menu.addAction(new_action)
 
+        edit_menu = menubar.addMenu("Edit")
+
+        layout_action = QAction("Auto Layout", self)
+        layout_action.triggered.connect(self.canvas.auto_layout)
+        edit_menu.addAction(layout_action)
+
+        undo_action = QAction("Undo", self)
+        undo_action.triggered.connect(self.canvas.undo)
+        edit_menu.addAction(undo_action)
+
+        redo_action = QAction("Redo", self)
+        redo_action.triggered.connect(self.canvas.redo)
+        edit_menu.addAction(redo_action)
+
     def _create_docks(self) -> None:
         dock = QDockWidget("Control Panel", self)
         panel = QWidget()

--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -127,34 +127,15 @@ class ConnectionPanel(QDockWidget):
 
 
 def build_toolbar(main_window) -> QToolBar:
-    """Create the graph toolbar and attach property panels."""
+    """Create the graph toolbar and attach property panels.
+
+    The toolbar now only exposes graph editing tools such as adding nodes or
+    connections. File and edit actions are provided by the menus on the main
+    window.
+    """
 
     toolbar = QToolBar("Graph", main_window)
     main_window.addToolBar(toolbar)
-
-    load_action = QAction("Load", main_window)
-    load_action.triggered.connect(main_window.load_graph)
-    toolbar.addAction(load_action)
-
-    save_action = QAction("Save", main_window)
-    save_action.triggered.connect(main_window.save_graph)
-    toolbar.addAction(save_action)
-
-    new_action = QAction("New", main_window)
-    new_action.triggered.connect(main_window.new_graph)
-    toolbar.addAction(new_action)
-
-    layout_action = QAction("Auto Layout", main_window)
-    layout_action.triggered.connect(main_window.canvas.auto_layout)
-    toolbar.addAction(layout_action)
-
-    undo_action = QAction("Undo", main_window)
-    undo_action.triggered.connect(main_window.canvas.undo)
-    toolbar.addAction(undo_action)
-
-    redo_action = QAction("Redo", main_window)
-    redo_action.triggered.connect(main_window.canvas.redo)
-    toolbar.addAction(redo_action)
 
     add_node_action = QAction("Add Node", main_window)
     add_node_action.triggered.connect(main_window.add_node)

--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ python -m Causal_Web.main --no-gui   # headless run
 ```
 
 Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
-Use the **File** menu to load, save or start a new graph. Editing actions such
-as **Auto Layout**, **Undo** and **Redo** now live in a separate **Edit** menu
-next to **File**. The graph view lives in a dock widget and the toolbar only
-provides a shortcut for enabling connection mode. The **Auto Layout** action
-still arranges nodes using a spring layout.
+Use the **File** menu to load, save or start a new graph. Editing actions
+including **Auto Layout**, **Undo** and **Redo** now live in a separate
+**Edit** menu next to **File**. The toolbar no longer exposes these commands and
+only provides a shortcut for enabling connection mode. The **Auto Layout**
+action still arranges nodes using a spring layout.
 When you press **Start Simulation** the current graph is written back to
 `input/graph.json`, a new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the


### PR DESCRIPTION
## Summary
- move editing commands from toolbar into a new Edit menu
- clean up toolbar so it only holds connection tools
- mention new File/Edit menus in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fd6e95b488325b428e17f52826aff