### PR TITLE
Improve node move handling

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -42,6 +42,8 @@ class NodeItem(QGraphicsEllipseItem):
         self.setPos(QPointF(x, y))
         self.setBrush(QBrush(Qt.gray))
         self.setPen(QPen(Qt.lightGray))
+        # ensure itemChange is triggered so connected edges update while moving
+        self.setFlag(QGraphicsItem.ItemSendsGeometryChanges)
         if canvas.editable:
             self.setFlag(QGraphicsItem.ItemIsMovable)
             self.setFlag(QGraphicsItem.ItemIsSelectable)

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Dragging begins on mouse press for smooth movement and remains responsive after
 resizing the window. Debug messages are printed to the console whenever nodes
 are clicked or dragged.
 Edges connected to a moving node are redrawn in real time so the relationships stay visible while dragging.
+Once the drag ends the node's new ``(x, y)`` coordinates are saved back to the
+graph model automatically.
 The Graph View window now resizes correctly, keeping graph elements interactive.
 A resize handler bug that halted GUI updates after resizing has been fixed.
 Dragging connections between nodes now works again across PySide6 versions.


### PR DESCRIPTION
## Summary
- ensure `itemChange` fires while dragging nodes by enabling `ItemSendsGeometryChanges`
- note that released positions are saved to the graph model in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fe49bb9988325aa9a51cb9e30ecee