### PR TITLE
Fix simulation start not applying pending graph edits

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -193,7 +193,15 @@ class MainWindow(QMainWindow):
         Config.tick_rate = float(value)
 
     def start_simulation(self) -> None:
-        """Persist the active graph and launch the simulation thread."""
+        """Persist the active graph and launch the simulation thread.
+
+        If the graph editor is open, any pending edits are applied to the
+        simulation view before saving. This ensures the runtime graph matches
+        the editor state when starting a new run.
+        """
+        # apply edits from the graph editor if it is currently visible
+        if self.canvas_dock.isVisible():
+            self._load_into_main()
         path = get_active_file() or Config.input_path("graph.json")
         os.makedirs(os.path.dirname(path), exist_ok=True)
         save_graph(path, get_graph())

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ The **Auto Layout** action still arranges nodes using a spring layout.
 When you press **Start Simulation** the current graph is saved and also copied
 to `input/graph.json`. A new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the
-exact input used for each run.
+exact input used for each run. Any unsaved edits in the **Graph View** are
+applied automatically so the main window reflects the latest changes when the
+simulation begins.
 These actions operate on the `graph.json` format and update the shared in-memory model.
 The dashboard also includes a **Graph View** tab which renders the loaded graph and displays
 basic information for the currently selected node. The **Graph View** window


### PR DESCRIPTION
## Summary
- ensure pending edits in the Graph View are applied when starting a simulation
- document the automatic apply behaviour in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688132d4078483258bb7e69a1c3ff634