### PR TITLE
Fix observer position persistence and connection rendering

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -341,6 +341,7 @@ class CanvasWidget(QGraphicsView):
             members = data.get("members", [])
             item = MetaNodeItem(meta_id, x, y, members, self)
             scene.addItem(item)
+            item.update_lines()
             self.meta_nodes[meta_id] = item
 
         for idx, obs in enumerate(model.observers):
@@ -348,6 +349,7 @@ class CanvasWidget(QGraphicsView):
             targets = obs.get("target_nodes")
             item = ObserverItem(idx, x, y, targets, self)
             scene.addItem(item)
+            item.update_lines()
             self.observers[idx] = item
 
     # ---- interaction -------------------------------------------------

--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -644,12 +644,19 @@ class ObserverPanel(QDockWidget):
         if self.current_index is None:
             return
         model = get_graph()
+        existing = (
+            model.observers[self.current_index]
+            if self.current_index < len(model.observers)
+            else {}
+        )
         data = {
             "id": self.id_edit.text(),
             "monitors": [
                 ev for ev, cb in self.monitor_checks.items() if cb.isChecked()
             ],
             "frequency": float(self.freq_spin.value()),
+            "x": float(existing.get("x", 0.0)),
+            "y": float(existing.get("y", 0.0)),
         }
         targets = [item.text() for item in self.node_list.selectedItems()]
         if targets:

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Edges connected to a moving node are redrawn in real time so the relationships s
 Once the drag ends the node's new ``(x, y)`` coordinates are saved back to the
 graph model automatically. Meta nodes and observers store their updated
 positions in the same way.
+Connections from observers and meta nodes now appear immediately after applying
+changes, without needing to drag the items first.
 The Graph View window now resizes correctly, keeping graph elements interactive.
 A resize handler bug that halted GUI updates after resizing has been fixed.
 Dragging connections between nodes now works again across PySide6 versions.


### PR DESCRIPTION
## Summary
- keep observer coordinates when applying edits
- draw observer and meta node link lines immediately
- document connection line fix in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6881213742ac83258f8432b16e354fd8