### PR TITLE
Fix panel target loading and minimise behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,13 @@ graph model automatically. Meta nodes and observers store their updated
 positions in the same way.
 Connections from observers and meta nodes now appear immediately after applying
 changes, without needing to drag the items first.
+Observer and meta node panels correctly remember their targeted nodes when reopened.
 The Graph View window now resizes correctly, keeping graph elements interactive.
 A resize handler bug that halted GUI updates after resizing has been fixed.
 Dragging connections between nodes now works again across PySide6 versions.
 
 Rendering is now event driven so the canvas only updates when the graph changes, greatly reducing idle CPU usage.
-Graph editing panels are now docked within the Graph View window. They close automatically when the view is hidden and prompt about unapplied changes before closing. The Graph View also warns when in-memory edits have not been saved to ``graph.json``.
+Graph editing panels are now docked within the Graph View window. They close automatically when the view is hidden and prompt about unapplied changes before closing. Panels minimize when they lose focus and restore when clicked again, warning about unsaved edits if you switch to a different object. The Graph View also warns when in-memory edits have not been saved to ``graph.json``.
 
 ### Analysing the output
 


### PR DESCRIPTION
## Summary
- ensure Observer and MetaNode panels keep target selections when reopened
- warn about unsaved changes when switching selected objects
- minimise panels on focus loss instead of auto-applying
- document improved panel interactions

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68812643a1588325a4b20ec004e59189