### PR TITLE
Update edge drawing on node drag

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -50,7 +50,8 @@ class NodeItem(QGraphicsEllipseItem):
         self._drag_start: Optional[QPointF] = None
 
     def itemChange(self, change, value):  # type: ignore[override]
-        if change == QGraphicsItem.ItemPositionChange:
+        """Redraw connected edges whenever the node moves."""
+        if change == QGraphicsItem.ItemPositionHasChanged:
             for edge in self.edges:
                 edge.update_position()
         return super().itemChange(change, value)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ the mouse. Interaction is handled by :class:`CanvasWidget`, a reusable
 Dragging begins on mouse press for smooth movement and remains responsive after
 resizing the window. Debug messages are printed to the console whenever nodes
 are clicked or dragged.
+Edges connected to a moving node are redrawn in real time so the relationships stay visible while dragging.
 The Graph View window now resizes correctly, keeping graph elements interactive.
 A resize handler bug that halted GUI updates after resizing has been fixed.
 Dragging connections between nodes now works again across PySide6 versions.


### PR DESCRIPTION
## Summary
- redraw edges after nodes move
- document real-time edge updates during node drag

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe2c061688325abdcb6959b2fff7d