### PR TITLE
Add missing type hints

### DIFF
--- a/Causal_Web/engine/node_services.py
+++ b/Causal_Web/engine/node_services.py
@@ -1,16 +1,21 @@
 """Service objects related to :class:`Node` lifecycle."""
 
+from __future__ import annotations
+
 from collections import defaultdict, deque
-from typing import Optional, List, Dict, Set
+from typing import Optional, List, Dict, Set, TYPE_CHECKING
 
 
 from ..config import Config
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .node import Node
 
 
 class NodeInitializationService:
     """Initialize a :class:`~Causal_Web.engine.node.Node` instance."""
 
-    def __init__(self, node):
+    def __init__(self, node: Node) -> None:
         self.node = node
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `TYPE_CHECKING` guard in `node_services` for importing `Node`
- annotate `NodeInitializationService.__init__` with `Node` type

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b6b769bc8325a2e785d55d812df2