### PR TITLE
Improve type annotations and JSON structures

### DIFF
--- a/Causal_Web/engine/services.py
+++ b/Causal_Web/engine/services.py
@@ -15,6 +15,7 @@ from ..config import Config
 from .logger import log_json
 from .tick import GLOBAL_TICK_POOL
 from .node import Node, NodeType
+from .graph import CausalGraph
 from . import tick_engine as te
 
 
@@ -440,7 +441,7 @@ class NodeMetricsService:
 class GraphLoadService:
     """Populate a :class:`Graph` from a JSON file."""
 
-    def __init__(self, graph, path: str):
+    def __init__(self, graph: "CausalGraph", path: str) -> None:
         self.graph = graph
         self.path = path
 
@@ -470,7 +471,7 @@ class GraphLoadService:
         g.meta_nodes.clear()
 
     # ------------------------------------------------------------------
-    def _load_nodes(self, nodes_data):
+    def _load_nodes(self, nodes_data: list | dict) -> None:
         g = self.graph
         if isinstance(nodes_data, dict):
             nodes_iter = [dict(v, id=k) for k, v in nodes_data.items()]
@@ -500,7 +501,7 @@ class GraphLoadService:
                 g.nodes[node_id].goals = goals
 
     # ------------------------------------------------------------------
-    def _load_edges(self, edges_data):
+    def _load_edges(self, edges_data: list | dict) -> None:
         g = self.graph
         if isinstance(edges_data, dict):
             edges_iter = []
@@ -547,7 +548,7 @@ class GraphLoadService:
             )
 
     # ------------------------------------------------------------------
-    def _load_bridges(self, bridges):
+    def _load_bridges(self, bridges: list[dict]) -> None:
         g = self.graph
         for bridge in bridges:
             src = bridge.get("from")
@@ -569,7 +570,7 @@ class GraphLoadService:
             )
 
     # ------------------------------------------------------------------
-    def _load_meta_nodes(self, meta_nodes):
+    def _load_meta_nodes(self, meta_nodes: dict) -> None:
         g = self.graph
         from .meta_node import MetaNode
 

--- a/Causal_Web/graph/io.py
+++ b/Causal_Web/graph/io.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from .types import GraphDict
+
 from .model import GraphModel
 
 
 def load_graph(path: str) -> GraphModel:
     """Load a graph from ``path`` and return a :class:`GraphModel`."""
     with open(path) as f:
-        data = json.load(f)
+        data: GraphDict = json.load(f)
     _validate_graph(data)
     return GraphModel.from_dict(data)
 
@@ -27,7 +29,7 @@ def new_graph(starter_node: bool = False) -> GraphModel:
     return GraphModel.blank(starter_node)
 
 
-def _validate_graph(data: dict[str, Any]) -> None:
+def _validate_graph(data: GraphDict) -> None:
     if "nodes" not in data or "edges" not in data:
         raise ValueError("Graph file must contain 'nodes' and 'edges'")
     if not isinstance(data["nodes"], (dict, list)):

--- a/Causal_Web/graph/types.py
+++ b/Causal_Web/graph/types.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, TypedDict
+
+# Reusable typed mappings for graph JSON files
+
+NodeData = TypedDict(
+    "NodeData",
+    {
+        "id": str,
+        "x": float,
+        "y": float,
+        "frequency": float,
+        "refractory_period": float,
+        "base_threshold": float,
+        "phase": float,
+        "origin_type": str,
+        "generation_tick": int,
+        "parent_ids": List[str],
+        "goals": Dict[str, Any],
+    },
+    total=False,
+)
+
+EdgeData = TypedDict(
+    "EdgeData",
+    {
+        "from": str,
+        "to": str,
+        "delay": float,
+        "attenuation": float,
+        "density": float,
+        "phase_shift": float,
+        "weight": float,
+    },
+    total=False,
+)
+
+BridgeData = TypedDict(
+    "BridgeData",
+    {
+        "from": str,
+        "to": str,
+        "bridge_type": str,
+        "phase_offset": float,
+        "drift_tolerance": float | None,
+        "decoherence_limit": float | None,
+        "initial_strength": float,
+        "medium_type": str,
+        "mutable": bool,
+    },
+    total=False,
+)
+
+MetaNodeData = TypedDict(
+    "MetaNodeData",
+    {
+        "members": List[str],
+        "constraints": Dict[str, Any],
+        "type": str,
+        "origin": str,
+        "collapsed": bool,
+        "x": float,
+        "y": float,
+    },
+    total=False,
+)
+
+ObserverData = TypedDict(
+    "ObserverData",
+    {
+        "id": str,
+        "monitors": List[str],
+        "frequency": float,
+        "target_nodes": List[str],
+        "x": float,
+        "y": float,
+    },
+    total=False,
+)
+
+GraphDict = TypedDict(
+    "GraphDict",
+    {
+        "nodes": Dict[str, NodeData] | List[NodeData],
+        "edges": List[EdgeData],
+        "bridges": List[BridgeData],
+        "tick_sources": List[Dict[str, Any]],
+        "observers": List[ObserverData],
+        "meta_nodes": Dict[str, MetaNodeData],
+    },
+    total=False,
+)


### PR DESCRIPTION
## Summary
- add TypedDict structures for JSON graph data
- annotate GraphModel using these TypedDicts
- expand typing across CausalGraph helpers
- add type hints to GraphLoadService helpers

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883af0d4d6c8325aca6d460fd1e6c7d