### PR TITLE
Fix graph reset bug and add tick rate text box

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -190,7 +190,7 @@ class CausalGraph:
         for c in cells:
             ids.update(self.spatial_index.get(c, set()))
         ids.discard(node.id)
-        return [self.nodes[i] for i in ids]
+        return [self.nodes[i] for i in ids if i in self.nodes]
 
     # --- Bridge-aware connectivity helpers ---
     def get_bridge_neighbors(self, node_id, active_only=True):
@@ -501,6 +501,8 @@ class CausalGraph:
         self.bridges.clear()
         self.bridges_by_node.clear()
         self.tick_sources = []
+        self.spatial_index.clear()
+        self.meta_nodes.clear()
 
         nodes_data = data.get("nodes", [])
         if isinstance(nodes_data, dict):

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -14,6 +14,8 @@ from PySide6.QtWidgets import (
     QPushButton,
     QSlider,
     QSpinBox,
+    QLineEdit,
+    QHBoxLayout,
     QWidget,
     QVBoxLayout,
 )
@@ -181,7 +183,17 @@ class MainWindow(QMainWindow):
         self.tick_slider.setMaximum(20)
         self.tick_slider.setValue(int(Config.tick_rate))
         self.tick_slider.valueChanged.connect(self._tick_rate_changed)
-        layout.addRow("Tick Rate", self.tick_slider)
+
+        self.tick_edit = QLineEdit(str(Config.tick_rate))
+        self.tick_edit.editingFinished.connect(self._tick_rate_edited)
+
+        tick_rate_row = QWidget()
+        tick_rate_layout = QHBoxLayout(tick_rate_row)
+        tick_rate_layout.setContentsMargins(0, 0, 0, 0)
+        tick_rate_layout.addWidget(self.tick_slider)
+        tick_rate_layout.addWidget(self.tick_edit)
+
+        layout.addRow("Tick Rate", tick_rate_row)
 
         self.tick_label = QLabel("0")
         layout.addRow("Current Tick", self.tick_label)
@@ -235,6 +247,18 @@ class MainWindow(QMainWindow):
     def _tick_rate_changed(self, value: int) -> None:
         """Update ``Config.tick_rate`` from the slider."""
         Config.tick_rate = float(value)
+        self.tick_edit.setText(str(float(value)))
+
+    def _tick_rate_edited(self) -> None:
+        """Synchronize slider with manual text input."""
+        try:
+            value = float(self.tick_edit.text())
+        except ValueError:
+            # reset invalid text
+            self.tick_edit.setText(str(Config.tick_rate))
+            return
+        Config.tick_rate = value
+        self.tick_slider.setValue(int(value))
 
     def start_simulation(self) -> None:
         """Persist the active graph and launch the simulation thread.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ python -m Causal_Web.main            # with GUI
 python -m Causal_Web.main --no-gui   # headless run
 ```
 
-Use the on-screen controls to start, pause/resume or stop the simulation and adjust the tick rate. A tick counter shows the current tick and a **Tick Limit** field determines how many ticks to run. These inputs now reside in the **Control Panel** window which is docked to the top left. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
+Use the on-screen controls to start, pause/resume or stop the simulation and adjust the tick rate. A text box next to the tick rate slider displays the current value and allows direct entry&mdash;when focus leaves the field the slider synchronises to match. A tick counter shows the current tick and a **Tick Limit** field determines how many ticks to run. These inputs now reside in the **Control Panel** window which is docked to the top left. Windows can be freely resized and the graph view will scroll if its contents exceed the available space. Window resizing is now handled more robustly to avoid occasional freezes. As the simulation runs, a number of JSON log files are produced inside `Causal_Web/output`.
 The main window now refreshes automatically as nodes and edges change during the run.
 Use the **File** menu to load, save or start a new graph. Editing actions
 include **Edit Graph...**, **Undo** and **Redo** in the **Edit** menu.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -79,3 +79,18 @@ def test_edge_weights_affect_delay(monkeypatch):
     delay = edge.adjusted_delay(1.0, 1.0, kappa=1.0)
     assert delay >= 2
     Config.edge_weight_range = old_range
+
+
+def test_load_from_file_resets_spatial_index(tmp_path):
+    g = CausalGraph()
+    path1 = tmp_path / "g1.json"
+    data1 = {"nodes": {"A": {"x": 0, "y": 0}, "B": {"x": 50, "y": 0}}}
+    path1.write_text(json.dumps(data1))
+    g.load_from_file(str(path1))
+    assert {nid for ids in g.spatial_index.values() for nid in ids} == {"A", "B"}
+
+    path2 = tmp_path / "g2.json"
+    data2 = {"nodes": {"C": {"x": 0, "y": 0}}}
+    path2.write_text(json.dumps(data2))
+    g.load_from_file(str(path2))
+    assert {nid for ids in g.spatial_index.values() for nid in ids} == {"C"}


### PR DESCRIPTION
## Summary
- clear `spatial_index` and `meta_nodes` when loading a graph
- guard `nearby_nodes` against missing nodes
- add editable tick rate field next to slider
- document tick rate text box
- test that `load_from_file` resets the spatial index

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882655e97688325b71ca28ea217f1df