### PR TITLE
Implement unsaved change handling and dock panels to Graph View

### DIFF
--- a/Causal_Web/command_stack.py
+++ b/Causal_Web/command_stack.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import List, Tuple
 
 from .graph.model import GraphModel
+from .gui.state import mark_graph_dirty
 
 
 class Command:
@@ -31,6 +32,7 @@ class CommandStack:
         command.execute()
         self.undo_stack.append(command)
         self.redo_stack.clear()
+        mark_graph_dirty()
 
     def undo(self) -> None:
         """Undo the most recent command if any."""
@@ -40,6 +42,7 @@ class CommandStack:
         cmd = self.undo_stack.pop()
         cmd.undo()
         self.redo_stack.append(cmd)
+        mark_graph_dirty()
 
     def redo(self) -> None:
         """Redo the most recently undone command if any."""
@@ -49,6 +52,7 @@ class CommandStack:
         cmd = self.redo_stack.pop()
         cmd.execute()
         self.undo_stack.append(cmd)
+        mark_graph_dirty()
 
 
 @dataclass

--- a/Causal_Web/gui/state.py
+++ b/Causal_Web/gui/state.py
@@ -25,6 +25,7 @@ _active_file: str | None = None
 _selected_node: str | None = None
 _selected_connection: tuple[str, int] | None = None
 _selected_observer: int | None = None
+_graph_dirty: bool = False
 
 
 def get_active_file() -> str | None:
@@ -36,6 +37,7 @@ def set_active_file(path: str | None) -> None:
     """Record the path of the loaded graph file."""
     global _active_file
     _active_file = path
+    clear_graph_dirty()
 
 
 def get_selected_node() -> str | None:
@@ -69,3 +71,20 @@ def set_selected_observer(index: int | None) -> None:
     """Update the currently selected observer index."""
     global _selected_observer
     _selected_observer = index
+
+
+def mark_graph_dirty() -> None:
+    """Flag the active graph as modified since the last load/save."""
+    global _graph_dirty
+    _graph_dirty = True
+
+
+def clear_graph_dirty() -> None:
+    """Reset the dirty flag for the active graph."""
+    global _graph_dirty
+    _graph_dirty = False
+
+
+def is_graph_dirty() -> bool:
+    """Return ``True`` if the active graph has unapplied changes."""
+    return _graph_dirty

--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ graph model automatically.
 The Graph View window now resizes correctly, keeping graph elements interactive.
 A resize handler bug that halted GUI updates after resizing has been fixed.
 Dragging connections between nodes now works again across PySide6 versions.
+
 Rendering is now event driven so the canvas only updates when the graph changes, greatly reducing idle CPU usage.
+Graph editing panels are now docked within the Graph View window. They close automatically when the view is hidden and prompt about unapplied changes before closing. The Graph View also warns when in-memory edits have not been saved to ``graph.json``.
 
 ### Analysing the output
 


### PR DESCRIPTION
## Summary
- add dirty flag helpers in GUI state
- mark graph changes in CommandStack and GUI panels
- dock Node, Connection, Observer and MetaNode panels inside the Graph View
- prompt about unsaved panel and graph changes when closing the Graph View
- update README with new behaviour

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6881103727d88325b357e25c1b820d26