### PR TITLE
Add edge selection and apply buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ now includes **Add Node**, **Add Connection**, **Auto Layout** and **Load Graph*
 tools for building and applying the graph.
 Selecting a node shows a docked panel where its attributes can be edited. When two nodes are
 chosen for a new connection a connection panel allows its type and parameters to be configured.
+Both panels now include an **Apply** button to commit any changes.
+Edges in the Graph View are selectable and will open the connection panel for
+editing when clicked.
 Nodes can be repositioned directly in the **Graph View** by dragging them with
 the mouse. Interaction is handled by :class:`CanvasWidget`, a reusable
 ``QGraphicsView`` subclass that supports selection, dragging, zooming and panning.


### PR DESCRIPTION
## Summary
- add "Apply" buttons to Node and Connection panels
- implement edge selection in Graph View
- update README with new GUI capabilities

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe16df7688325abcf4974f5305f3e