### PR TITLE
Add graph item deletion and context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ allows connecting nodes by dragging between them, applies an automatic spring
 layout based on ``networkx`` and validates connections to prevent duplicates or
 self-loops. Observers appear as draggable squares connected to each of their
 target nodes with dotted lines and open the observer panel when clicked.
+Right-clicking the canvas opens a menu to insert new nodes, observers or meta
+nodes at the clicked location. Right-clicking existing items exposes a delete
+option that removes the object and any associated links.
 
 Key modules include:
 

--- a/tests/test_graph_model_delete.py
+++ b/tests/test_graph_model_delete.py
@@ -1,0 +1,36 @@
+import pytest
+from Causal_Web.graph.model import GraphModel
+
+
+def test_remove_node_cleans_references():
+    model = GraphModel.blank()
+    model.add_node("A")
+    model.add_node("B")
+    model.add_connection("A", "B")
+    model.add_observer("OBS1", monitors=["A", "B"], x=0.0, y=0.0)
+    model.add_meta_node("MN1", members=["A", "B"], x=0.0, y=0.0)
+
+    model.remove_node("B")
+
+    assert "B" not in model.nodes
+    assert all("B" not in (e["from"], e["to"]) for e in model.edges)
+    assert "B" not in model.meta_nodes["MN1"]["members"]
+    assert "B" not in model.observers[0]["monitors"]
+
+
+def test_remove_observer():
+    model = GraphModel.blank()
+    model.add_observer("O1")
+    model.add_observer("O2")
+    model.remove_observer(0)
+    assert len(model.observers) == 1
+    assert model.observers[0]["id"] == "O2"
+
+
+def test_remove_meta_node():
+    model = GraphModel.blank()
+    model.add_meta_node("MN1")
+    model.add_meta_node("MN2")
+    model.remove_meta_node("MN1")
+    assert "MN1" not in model.meta_nodes
+    assert "MN2" in model.meta_nodes


### PR DESCRIPTION
## Summary
- implement `remove_node`, `remove_observer` and `remove_meta_node` in `GraphModel`
- add deletion commands to command stack
- extend `CanvasWidget` with right-click context menu for adding and deleting items
- document new behaviour
- add tests for new removal helpers

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810c74c5fc832594ea1cdaca4f4906