### PR TITLE
Attach graph editing tools to graph view window

### DIFF
--- a/Causal_Web/gui/dashboard.py
+++ b/Causal_Web/gui/dashboard.py
@@ -243,15 +243,13 @@ def dashboard():
     with dpg.window(label="Parameters", width=250, height=400):
         _add_param_controls(config_data)
 
-    with dpg.window(label="Graph Editor", width=200, height=150, pos=(610, 120)):
+    with dpg.window(label="Causal Graph", width=800, height=460, tag="graph_window"):
         add_toolbar()
         dpg.add_button(label="Add Node", callback=add_node_callback)
         dpg.add_button(
             label="Add Connection",
             callback=connection_tool.start_add_connection,
         )
-
-    with dpg.window(label="Causal Graph", width=800, height=460, tag="graph_window"):
         with dpg.child_window(tag="graph_child", horizontal_scrollbar=True):
             dpg.add_drawlist(width=1, height=1, tag="graph_drawlist")
             for node_id, (x, y) in node_positions.items():

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QSlider,
     QWidget,
+    QVBoxLayout,
 )
 
 from ..config import Config
@@ -40,8 +41,16 @@ class MainWindow(QMainWindow):
 
         self.setCentralWidget(QWidget())
         self.canvas = CanvasWidget(self)
+        toolbar = build_toolbar(self)
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(toolbar)
+        layout.addWidget(self.canvas)
+
         self.canvas_dock = QDockWidget("Graph View", self)
-        self.canvas_dock.setWidget(self.canvas)
+        self.canvas_dock.setWidget(container)
         self.addDockWidget(Qt.LeftDockWidgetArea, self.canvas_dock)
         self.canvas.load_model(get_graph())
 
@@ -51,7 +60,6 @@ class MainWindow(QMainWindow):
         self._redo_shortcut.activated.connect(self.canvas.redo)
 
         self._create_menus()
-        build_toolbar(self)
         self._create_docks()
 
     # ---- UI setup ----

--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -127,15 +127,16 @@ class ConnectionPanel(QDockWidget):
 
 
 def build_toolbar(main_window) -> QToolBar:
-    """Create the graph toolbar and attach property panels.
+    """Create the graph editing toolbar and property docks.
 
-    The toolbar now only exposes graph editing tools such as adding nodes or
-    connections. File and edit actions are provided by the menus on the main
+    The returned :class:`QToolBar` contains actions for adding nodes,
+    creating connections and applying automatic layout.  The caller is
+    responsible for embedding the toolbar, typically inside the Graph View
+    dock.  File and edit menu actions are handled separately by the main
     window.
     """
 
     toolbar = QToolBar("Graph", main_window)
-    main_window.addToolBar(toolbar)
 
     add_node_action = QAction("Add Node", main_window)
     add_node_action.triggered.connect(main_window.add_node)
@@ -144,6 +145,10 @@ def build_toolbar(main_window) -> QToolBar:
     add_conn_action = QAction("Add Connection", main_window)
     add_conn_action.triggered.connect(main_window.start_add_connection)
     toolbar.addAction(add_conn_action)
+
+    layout_action = QAction("Auto Layout", main_window)
+    layout_action.triggered.connect(main_window.canvas.auto_layout)
+    toolbar.addAction(layout_action)
 
     main_window.node_panel = NodePanel(main_window)
     main_window.addDockWidget(Qt.RightDockWidgetArea, main_window.node_panel)

--- a/README.md
+++ b/README.md
@@ -172,18 +172,19 @@ python -m Causal_Web.main --no-gui   # headless run
 
 Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
 Use the **File** menu to load, save or start a new graph. Editing actions
-including **Auto Layout**, **Undo** and **Redo** now live in a separate
-**Edit** menu next to **File**. The toolbar no longer exposes these commands and
-only provides a shortcut for enabling connection mode. The **Auto Layout**
-action still arranges nodes using a spring layout.
+including **Auto Layout**, **Undo** and **Redo** remain in the **Edit** menu.
+The **Graph View** dock now embeds a small toolbar offering **Add Node**,
+**Add Connection** and **Auto Layout** buttons for quick access.
+The **Auto Layout** action still arranges nodes using a spring layout.
 When you press **Start Simulation** the current graph is written back to
 `input/graph.json`, a new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the
 exact input used for each run.
 These actions operate on the `graph.json` format and update the shared in-memory model.
 The dashboard also includes a **Graph View** tab which renders the loaded graph and displays
-basic information for the currently selected node. The **Graph Editor** window
-now includes **Add Node** and **Add Connection** tools for building the graph.
+basic information for the currently selected node. The **Graph View** window
+now includes **Add Node**, **Add Connection** and **Auto Layout** tools for
+building and arranging the graph.
 Selecting a node shows a docked panel where its attributes can be edited. When two nodes are
 chosen for a new connection a connection panel allows its type and parameters to be configured.
 Nodes can be repositioned directly in the **Graph View** by dragging them with


### PR DESCRIPTION
## Summary
- embed Add Node, Add Connection and Auto Layout controls in the graph view
- expose the same toolbar in the PySide interface
- document new toolbar placement

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd88299408325a2762010de55469d