### PR TITLE
Add observer editing and improve UI controls

### DIFF
--- a/Causal_Web/command_stack.py
+++ b/Causal_Web/command_stack.py
@@ -116,3 +116,25 @@ class MoveNodeCommand(Command):
         if node is None:
             return
         node["x"], node["y"] = self._old_pos
+
+
+@dataclass
+class AddObserverCommand(Command):
+    """Command that inserts an observer into a :class:`GraphModel`."""
+
+    model: GraphModel
+    observer: dict
+    index: int | None = None
+
+    def execute(self) -> None:
+        if self.index is None:
+            self.model.observers.append(self.observer)
+            self.index = len(self.model.observers) - 1
+        else:
+            self.model.observers.insert(self.index, self.observer)
+
+    def undo(self) -> None:
+        if self.index is None:
+            return
+        if 0 <= self.index < len(self.model.observers):
+            self.model.observers.pop(self.index)

--- a/Causal_Web/graph/io.py
+++ b/Causal_Web/graph/io.py
@@ -39,3 +39,5 @@ def _validate_graph(data: dict[str, Any]) -> None:
             raise ValueError("edge entries must be objects")
         if "from" not in edge or "to" not in edge:
             raise ValueError("edge missing 'from' or 'to'")
+    if "observers" in data and not isinstance(data["observers"], list):
+        raise ValueError("'observers' must be a list")

--- a/Causal_Web/graph/model.py
+++ b/Causal_Web/graph/model.py
@@ -12,6 +12,7 @@ class GraphModel:
     edges: List[Dict[str, Any]] = field(default_factory=list)
     bridges: List[Dict[str, Any]] = field(default_factory=list)
     tick_sources: List[Dict[str, Any]] = field(default_factory=list)
+    observers: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the model to a plain ``dict``."""
@@ -20,6 +21,7 @@ class GraphModel:
             "edges": self.edges,
             "bridges": self.bridges,
             "tick_sources": self.tick_sources,
+            "observers": self.observers,
         }
 
     @classmethod
@@ -34,6 +36,7 @@ class GraphModel:
         model.edges = list(data.get("edges", []))
         model.bridges = list(data.get("bridges", []))
         model.tick_sources = list(data.get("tick_sources", []))
+        model.observers = list(data.get("observers", []))
         return model
 
     @classmethod
@@ -168,6 +171,27 @@ class GraphModel:
         if index < 0 or index >= len(target_list):
             raise IndexError("connection index out of range")
         del target_list[index]
+
+    # ---- Observer management -------------------------------------------------
+
+    def add_observer(
+        self,
+        obs_id: str,
+        *,
+        monitors: List[str] | None = None,
+        frequency: float = 1.0,
+        target_nodes: List[str] | None = None,
+    ) -> None:
+        """Insert a new observer definition."""
+
+        data: Dict[str, Any] = {
+            "id": obs_id,
+            "monitors": monitors or [],
+            "frequency": frequency,
+        }
+        if target_nodes:
+            data["target_nodes"] = list(target_nodes)
+        self.observers.append(data)
 
     def apply_spring_layout(self) -> None:
         """Position nodes using ``networkx.spring_layout``."""

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -27,7 +27,7 @@ from ..gui.state import (
 )
 from .canvas_widget import CanvasWidget
 from .toolbar_builder import build_toolbar
-from ..command_stack import AddNodeCommand
+from ..command_stack import AddNodeCommand, AddObserverCommand
 from ..engine import tick_engine
 
 
@@ -198,6 +198,18 @@ class MainWindow(QMainWindow):
         cmd = AddNodeCommand(model, f"N{idx}", {"x": 50.0 * idx, "y": 50.0 * idx})
         self.canvas.command_stack.do(cmd)
         self.canvas.load_model(model)
+
+    def add_observer(self) -> None:
+        """Create a new observer definition."""
+        model = get_graph()
+        idx = 1
+        existing = {o.get("id") for o in model.observers}
+        while f"OBS{idx}" in existing:
+            idx += 1
+        observer = {"id": f"OBS{idx}", "monitors": [], "frequency": 1.0}
+        cmd = AddObserverCommand(model, observer)
+        self.canvas.command_stack.do(cmd)
+        self.observer_panel.open_new(cmd.index)
 
     def start_add_connection(self) -> None:
         """Enable interactive connection mode."""

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Use the on-screen controls to start or pause the simulation and adjust the tick 
 Use the **File** menu to load, save or start a new graph. Editing actions
 include **Edit Graph...**, **Undo** and **Redo** in the **Edit** menu.
 The **Graph View** dock now embeds a small toolbar offering **Add Node**,
-**Add Connection**, **Auto Layout** and a **Load Graph** button for quick access.
+**Add Connection**, **Add Observer**, **Auto Layout** and a **Load Graph** button for quick access.
 The **Auto Layout** action still arranges nodes using a spring layout.
 When you press **Start Simulation** the current graph is written back to
 `input/graph.json`, a new run directory is created via `Config.new_run()` and
@@ -183,7 +183,7 @@ exact input used for each run.
 These actions operate on the `graph.json` format and update the shared in-memory model.
 The dashboard also includes a **Graph View** tab which renders the loaded graph and displays
 basic information for the currently selected node. The **Graph View** window
-now includes **Add Node**, **Add Connection**, **Auto Layout** and **Load Graph**
+now includes **Add Node**, **Add Connection**, **Add Observer**, **Auto Layout** and **Load Graph**
 tools for building and applying the graph.
 Selecting a node shows a docked panel where its attributes can be edited. The panel now includes
 the node's initial **phase** and an optional **Tick Source** section for emitting periodic ticks.


### PR DESCRIPTION
## Summary
- expand coordinate ranges in Node panel
- store observers in `GraphModel`
- validate `observers` when loading graphs
- add Observer panel and toolbar action
- allow selecting nodes from drop-down lists when creating connections
- document toolbar changes

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff411c338832597213daa75db5963