### PR TITLE
Fix interference type bug and improve panning

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -290,10 +290,26 @@ class CausalGraph:
         return inspection_log
 
     def _interference_type(self, phases):
-        if len(phases) < 2:
+        """Classify the interference pattern of a set of phases.
+
+        Parameters
+        ----------
+        phases : list
+            Sequence of phase values or ``(phase, tick)`` tuples.
+
+        Returns
+        -------
+        str
+            ``"constructive"`` when all phases are closely aligned,
+            ``"destructive"`` when they cancel out, ``"partial``" otherwise.
+        """
+
+        phase_vals = [p[0] if isinstance(p, (tuple, list)) else p for p in phases]
+
+        if len(phase_vals) < 2:
             return "neutral"
 
-        normalized = [p % (2 * math.pi) for p in phases]
+        normalized = [p % (2 * math.pi) for p in phase_vals]
 
         phase_diffs = [
             abs((p1 - p2 + math.pi) % (2 * math.pi) - math.pi)

--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -360,7 +360,11 @@ class CanvasWidget(QGraphicsView):
         self.scale(factor, factor)
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
-        if event.button() == Qt.MiddleButton:
+        if event.button() == Qt.MiddleButton or (
+            event.button() == Qt.LeftButton
+            and self.itemAt(event.pos()) is None
+            and not self._connect_mode
+        ):
             self._pan_start = event.pos()
             self.setCursor(Qt.ClosedHandCursor)
         else:
@@ -401,7 +405,10 @@ class CanvasWidget(QGraphicsView):
                 super().mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:
-        if event.button() == Qt.MiddleButton:
+        if (
+            event.button() in (Qt.MiddleButton, Qt.LeftButton)
+            and self._pan_start is not None
+        ):
             self._pan_start = None
             self.setCursor(Qt.ArrowCursor)
         else:

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ editing when clicked.
 Nodes can be repositioned directly in the **Graph View** by dragging them with
 the mouse. Interaction is handled by :class:`CanvasWidget`, a reusable
 ``QGraphicsView`` subclass that supports selection, dragging, zooming and panning.
+You can pan the scene by dragging with the left mouse button over empty space or
+using the middle mouse button.
 Dragging begins on mouse press for smooth movement and remains responsive after
 resizing the window. Debug messages are printed to the console whenever nodes
 are clicked or dragged.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -18,6 +18,12 @@ def test_interference_type_destructive():
     assert g._interference_type(phases) == "destructive"
 
 
+def test_interference_type_handles_tuples():
+    g = CausalGraph()
+    phases = [(0.0, 1), (0.05, 1)]
+    assert g._interference_type(phases) == "constructive"
+
+
 def test_detect_clusters():
     g = CausalGraph()
     for nid, freq in {"A": 1.0, "B": 1.02, "C": 1.5}.items():


### PR DESCRIPTION
## Summary
- handle tuple phase values in `CausalGraph._interference_type`
- allow panning the canvas with left mouse drag when clicking empty space
- document new panning behaviour in README
- test tuple handling

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688268e0212083258147e8095af93d0c