### PR TITLE
Add type hints to tick modules

### DIFF
--- a/Causal_Web/engine/tick_router.py
+++ b/Causal_Web/engine/tick_router.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+from .node import Node
+from .tick import Tick
+
+
 class TickRouter:
     """Route ticks across LCCM layers"""
 
@@ -22,9 +28,9 @@ class TickRouter:
         return cls.LAYERS[-1]
 
     @classmethod
-    def route_tick(cls, node, tick):
+    def route_tick(cls, node: Node, tick: Tick) -> None:
+        """Update ``tick`` to the next layer and record the transition."""
         from ..config import Config
-        import json
         from .logger import log_json
 
         new_layer = cls.next_layer(tick.layer)

--- a/Causal_Web/engine/tick_seeder.py
+++ b/Causal_Web/engine/tick_seeder.py
@@ -1,6 +1,6 @@
 import json
 import random
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from .graph import CausalGraph
 from ..config import Config
@@ -10,7 +10,13 @@ from .logger import log_json
 class TickSeeder:
     """Injects ticks into the graph under configurable strategies."""
 
-    def __init__(self, graph: CausalGraph, config: Dict = None, log_path: str = None):
+    def __init__(
+        self,
+        graph: CausalGraph,
+        config: Optional[Dict] = None,
+        log_path: Optional[str] = None,
+    ) -> None:
+        """Create a new seeder for *graph* with optional configuration."""
         self.graph = graph
         self.config = config or getattr(Config, "seeding", {"strategy": "static"})
         self.log_path = log_path or Config.output_path("tick_seed_log.json")


### PR DESCRIPTION
## Summary
- annotate constructor for TickSeeder
- type Node and Tick in TickRouter.route_tick

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883b6eebfc08325bd16bb47e6b39c81