### PR TITLE
Fix connection dragging

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, Optional, Tuple
 
-from PySide6.QtCore import QPointF, Qt, Signal
+from PySide6.QtCore import QPoint, QPointF, Qt, Signal
 from PySide6.QtGui import (
     QBrush,
     QMouseEvent,
@@ -203,9 +203,10 @@ class CanvasWidget(QGraphicsView):
                 super().mouseReleaseEvent(event)
 
     # ---- helpers ----------------------------------------------------
-    def _update_temp_edge(self, view_pos: QPointF) -> None:
+    def _update_temp_edge(self, view_pos: QPoint) -> None:
+        """Update the dashed preview edge while dragging."""
         if self._temp_edge and self._connect_start:
-            scene_pos = self.mapToScene(view_pos.toPoint())
+            scene_pos = self.mapToScene(view_pos)
             self._temp_edge.setLine(
                 self._connect_start.x(),
                 self._connect_start.y(),

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ resizing the window. Debug messages are printed to the console whenever nodes
 are clicked or dragged.
 The Graph View window now resizes correctly, keeping graph elements interactive.
 A resize handler bug that halted GUI updates after resizing has been fixed.
+Dragging connections between nodes now works again across PySide6 versions.
 Rendering is now event driven so the canvas only updates when the graph changes, greatly reducing idle CPU usage.
 
 ### Analysing the output


### PR DESCRIPTION
## Summary
- ensure CanvasWidget uses QPoint when updating temporary edges
- document that connection dragging now works with new PySide6

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fdf38bcc88325a2a53118bf7ffed1