### PR TITLE
Optimize cluster detection

### DIFF
--- a/Causal_Web/engine/tick_engine.py
+++ b/Causal_Web/engine/tick_engine.py
@@ -186,8 +186,6 @@ def propagate_phases(global_tick):
 
 def evaluate_nodes(global_tick):
     """Evaluate only nodes flagged in :data:`nodes_to_update`."""
-    if global_tick % getattr(Config, "cluster_interval", 1) == 0:
-        graph.detect_clusters()
     reset_firing_limits()
     for node_id in list(nodes_to_update):
         node = graph.get_node(node_id)
@@ -823,6 +821,7 @@ def simulation_loop():
             propagate_phases(global_tick)
 
             if global_tick % getattr(Config, "cluster_interval", 1) == 0:
+                graph.detect_clusters()
                 evaluate_nodes(global_tick)
                 graph.update_meta_nodes(global_tick)
                 if not Config.headless:


### PR DESCRIPTION
## Summary
- avoid redundant cluster ID writes in `graph.detect_clusters`
- cache neighbor lookups in `graph.hierarchical_clusters`
- remove cluster detection from `evaluate_nodes`
- call `graph.detect_clusters` once per `cluster_interval` in `simulation_loop`

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882968eaa00832583ce96386082e07d