### PR TITLE
Add pause/resume controls and fix graph loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ python -m Causal_Web.main            # with GUI
 python -m Causal_Web.main --no-gui   # headless run
 ```
 
-Use the on-screen controls to start or pause the simulation and adjust the tick rate. The tick rate and maximum tick count sliders now reside in the **Control Panel** window instead of the **Parameters** panel. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
+Use the on-screen controls to start, pause/resume or stop the simulation and adjust the tick rate. A tick counter shows the current tick and a **Tick Limit** field determines how many ticks to run. These inputs now reside in the **Control Panel** window which is docked to the top left. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
 The main window now refreshes automatically as nodes and edges change during the run.
 Use the **File** menu to load, save or start a new graph. Editing actions
 include **Edit Graph...**, **Undo** and **Redo** in the **Edit** menu.


### PR DESCRIPTION
## Summary
- fix refresh logic when loading graphs
- add tick limit and tick counter widgets
- implement pause/resume and stop controls for the simulation
- update README with new control panel features

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813b68a64083258a19f2ef8c4c0a60