### PR TITLE
Add MetaNode editing support

### DIFF
--- a/Causal_Web/command_stack.py
+++ b/Causal_Web/command_stack.py
@@ -138,3 +138,43 @@ class AddObserverCommand(Command):
             return
         if 0 <= self.index < len(self.model.observers):
             self.model.observers.pop(self.index)
+
+
+@dataclass
+class AddMetaNodeCommand(Command):
+    """Command that inserts a meta node into a :class:`GraphModel`."""
+
+    model: GraphModel
+    meta_id: str
+    data: dict
+
+    def execute(self) -> None:
+        self.model.meta_nodes[self.meta_id] = dict(self.data)
+
+    def undo(self) -> None:
+        self.model.meta_nodes.pop(self.meta_id, None)
+
+
+@dataclass
+class MoveMetaNodeCommand(Command):
+    """Command that updates a meta node's position."""
+
+    model: GraphModel
+    meta_id: str
+    new_pos: Tuple[float, float]
+    _old_pos: Tuple[float, float] | None = None
+
+    def execute(self) -> None:
+        data = self.model.meta_nodes.get(self.meta_id)
+        if data is None:
+            return
+        self._old_pos = (data.get("x", 0.0), data.get("y", 0.0))
+        data["x"], data["y"] = self.new_pos
+
+    def undo(self) -> None:
+        if self._old_pos is None:
+            return
+        data = self.model.meta_nodes.get(self.meta_id)
+        if data is None:
+            return
+        data["x"], data["y"] = self._old_pos

--- a/Causal_Web/graph/io.py
+++ b/Causal_Web/graph/io.py
@@ -41,3 +41,5 @@ def _validate_graph(data: dict[str, Any]) -> None:
             raise ValueError("edge missing 'from' or 'to'")
     if "observers" in data and not isinstance(data["observers"], list):
         raise ValueError("'observers' must be a list")
+    if "meta_nodes" in data and not isinstance(data["meta_nodes"], dict):
+        raise ValueError("'meta_nodes' must be a dict")

--- a/Causal_Web/graph/model.py
+++ b/Causal_Web/graph/model.py
@@ -13,6 +13,7 @@ class GraphModel:
     bridges: List[Dict[str, Any]] = field(default_factory=list)
     tick_sources: List[Dict[str, Any]] = field(default_factory=list)
     observers: List[Dict[str, Any]] = field(default_factory=list)
+    meta_nodes: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the model to a plain ``dict``."""
@@ -22,6 +23,7 @@ class GraphModel:
             "bridges": self.bridges,
             "tick_sources": self.tick_sources,
             "observers": self.observers,
+            "meta_nodes": self.meta_nodes,
         }
 
     @classmethod
@@ -37,6 +39,7 @@ class GraphModel:
         model.bridges = list(data.get("bridges", []))
         model.tick_sources = list(data.get("tick_sources", []))
         model.observers = list(data.get("observers", []))
+        model.meta_nodes = dict(data.get("meta_nodes", {}))
         return model
 
     @classmethod
@@ -55,6 +58,7 @@ class GraphModel:
                 "generation_tick": 0,
                 "parent_ids": [],
             }
+        model.meta_nodes = {}
         return model
 
     def node_position(self, node_id: str) -> tuple[float, float] | None:
@@ -171,6 +175,34 @@ class GraphModel:
         if index < 0 or index >= len(target_list):
             raise IndexError("connection index out of range")
         del target_list[index]
+
+    # ---- Meta node management -------------------------------------------------
+
+    def add_meta_node(
+        self,
+        meta_id: str,
+        *,
+        members: List[str] | None = None,
+        constraints: Dict[str, Any] | None = None,
+        type: str = "Configured",
+        origin: str | None = None,
+        collapsed: bool = False,
+        x: float = 0.0,
+        y: float = 0.0,
+    ) -> None:
+        """Insert a new meta node definition."""
+
+        data: Dict[str, Any] = {
+            "members": list(members or []),
+            "constraints": constraints or {},
+            "type": type,
+            "collapsed": collapsed,
+            "x": x,
+            "y": y,
+        }
+        if origin is not None:
+            data["origin"] = origin
+        self.meta_nodes[meta_id] = data
 
     # ---- Observer management -------------------------------------------------
 

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -211,6 +211,27 @@ class MainWindow(QMainWindow):
         self.canvas.command_stack.do(cmd)
         self.observer_panel.open_new(cmd.index)
 
+    def add_meta_node(self) -> None:
+        """Create a new configured meta node."""
+        model = get_graph()
+        idx = 1
+        while f"MN{idx}" in model.meta_nodes:
+            idx += 1
+        meta_id = f"MN{idx}"
+        data = {
+            "members": [],
+            "constraints": {},
+            "type": "Configured",
+            "collapsed": False,
+            "x": 0.0,
+            "y": 0.0,
+        }
+        from ..command_stack import AddMetaNodeCommand
+
+        cmd = AddMetaNodeCommand(model, meta_id, data)
+        self.canvas.command_stack.do(cmd)
+        self.meta_node_panel.open_new(meta_id)
+
     def start_add_connection(self) -> None:
         """Enable interactive connection mode."""
         self.canvas.enable_connection_mode()

--- a/Causal_Web/input/tooltip.json
+++ b/Causal_Web/input/tooltip.json
@@ -16,5 +16,16 @@
   "decoherence_limit": "The decoherence level at which the bridge might rupture",
   "initial_strength": "The starting strength of integrity of the bridge",
   "medium_type": "The type of medium the bridge represents",
-  "mutable": "If the simulation can modify the bridge"
-}
+  "mutable": "If the simulation can modify the bridge",
+  "members": "Nodes included in the MetaNode",
+  "phase_lock": "Enforces phase sync via tolerance",
+  "coherence_tie": "Requires minimum coherence level",
+  "shared_tick_input": "Forces nodes to tick in unison",
+  "sync_topology": "Enforces identical edge structures",
+  "role_lock": "Enforces same functional role across nodes",
+  "type": "Informational tag: Configured or Emergent",
+  "origin": "Event/tick that spawned the MetaNode (Emergent only)",
+  "collapsed": "Whether to process the MetaNode as a single unit",
+  "tolerance": "Allowable phase difference",
+  "min_coherence": "Minimum coherence across members"
+ }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Collapse-Seeded Propagation. These options are also exposed as CLI flags and can
 be modified in the Parameters window.
 ## Graph format
 
-Graphs are defined by a JSON file with `nodes`, `edges`, optional `bridges`, `tick_sources` and `observers`. Each node defines its position, frequency and thresholds. Edges specify delays and attenuation. Tick sources seed periodic activity and observers describe which metrics to record.
+Graphs are defined by a JSON file with `nodes`, `edges`, optional `bridges`, `tick_sources`, `observers` and `meta_nodes`. Each node defines its position, frequency and thresholds. Edges specify delays and attenuation. Tick sources seed periodic activity and observers describe which metrics to record. Meta nodes group related nodes under additional constraints.
 
 Example:
 ```json
@@ -151,7 +151,8 @@ Example:
       "monitors": [ "collapse", "law_wave", "region" ],
       "frequency": 1
     }
-  ]
+  ],
+  "meta_nodes": {}
 }
 ```
 

--- a/tests/test_meta_nodes.py
+++ b/tests/test_meta_nodes.py
@@ -1,0 +1,29 @@
+import json
+from Causal_Web.graph.model import GraphModel
+from Causal_Web.graph.io import load_graph, save_graph
+
+def test_meta_node_roundtrip(tmp_path):
+    data = {
+        "nodes": {"A": {"x": 0, "y": 0}},
+        "edges": [],
+        "meta_nodes": {
+            "MN1": {
+                "members": ["A"],
+                "constraints": {"phase_lock": {"tolerance": 0.1}},
+                "type": "Configured",
+                "collapsed": False,
+                "x": 1.0,
+                "y": 2.0,
+            }
+        },
+    }
+    path = tmp_path / "g.json"
+    path.write_text(json.dumps(data))
+    graph = load_graph(str(path))
+    assert "MN1" in graph.meta_nodes
+    out = tmp_path / "out.json"
+    save_graph(str(out), graph)
+    saved = json.loads(out.read_text())
+    assert "meta_nodes" in saved
+    assert saved["meta_nodes"]["MN1"]["members"] == ["A"]
+


### PR DESCRIPTION
## Summary
- add `meta_nodes` field to `GraphModel` and related helpers
- provide commands for adding and moving meta nodes
- create `MetaNodePanel` UI and toolbar action
- draw meta nodes in `CanvasWidget`
- document meta nodes and tooltips
- add regression test for meta node roundtrip

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f7047d7883258d227963f85699f2