### PR TITLE
Add settings menu for log file toggles

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -95,6 +95,30 @@ class Config:
         """Return ``True`` if the given log file should be written."""
         return cls.log_files.get(name, True)
 
+    @classmethod
+    def save_log_files(cls, path: str | None = None) -> None:
+        """Persist ``log_files`` settings back to ``config.json``.
+
+        Parameters
+        ----------
+        path:
+            Optional path to write. Defaults to :attr:`config_file`.
+        """
+        import json
+        import os
+
+        if path is None:
+            path = cls.config_file
+        if os.path.exists(path):
+            with open(path) as f:
+                data = json.load(f)
+        else:
+            data = {}
+        data.setdefault("log_files", {})
+        data["log_files"].update(cls.log_files)
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
     # Global rhythmic forcing parameters
     phase_jitter = {"amplitude": 0.0, "period": 20}  # radians  # ticks
     coherence_wave = {"amplitude": 0.0, "period": 30}  # threshold modulation

--- a/Causal_Web/gui_pyside/log_files_window.py
+++ b/Causal_Web/gui_pyside/log_files_window.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Window for toggling individual log files on or off."""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QHBoxLayout,
+    QMainWindow,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..config import Config
+
+
+class LogFilesWindow(QMainWindow):
+    """Window listing all known log files with enable checkboxes."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Log Files")
+        self.resize(300, 400)
+
+        self._checkboxes: dict[str, QCheckBox] = {}
+
+        central = QWidget()
+        layout = QVBoxLayout(central)
+        btn_layout = QHBoxLayout()
+        self.apply_button = QPushButton("Apply")
+        self.apply_button.clicked.connect(self.apply_changes)
+        btn_layout.addWidget(self.apply_button, alignment=Qt.AlignLeft)
+        btn_layout.addStretch()
+        layout.addLayout(btn_layout)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        container = QWidget()
+        checks = QVBoxLayout(container)
+
+        for name in sorted(Config.log_files):
+            cb = QCheckBox(name)
+            cb.setChecked(Config.log_files.get(name, True))
+            self._checkboxes[name] = cb
+            checks.addWidget(cb)
+        checks.addStretch()
+
+        scroll.setWidget(container)
+        layout.addWidget(scroll)
+        self.setCentralWidget(central)
+
+    def apply_changes(self) -> None:
+        """Update :class:`Config.log_files` and write to ``config.json``."""
+        for name, cb in self._checkboxes.items():
+            Config.log_files[name] = cb.isChecked()
+        Config.save_log_files()

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -104,6 +104,11 @@ class MainWindow(QMainWindow):
         redo_action.triggered.connect(self.canvas.redo)
         edit_menu.addAction(redo_action)
 
+        settings_menu = menubar.addMenu("Settings")
+        log_action = QAction("Log Files...", self)
+        log_action.triggered.connect(self._show_log_files_window)
+        settings_menu.addAction(log_action)
+
     def _create_docks(self) -> None:
         dock = QDockWidget("Control Panel", self)
         panel = QWidget()
@@ -202,6 +207,14 @@ class MainWindow(QMainWindow):
         """Display the graph editor window."""
         self.canvas.load_model(GraphModel.from_dict(get_graph().to_dict()))
         self.canvas_dock.show()
+
+    def _show_log_files_window(self) -> None:
+        """Open the Log Files settings window."""
+        if not hasattr(self, "log_files_window"):
+            from .log_files_window import LogFilesWindow
+
+            self.log_files_window = LogFilesWindow(self)
+        self.log_files_window.show()
 
     def _load_into_main(self) -> None:
         """Apply the edited graph to the main simulation view and disk."""

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ subdirectory so every run has a frozen copy of its inputs. Basic metadata
 about the run is inserted into the PostgreSQL `runs` table automatically. The
 location of `runs/` and other output folders can be customised using the
 `paths` section in `input/config.json`.
-Logging for each file can be enabled or disabled individually using the
-**Logging** window in the GUI or via the `log_files` section of the
+Logging for each file can be enabled or disabled individually using
+**Settings > Log Files...** in the GUI or via the `log_files` section of the
 configuration file.
 All log entries are buffered in memory and flushed periodically to minimize
 disk writes.

--- a/tests/test_log_files.py
+++ b/tests/test_log_files.py
@@ -1,0 +1,13 @@
+import json
+from Causal_Web.config import Config
+
+
+def test_save_log_files_updates_config(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    data = {"log_files": {"a.json": True, "b.json": False}}
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(Config, "config_file", str(path))
+    Config.log_files = {"a.json": False, "b.json": True}
+    Config.save_log_files()
+    saved = json.loads(path.read_text())
+    assert saved["log_files"] == Config.log_files


### PR DESCRIPTION
## Summary
- add `LogFilesWindow` for enabling/disabling output logs
- persist log file flags with new `Config.save_log_files`
- expose log file window via **Settings > Log Files...** menu
- document new menu option
- test config persistence

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe61389b483259a97c981dd7cb2dd