### PR TITLE
Fix live simulation updates in GUI

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QAction, QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QApplication,
@@ -128,6 +128,7 @@ class MainWindow(QMainWindow):
         self._create_menus()
         self.edit_action.setEnabled(bool(get_graph().nodes))
         self._create_docks()
+        self._start_refresh_timer()
 
     # ---- UI setup ----
 
@@ -185,6 +186,17 @@ class MainWindow(QMainWindow):
 
         dock.setWidget(panel)
         self.addDockWidget(Qt.RightDockWidgetArea, dock)
+
+    def _start_refresh_timer(self) -> None:
+        """Begin periodic updates of the simulation canvas."""
+        self._refresh_timer = QTimer(self)
+        self._refresh_timer.setInterval(100)
+        self._refresh_timer.timeout.connect(self._refresh_sim_canvas)
+        self._refresh_timer.start()
+
+    def _refresh_sim_canvas(self) -> None:
+        """Reload the canvas from the current engine graph."""
+        self.sim_canvas.load_model(GraphModel.from_dict(tick_engine.graph.to_dict()))
 
     # ---- actions ----
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ python -m Causal_Web.main --no-gui   # headless run
 ```
 
 Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
+The main window now refreshes automatically as nodes and edges change during the run.
 Use the **File** menu to load, save or start a new graph. Editing actions
 include **Edit Graph...**, **Undo** and **Redo** in the **Edit** menu.
 The **Graph View** dock now embeds a small toolbar offering **Add Node**,


### PR DESCRIPTION
## Summary
- refresh the simulation canvas automatically while the engine runs
- document live refresh behaviour in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688135983f1c83259dd3e44e147e0c43