### PR TITLE
Refactor longest functions into service classes

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -472,86 +472,11 @@ class CausalGraph:
             meta.update_internal_state(tick_time)
 
     def to_dict(self):
-        node_list = [
-            {
-                "id": nid,
-                "x": n.x,
-                "y": n.y,
-                "ticks": [
-                    {
-                        "time": tick.time,
-                        "phase": tick.phase,
-                        "origin": tick.origin,
-                        "layer": getattr(tick, "layer", "tick"),
-                        "trace_id": getattr(tick, "trace_id", ""),
-                    }
-                    for tick in n.tick_history
-                ],
-                "phase": n.phase,
-                "coherence": n.coherence,
-                "decoherence": n.decoherence,
-                "frequency": n.frequency,
-                "refractory_period": n.refractory_period,
-                "base_threshold": n.base_threshold,
-                "collapse_origin": n.collapse_origin,
-                "is_classical": getattr(n, "is_classical", False),
-                "decoherence_streak": getattr(n, "_decoherence_streak", 0),
-                "last_tick_time": n.last_tick_time,
-                "subjective_ticks": n.subjective_ticks,
-                "law_wave_frequency": n.law_wave_frequency,
-                "trust_profile": n.trust_profile,
-                "phase_confidence": n.phase_confidence_index,
-                "goals": n.goals,
-                "origin_type": n.origin_type,
-                "generation_tick": n.generation_tick,
-                "parent_ids": n.parent_ids,
-                "node_type": n.node_type.value,
-                "coherence_credit": n.coherence_credit,
-                "decoherence_debt": n.decoherence_debt,
-                "phase_lock": n.phase_lock,
-            }
-            for nid, n in self.nodes.items()
-        ]
+        """Return a JSON serializable representation of the graph."""
 
-        return {
-            "nodes": node_list,
-            "superpositions": {
-                nid: {
-                    str(t): [
-                        round(float(p[0] if isinstance(p, (tuple, list)) else p), 4)
-                        for p in node.pending_superpositions[t]
-                    ]
-                    for t in node.pending_superpositions
-                }
-                for nid, node in self.nodes.items()
-                if node.pending_superpositions
-            },
-            "edges": [
-                {
-                    "from": e.source,
-                    "to": e.target,
-                    "delay": e.delay,
-                    "attenuation": e.attenuation,
-                    "density": e.density,
-                    "phase_shift": e.phase_shift,
-                }
-                for e in self.edges
-            ],
-            "bridges": [b.to_dict() for b in self.bridges],
-            "tick_sources": self.tick_sources,
-            "meta_nodes": {
-                mid: {
-                    "members": meta.member_ids,
-                    "constraints": meta.constraints,
-                    "type": meta.meta_type,
-                    "origin": meta.origin,
-                    "collapsed": meta.collapsed,
-                    "x": meta.x,
-                    "y": meta.y,
-                }
-                for mid, meta in self.meta_nodes.items()
-            },
-        }
+        from .serialization_service import GraphSerializationService
+
+        return GraphSerializationService(self).as_dict()
 
     def save_to_file(self, path):
         with open(path, "w") as f:

--- a/Causal_Web/engine/log_interpreter.py
+++ b/Causal_Web/engine/log_interpreter.py
@@ -365,84 +365,11 @@ class CWTLogInterpreter:
 
     # ------------------------------------------------------------
     def generate_narrative(self) -> str:
-        lines: List[str] = []
-        ticks = self.summary.get("tick_counts", {})
-        if ticks:
-            total = sum(ticks.values())
-            lines.append(
-                f"The simulation recorded {total} ticks across {len(ticks)} nodes."
-            )
-            for nid, cnt in ticks.items():
-                lines.append(f"- Node {nid} emitted {cnt} ticks.")
+        """Return a textual summary of the collected metrics."""
 
-        collapse = self.summary.get("collapse")
-        if collapse:
-            parts = [f"{n} at tick {t}" for n, t in collapse.items()]
-            lines.append("Nodes collapsed to classical states: " + ", ".join(parts))
+        from .serialization_service import NarrativeGeneratorService
 
-        coh = self.summary.get("coherence")
-        if coh:
-            for nid, data in coh.items():
-                lines.append(
-                    f"- {nid} coherence ranged from {data['min']:.3f} to {data['max']:.3f}."
-                )
-
-        deco = self.summary.get("decoherence")
-        if deco:
-            for nid, data in deco.items():
-                lines.append(
-                    f"- {nid} decoherence ranged from {data['min']:.3f} to {data['max']:.3f}."
-                )
-
-        if "clusters" in self.summary:
-            c = self.summary["clusters"]
-            if c["first_detected"] is not None:
-                lines.append(
-                    f"Clusters first appeared at tick {c['first_detected']} with up to {c['max_clusters']} cluster(s)."
-                )
-
-        if "law_drift" in self.summary:
-            events = sum(self.summary["law_drift"].values())
-            lines.append(f"Law drift events recorded: {events} total.")
-
-        bridges = self.summary.get("bridges")
-        if bridges:
-            for b, data in bridges.items():
-                state = "active" if data.get("active") else "inactive"
-                lines.append(
-                    f"- Bridge {b} ended {state}; last rupture at {data.get('last_rupture_tick')}"
-                )
-
-        if "collapse_origins" in self.summary:
-            parts = [f"{n} at {t}" for n, t in self.summary["collapse_origins"].items()]
-            lines.append("Collapse origins: " + ", ".join(parts))
-
-        if "collapse_chains" in self.summary:
-            for src, length in self.summary["collapse_chains"].items():
-                lines.append(f"- Collapse from {src} affected {length} nodes")
-
-        if "layer_transitions" in self.summary:
-            total = sum(self.summary["layer_transitions"]["totals"].values())
-            lines.append(f"Layer transitions recorded: {total}")
-
-        if "rerouting" in self.summary:
-            r = self.summary["rerouting"]
-            lines.append(
-                f"Rerouting events - recursive: {r['recursive']}, alt paths: {r['alt_path']}"
-            )
-
-        if "inspection_events" in self.summary:
-            lines.append(
-                f"Recorded {self.summary['inspection_events']} superposition inspections."
-            )
-
-        if "console" in self.summary:
-            c = self.summary["console"]
-            lines.append(
-                f"Console log contains {c['lines']} lines covering {c['ticks_logged']} ticks."
-            )
-
-        return "\n".join(lines)
+        return NarrativeGeneratorService(self.summary).generate()
 
     # ------------------------------------------------------------
     def run(self) -> None:

--- a/Causal_Web/engine/serialization_service.py
+++ b/Causal_Web/engine/serialization_service.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class GraphSerializationService:
+    """Serialize a ``CausalGraph`` into a dictionary."""
+
+    graph: Any
+
+    # ------------------------------------------------------------------
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "nodes": self._nodes(),
+            "superpositions": self._superpositions(),
+            "edges": self._edges(),
+            "bridges": self._bridges(),
+            "tick_sources": self.graph.tick_sources,
+            "meta_nodes": self._meta_nodes(),
+        }
+
+    # ------------------------------------------------------------------
+    def _nodes(self) -> List[Dict[str, Any]]:
+        nodes = []
+        for nid, n in self.graph.nodes.items():
+            nodes.append(
+                {
+                    "id": nid,
+                    "x": n.x,
+                    "y": n.y,
+                    "ticks": [
+                        {
+                            "time": t.time,
+                            "phase": t.phase,
+                            "origin": t.origin,
+                            "layer": getattr(t, "layer", "tick"),
+                            "trace_id": getattr(t, "trace_id", ""),
+                        }
+                        for t in n.tick_history
+                    ],
+                    "phase": n.phase,
+                    "coherence": n.coherence,
+                    "decoherence": n.decoherence,
+                    "frequency": n.frequency,
+                    "refractory_period": n.refractory_period,
+                    "base_threshold": n.base_threshold,
+                    "collapse_origin": n.collapse_origin,
+                    "is_classical": getattr(n, "is_classical", False),
+                    "decoherence_streak": getattr(n, "_decoherence_streak", 0),
+                    "last_tick_time": n.last_tick_time,
+                    "subjective_ticks": n.subjective_ticks,
+                    "law_wave_frequency": n.law_wave_frequency,
+                    "trust_profile": n.trust_profile,
+                    "phase_confidence": n.phase_confidence_index,
+                    "goals": n.goals,
+                    "origin_type": n.origin_type,
+                    "generation_tick": n.generation_tick,
+                    "parent_ids": n.parent_ids,
+                    "node_type": n.node_type.value,
+                    "coherence_credit": n.coherence_credit,
+                    "decoherence_debt": n.decoherence_debt,
+                    "phase_lock": n.phase_lock,
+                }
+            )
+        return nodes
+
+    # ------------------------------------------------------------------
+    def _superpositions(self) -> Dict[str, Dict[str, List[float]]]:
+        result = {}
+        for nid, node in self.graph.nodes.items():
+            if not node.pending_superpositions:
+                continue
+            result[nid] = {
+                str(t): [
+                    round(float(p[0] if isinstance(p, (tuple, list)) else p), 4)
+                    for p in node.pending_superpositions[t]
+                ]
+                for t in node.pending_superpositions
+            }
+        return result
+
+    # ------------------------------------------------------------------
+    def _edges(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "from": e.source,
+                "to": e.target,
+                "delay": e.delay,
+                "attenuation": e.attenuation,
+                "density": e.density,
+                "phase_shift": e.phase_shift,
+            }
+            for e in self.graph.edges
+        ]
+
+    # ------------------------------------------------------------------
+    def _bridges(self) -> List[Dict[str, Any]]:
+        return [b.to_dict() for b in self.graph.bridges]
+
+    # ------------------------------------------------------------------
+    def _meta_nodes(self) -> Dict[str, Dict[str, Any]]:
+        return {
+            mid: {
+                "members": m.member_ids,
+                "constraints": m.constraints,
+                "type": m.meta_type,
+                "origin": m.origin,
+                "collapsed": m.collapsed,
+                "x": m.x,
+                "y": m.y,
+            }
+            for mid, m in self.graph.meta_nodes.items()
+        }
+
+
+@dataclass
+class NarrativeGeneratorService:
+    """Build a human readable summary from interpreter metrics."""
+
+    summary: Dict[str, Any]
+
+    # ------------------------------------------------------------------
+    def generate(self) -> str:
+        lines: List[str] = []
+        lines.extend(self._tick_summary())
+        lines.extend(self._collapse_summary())
+        lines.extend(self._coherence_summary())
+        lines.extend(self._decoherence_summary())
+        lines.extend(self._cluster_summary())
+        lines.extend(self._law_drift_summary())
+        lines.extend(self._bridge_summary())
+        lines.extend(self._origin_summary())
+        lines.extend(self._chain_summary())
+        lines.extend(self._layer_summary())
+        lines.extend(self._reroute_summary())
+        lines.extend(self._inspection_summary())
+        lines.extend(self._console_summary())
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    def _tick_summary(self) -> List[str]:
+        result = []
+        ticks = self.summary.get("tick_counts", {})
+        if ticks:
+            total = sum(ticks.values())
+            result.append(
+                f"The simulation recorded {total} ticks across {len(ticks)} nodes."
+            )
+            for nid, cnt in ticks.items():
+                result.append(f"- Node {nid} emitted {cnt} ticks.")
+        return result
+
+    # ------------------------------------------------------------------
+    def _collapse_summary(self) -> List[str]:
+        result = []
+        collapse = self.summary.get("collapse")
+        if collapse:
+            parts = [f"{n} at tick {t}" for n, t in collapse.items()]
+            result.append("Nodes collapsed to classical states: " + ", ".join(parts))
+        return result
+
+    # ------------------------------------------------------------------
+    def _coherence_summary(self) -> List[str]:
+        result = []
+        coh = self.summary.get("coherence")
+        if coh:
+            for nid, data in coh.items():
+                result.append(
+                    f"- {nid} coherence ranged from {data['min']:.3f} to {data['max']:.3f}."
+                )
+        return result
+
+    # ------------------------------------------------------------------
+    def _decoherence_summary(self) -> List[str]:
+        result = []
+        deco = self.summary.get("decoherence")
+        if deco:
+            for nid, data in deco.items():
+                result.append(
+                    f"- {nid} decoherence ranged from {data['min']:.3f} to {data['max']:.3f}."
+                )
+        return result
+
+    # ------------------------------------------------------------------
+    def _cluster_summary(self) -> List[str]:
+        result = []
+        if "clusters" in self.summary:
+            c = self.summary["clusters"]
+            if c["first_detected"] is not None:
+                result.append(
+                    f"Clusters first appeared at tick {c['first_detected']} with up to {c['max_clusters']} cluster(s)."
+                )
+        return result
+
+    # ------------------------------------------------------------------
+    def _law_drift_summary(self) -> List[str]:
+        result = []
+        if "law_drift" in self.summary:
+            events = sum(self.summary["law_drift"].values())
+            result.append(f"Law drift events recorded: {events} total.")
+        return result
+
+    # ------------------------------------------------------------------
+    def _bridge_summary(self) -> List[str]:
+        result = []
+        bridges = self.summary.get("bridges")
+        if bridges:
+            for b, data in bridges.items():
+                state = "active" if data.get("active") else "inactive"
+                result.append(
+                    f"- Bridge {b} ended {state}; last rupture at {data.get('last_rupture_tick')}"
+                )
+        return result
+
+    # ------------------------------------------------------------------
+    def _origin_summary(self) -> List[str]:
+        result = []
+        if "collapse_origins" in self.summary:
+            parts = [f"{n} at {t}" for n, t in self.summary["collapse_origins"].items()]
+            result.append("Collapse origins: " + ", ".join(parts))
+        return result
+
+    # ------------------------------------------------------------------
+    def _chain_summary(self) -> List[str]:
+        result = []
+        if "collapse_chains" in self.summary:
+            for src, length in self.summary["collapse_chains"].items():
+                result.append(f"- Collapse from {src} affected {length} nodes")
+        return result
+
+    # ------------------------------------------------------------------
+    def _layer_summary(self) -> List[str]:
+        result = []
+        if "layer_transitions" in self.summary:
+            total = sum(self.summary["layer_transitions"]["totals"].values())
+            result.append(f"Layer transitions recorded: {total}")
+        return result
+
+    # ------------------------------------------------------------------
+    def _reroute_summary(self) -> List[str]:
+        result = []
+        if "rerouting" in self.summary:
+            r = self.summary["rerouting"]
+            result.append(
+                f"Rerouting events - recursive: {r['recursive']}, alt paths: {r['alt_path']}"
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    def _inspection_summary(self) -> List[str]:
+        result = []
+        if "inspection_events" in self.summary:
+            result.append(
+                f"Recorded {self.summary['inspection_events']} superposition inspections."
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    def _console_summary(self) -> List[str]:
+        result = []
+        if "console" in self.summary:
+            c = self.summary["console"]
+            result.append(
+                f"Console log contains {c['lines']} lines covering {c['ticks_logged']} ticks."
+            )
+        return result

--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -811,71 +811,8 @@ class MetaNodePanel(QDockWidget):
 
 
 def build_toolbar(main_window) -> QToolBar:
-    """Create the graph editing toolbar and property docks.
+    """Create the graph editing toolbar and property docks."""
 
-    The returned :class:`QToolBar` contains actions for adding nodes,
-    creating connections and applying automatic layout.  The caller is
-    responsible for embedding the toolbar, typically inside the Graph View
-    dock.  File and edit menu actions are handled separately by the main
-    window.
-    """
+    from .toolbar_services import ToolbarBuildService
 
-    toolbar = QToolBar("Graph", main_window)
-
-    add_node_action = QAction("Add Node", main_window)
-    add_node_action.triggered.connect(main_window.add_node)
-    toolbar.addAction(add_node_action)
-
-    add_conn_action = QAction("Add Connection", main_window)
-    add_conn_action.triggered.connect(main_window.start_add_connection)
-    toolbar.addAction(add_conn_action)
-
-    add_obs_action = QAction("Add Observer", main_window)
-    add_obs_action.triggered.connect(main_window.add_observer)
-    toolbar.addAction(add_obs_action)
-
-    add_meta_action = QAction("Add MetaNode", main_window)
-    add_meta_action.triggered.connect(main_window.add_meta_node)
-    toolbar.addAction(add_meta_action)
-
-    layout_action = QAction("Auto Layout", main_window)
-    layout_action.triggered.connect(main_window.canvas.auto_layout)
-    toolbar.addAction(layout_action)
-
-    main_window.node_panel = NodePanel(main_window, main_window.graph_window)
-    main_window.graph_window.addDockWidget(
-        Qt.RightDockWidgetArea, main_window.node_panel
-    )
-    main_window.node_panel.hide()
-
-    main_window.connection_panel = ConnectionPanel(
-        main_window, main_window.graph_window
-    )
-    main_window.graph_window.addDockWidget(
-        Qt.RightDockWidgetArea, main_window.connection_panel
-    )
-    main_window.connection_panel.hide()
-
-    main_window.observer_panel = ObserverPanel(main_window, main_window.graph_window)
-    main_window.graph_window.addDockWidget(
-        Qt.RightDockWidgetArea, main_window.observer_panel
-    )
-    main_window.observer_panel.hide()
-
-    main_window.meta_node_panel = MetaNodePanel(main_window, main_window.graph_window)
-    main_window.graph_window.addDockWidget(
-        Qt.RightDockWidgetArea, main_window.meta_node_panel
-    )
-    main_window.meta_node_panel.hide()
-
-    main_window.canvas.node_selected.connect(main_window.node_panel.show_node)
-    main_window.canvas.connection_request.connect(main_window.connection_panel.open_for)
-    main_window.canvas.connection_selected.connect(
-        main_window.connection_panel.show_connection
-    )
-    main_window.canvas.meta_node_selected.connect(
-        main_window.meta_node_panel.show_meta_node
-    )
-    main_window.canvas.observer_selected.connect(main_window.observer_panel.open_for)
-
-    return toolbar
+    return ToolbarBuildService(main_window).build()

--- a/Causal_Web/gui_pyside/toolbar_services.py
+++ b/Causal_Web/gui_pyside/toolbar_services.py
@@ -1,0 +1,80 @@
+"""Service objects for building the main toolbar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from PySide6.QtWidgets import QAction, QToolBar
+from PySide6.QtCore import Qt
+
+from .toolbar_builder import NodePanel, ConnectionPanel, ObserverPanel, MetaNodePanel
+
+
+@dataclass
+class ToolbarBuildService:
+    """Construct the graph editing toolbar and associated panels."""
+
+    main_window: Any
+
+    # ------------------------------------------------------------------
+    def build(self) -> QToolBar:
+        toolbar = self._create_toolbar()
+        self._create_panels()
+        self._connect_signals(toolbar)
+        return toolbar
+
+    # ------------------------------------------------------------------
+    def _create_toolbar(self) -> QToolBar:
+        mw = self.main_window
+        toolbar = QToolBar("Graph", mw)
+
+        add_node_action = QAction("Add Node", mw)
+        add_node_action.triggered.connect(mw.add_node)
+        toolbar.addAction(add_node_action)
+
+        add_conn_action = QAction("Add Connection", mw)
+        add_conn_action.triggered.connect(mw.start_add_connection)
+        toolbar.addAction(add_conn_action)
+
+        add_obs_action = QAction("Add Observer", mw)
+        add_obs_action.triggered.connect(mw.add_observer)
+        toolbar.addAction(add_obs_action)
+
+        add_meta_action = QAction("Add MetaNode", mw)
+        add_meta_action.triggered.connect(mw.add_meta_node)
+        toolbar.addAction(add_meta_action)
+
+        layout_action = QAction("Auto Layout", mw)
+        layout_action.triggered.connect(mw.canvas.auto_layout)
+        toolbar.addAction(layout_action)
+
+        return toolbar
+
+    # ------------------------------------------------------------------
+    def _create_panels(self) -> None:
+        mw = self.main_window
+        mw.node_panel = NodePanel(mw, mw.graph_window)
+        mw.graph_window.addDockWidget(Qt.RightDockWidgetArea, mw.node_panel)
+        mw.node_panel.hide()
+
+        mw.connection_panel = ConnectionPanel(mw, mw.graph_window)
+        mw.graph_window.addDockWidget(Qt.RightDockWidgetArea, mw.connection_panel)
+        mw.connection_panel.hide()
+
+        mw.observer_panel = ObserverPanel(mw, mw.graph_window)
+        mw.graph_window.addDockWidget(Qt.RightDockWidgetArea, mw.observer_panel)
+        mw.observer_panel.hide()
+
+        mw.meta_node_panel = MetaNodePanel(mw, mw.graph_window)
+        mw.graph_window.addDockWidget(Qt.RightDockWidgetArea, mw.meta_node_panel)
+        mw.meta_node_panel.hide()
+
+    # ------------------------------------------------------------------
+    def _connect_signals(self, toolbar: QToolBar) -> None:
+        mw = self.main_window
+        mw.canvas.node_selected.connect(mw.node_panel.show_node)
+        mw.canvas.connection_request.connect(mw.connection_panel.open_for)
+        mw.canvas.connection_selected.connect(mw.connection_panel.show_connection)
+        mw.canvas.meta_node_selected.connect(mw.meta_node_panel.show_meta_node)
+        mw.canvas.observer_selected.connect(mw.observer_panel.open_for)

--- a/README.md
+++ b/README.md
@@ -586,8 +586,10 @@ Large functions have been decomposed into reusable services. The `NodeTickServic
 encapsulates the tick emission lifecycle while `GraphLoadService` handles JSON
 graph loading. Metric collection is delegated to `NodeMetricsService` which
 replaced the bulky `log_metrics_per_tick` function. The `NodeTickDecisionService`
-isolates the tick decision logic from `Node.should_tick`. All services live in
-`Causal_Web/engine/services.py`.
+isolates the tick decision logic from `Node.should_tick`. Serialization and
+narrative generation are now handled by `GraphSerializationService` and
+`NarrativeGeneratorService`. GUI setup moved to `ToolbarBuildService`. All
+services live in `Causal_Web/engine/services.py` or the GUI package.
 
 ### Identified long functions
 
@@ -605,11 +607,8 @@ isolates the tick decision logic from `Node.should_tick`. All services live in
 - `engine/node.py:should_tick` – 111 lines
 - `engine/node.py:apply_tick` – 143 lines
 - `engine/graph.py:detect_clusters` – 55 lines
-- `engine/graph.py:to_dict` – 81 lines
 - `engine/graph.py:load_from_file` – 138 lines
 - `engine/explanation_rules.py:_match_emergence_events` – 51 lines
-- `engine/log_interpreter.py:generate_narrative` – 79 lines
-- `gui_pyside/toolbar_builder.py:build_toolbar` – 69 lines
 - `gui_pyside/toolbar_builder.py:__init__` – 57 lines
 - `gui_pyside/toolbar_builder.py:__init__` – 101 lines
 - `gui_pyside/toolbar_builder.py:show_connection` – 52 lines


### PR DESCRIPTION
## Summary
- decompose graph serialization into `GraphSerializationService`
- generate narrative through `NarrativeGeneratorService`
- move toolbar setup logic into `ToolbarBuildService`
- use new services in `graph`, `log_interpreter` and toolbar builder
- update README with new services

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688387ea4e0c8325b63ba6007783e7ad