### PR TITLE
Fix missing dirty handlers in GUI panels

### DIFF
--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -609,6 +609,10 @@ class ObserverPanel(QDockWidget):
         widget.installEventFilter(_FocusWatcher(self.commit))
         self.setWidget(widget)
 
+    def _mark_dirty(self, *args) -> None:
+        """Mark the panel state as having unsaved changes."""
+        self.dirty = True
+
     def open_for(self, index: int) -> None:
         model = get_graph()
         if index < 0 or index >= len(model.observers):
@@ -757,6 +761,10 @@ class MetaNodePanel(QDockWidget):
         layout.addRow(apply_btn)
         widget.installEventFilter(_FocusWatcher(self.commit))
         self.setWidget(widget)
+
+    def _mark_dirty(self, *args) -> None:
+        """Indicate that changes need saving."""
+        self.dirty = True
 
     def open_new(self, meta_id: str) -> None:
         self.current = meta_id


### PR DESCRIPTION
## Summary
- add `_mark_dirty` handlers to ObserverPanel and MetaNodePanel
- keep GUI panels tracking unsaved state correctly

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688114d438e483259e4992772c88ded2