### PR TITLE
Auto-save node panel coordinates

### DIFF
--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -150,15 +150,11 @@ class NodePanel(QDockWidget):
         widget.installEventFilter(_FocusWatcher(self.commit))
         self.setWidget(widget)
 
-    def _mark_dirty(self, *args) -> None:
-        self.dirty = True
-
-    def _mark_dirty(self, *args) -> None:
-        self.dirty = True
-        # update coordinates if node moves while panel is visible
+        # keep displayed coordinates in sync with the canvas
         self.main_window.canvas.node_position_changed.connect(self.update_position)
 
     def _mark_dirty(self, *args) -> None:
+        """Indicate that edits are pending."""
         self.dirty = True
 
     def _toggle_tick_source_fields(self, checked: bool) -> None:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ resizing the window. Debug messages are printed to the console whenever nodes
 are clicked or dragged.
 Edges connected to a moving node are redrawn in real time so the relationships stay visible while dragging.
 Once the drag ends the node's new ``(x, y)`` coordinates are saved back to the
-graph model automatically.
+graph model automatically. Meta nodes and observers store their updated
+positions in the same way.
 The Graph View window now resizes correctly, keeping graph elements interactive.
 A resize handler bug that halted GUI updates after resizing has been fixed.
 Dragging connections between nodes now works again across PySide6 versions.


### PR DESCRIPTION
## Summary
- connect node panel to canvas position updates
- clarify that meta nodes and observers also save moved positions

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68811e7d7ab88325aaeaf40c7742c750