### PR TITLE
Fix Start Simulation graph write

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -193,10 +193,13 @@ class MainWindow(QMainWindow):
         Config.tick_rate = float(value)
 
     def start_simulation(self) -> None:
-        """Save the graph and start the simulation loop."""
+        """Persist the active graph and launch the simulation thread."""
         path = get_active_file() or Config.input_path("graph.json")
         os.makedirs(os.path.dirname(path), exist_ok=True)
         save_graph(path, get_graph())
+        # always write the runtime graph to the package input directory so the
+        # engine uses the latest edits regardless of the loaded file location
+        save_graph(Config.input_path("graph.json"), get_graph())
         clear_graph_dirty()
         mark_graph_dirty()
         Config.new_run()

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ include **Edit Graph...**, **Undo** and **Redo** in the **Edit** menu.
 The **Graph View** dock now embeds a small toolbar offering **Add Node**,
 **Add Connection**, **Add Observer**, **Auto Layout** and a **Load Graph** button for quick access.
 The **Auto Layout** action still arranges nodes using a spring layout.
-When you press **Start Simulation** the current graph is written back to
-`input/graph.json`, a new run directory is created via `Config.new_run()` and
+When you press **Start Simulation** the current graph is saved and also copied
+to `input/graph.json`. A new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the
 exact input used for each run.
 These actions operate on the `graph.json` format and update the shared in-memory model.


### PR DESCRIPTION
## Summary
- copy the active graph to `input/graph.json` whenever starting a run
- note the behaviour in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688116bbfb408325b88b7042cfad69a0