### PR TITLE
Add configurable MetaNode constraints

### DIFF
--- a/Causal_Web/engine/meta_node.py
+++ b/Causal_Web/engine/meta_node.py
@@ -1,25 +1,94 @@
-from typing import List
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .node import Node
 
 
+@dataclass
 class MetaNode:
-    """Abstract node representing a collapsed subgraph."""
+    """Group of nodes subject to optional constraints."""
 
-    def __init__(self, node_ids: List[str], graph):
-        self.id = "meta_" + "_".join(sorted(node_ids))
-        self.member_ids = node_ids
-        self.graph = graph
-        self.phase = 0.0
+    member_ids: List[str]
+    graph: "CausalGraph"
+    meta_type: str = "Configured"
+    constraints: Dict[str, Dict] = field(default_factory=dict)
+    origin: Optional[str] = None
+    collapsed: bool = False
+    x: float = 0.0
+    y: float = 0.0
+    id: str = ""
+    phase: float = 0.0
 
-    def apply_tick(self, tick_time: int, phase: float, origin: str = "meta"):
-        """Propagate tick to all member nodes."""
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = "meta_" + "_".join(sorted(self.member_ids))
+
+    # ------------------------------------------------------------------
+    def apply_tick(self, tick_time: int, phase: float, origin: str = "meta") -> None:
+        """Propagate ``phase`` to all member nodes."""
         self.phase = phase
         for nid in self.member_ids:
-            node = self.graph.get_node(nid)
+            node: Optional[Node] = self.graph.get_node(nid)
             if node:
                 node.apply_tick(tick_time, phase, self.graph, origin=origin)
 
-    def update_internal_state(self, tick_time: int):
-        for nid in self.member_ids:
-            node = self.graph.get_node(nid)
+    # ------------------------------------------------------------------
+    def update_internal_state(self, tick_time: int) -> None:
+        """Tick member nodes and enforce constraints."""
+        self._enforce_constraints(tick_time)
+        for nid in list(self.member_ids):
+            node: Optional[Node] = self.graph.get_node(nid)
             if node:
                 node.maybe_tick(tick_time, self.graph)
+
+    # ------------------------------------------------------------------
+    def _enforce_constraints(self, tick_time: int) -> None:
+        """Apply configured MetaNode constraints."""
+
+        if self.meta_type != "Configured":
+            return
+
+        cons = self.constraints
+
+        # Phase lock ---------------------------------------------------
+        if "phase_lock" in cons:
+            tol = float(cons["phase_lock"].get("tolerance", 0.0))
+            phases = []
+            for nid in self.member_ids:
+                node = self.graph.get_node(nid)
+                if node:
+                    phases.append(node.phase)
+            if phases:
+                avg = sum(phases) / len(phases)
+                for nid in self.member_ids:
+                    node = self.graph.get_node(nid)
+                    if node and abs(node.phase - avg) > tol:
+                        node.phase = avg
+
+        # Shared tick input -------------------------------------------
+        if cons.get("shared_tick_input"):
+            combined: List = []
+            for nid in self.member_ids:
+                node = self.graph.get_node(nid)
+                if node:
+                    combined.extend(node.incoming_phase_queue.get(tick_time, []))
+            if combined:
+                for nid in self.member_ids:
+                    node = self.graph.get_node(nid)
+                    if node:
+                        q = node.incoming_phase_queue.setdefault(tick_time, [])
+                        for item in combined:
+                            if item not in q:
+                                q.append(item)
+
+        # Coherence tie -----------------------------------------------
+        if "coherence_tie" in cons:
+            threshold = float(cons["coherence_tie"].get("min_coherence", 0.0))
+            remain = []
+            for nid in self.member_ids:
+                node = self.graph.get_node(nid)
+                if node and node.compute_coherence_level(tick_time) >= threshold:
+                    remain.append(nid)
+            self.member_ids = remain

--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -780,6 +780,7 @@ def simulation_loop():
             emit_ticks(global_tick)
             propagate_phases(global_tick)
             evaluate_nodes(global_tick)
+            graph.update_meta_nodes(global_tick)
             check_propagation(global_tick)
 
             log_metrics_per_tick(global_tick)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,12 @@ Collapse-Seeded Propagation. These options are also exposed as CLI flags and can
 be modified in the Parameters window.
 ## Graph format
 
+
 Graphs are defined by a JSON file with `nodes`, `edges`, optional `bridges`, `tick_sources`, `observers` and `meta_nodes`. Each node defines its position, frequency and thresholds. Edges specify delays and attenuation. Tick sources seed periodic activity and observers describe which metrics to record. Meta nodes group related nodes under additional constraints.
+
+### Meta nodes
+
+Configured meta nodes are declared under the `meta_nodes` key and can enforce constraints such as `phase_lock`, `shared_tick_input` or `coherence_tie`. Emergent meta nodes are discovered at runtime when the engine observes naturally synchronized clusters. Only configured meta nodes modify behaviour; emergent ones are logged for analysis.
 
 Observers include optional `x` and `y` fields storing their location on the canvas.
 
@@ -155,8 +160,17 @@ Example:
       "frequency": 1
     }
   ],
-  "meta_nodes": {}
-}
+  "meta_nodes": {
+    "MN1": {
+      "members": ["A", "B"],
+      "constraints": {"phase_lock": {"tolerance": 0.1}},
+      "type": "Configured",
+      "collapsed": false,
+      "x": 0.0,
+      "y": 0.0
+    }
+  }
+  }
 ```
 
 


### PR DESCRIPTION
## Summary
- load meta_nodes from graph file and save them in tick trace
- add MetaNode dataclass enforcing phase lock, shared ticks, and coherence
- track emergent meta nodes separately at runtime
- call `update_meta_nodes` each tick
- document configured and emergent meta nodes in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880fce2262c832589da8e3eb7a1bfc5