### PR TITLE
Add type hints to CausalGraph initializer

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -17,7 +17,9 @@ from .logger import log_json
 class CausalGraph:
     """Container for nodes, edges and bridges comprising the simulation."""
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize empty collections tracking graph elements."""
+
         self.nodes = {}
         self.edges = []
         self.edges_from = defaultdict(list)


### PR DESCRIPTION
## Summary
- annotate `CausalGraph.__init__` with return type and basic docstring

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b3f98c488325827d57b4aa795b4b