### PR TITLE
Annotate service methods

### DIFF
--- a/Causal_Web/engine/observer.py
+++ b/Causal_Web/engine/observer.py
@@ -1,15 +1,22 @@
+from typing import Any, Dict, List
+
+
 class Observer:
     """Epistemic observer with limited perceptual window."""
 
-    def __init__(self, observer_id: str, window: int = 10):
+    def __init__(self, observer_id: str, window: int = 10) -> None:
+        """Create a new ``Observer`` instance."""
+
         self.id = observer_id
         self.window = window
-        self.memory = []  # list of {'tick': int, 'events': [...]}
-        self.belief_state = {}
-        self.disagreement = []  # list of diffs per tick
+        self.memory: List[Dict[str, Any]] = []
+        self.belief_state: Dict[int, Dict[str, int]] = {}
+        self.disagreement: List[Any] = []
 
-    def observe(self, graph, tick_time: int):
-        events = []
+    def observe(self, graph: Any, tick_time: int) -> None:
+        """Record events at ``tick_time`` from ``graph``."""
+
+        events: List[Dict[str, Any]] = []
         seen_nodes = set()
         for node in graph.nodes.values():
             if node.tick_history and node.tick_history[-1].time == tick_time:
@@ -41,9 +48,10 @@ class Observer:
         if len(self.memory) > self.window:
             self.memory.pop(0)
 
-    def infer_field_state(self):
-        """Simple inference based on memory of recent events."""
-        state = {}
+    def infer_field_state(self) -> Dict[str, int]:
+        """Return a naive belief state derived from recent events."""
+
+        state: Dict[str, int] = {}
         for entry in self.memory:
             for ev in entry["events"]:
                 state.setdefault(ev["node"], 0)

--- a/Causal_Web/engine/serialization_service.py
+++ b/Causal_Web/engine/serialization_service.py
@@ -12,6 +12,8 @@ class GraphSerializationService:
 
     # ------------------------------------------------------------------
     def as_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation of the graph."""
+
         return {
             "nodes": self._nodes(),
             "superpositions": self._superpositions(),
@@ -123,6 +125,8 @@ class NarrativeGeneratorService:
 
     # ------------------------------------------------------------------
     def generate(self) -> str:
+        """Return a formatted narrative summarizing the simulation."""
+
         lines: List[str] = []
         lines.extend(self._tick_summary())
         lines.extend(self._collapse_summary())

--- a/Causal_Web/engine/services.py
+++ b/Causal_Web/engine/services.py
@@ -26,10 +26,12 @@ class NodeTickService:
     node: Node
     tick_time: int
     phase: float
-    graph: any
+    graph: Any
     origin: str = "self"
 
     def process(self) -> None:
+        """Execute the node tick lifecycle for ``tick_time``."""
+
         if not self._pre_check():
             return
         self._register_tick()
@@ -142,6 +144,8 @@ class EdgePropagationService:
     graph: Any
 
     def propagate(self) -> None:
+        """Propagate the tick across all outgoing edges."""
+
         self._log_recursion()
         from .tick_engine import kappa
 
@@ -241,6 +245,8 @@ class NodeMetricsResultService:
     last_coherence: dict
 
     def process(self) -> dict:
+        """Aggregate node metric results into structured logs."""
+
         self._init_logs()
         for rec in self.results:
             self._handle_record(*rec)
@@ -336,7 +342,7 @@ class NodeMetricsResultService:
 class NodeMetricsService:
     """Collect and persist per-tick node metrics."""
 
-    graph: any
+    graph: Any
     last_coherence: dict = field(default_factory=dict)
 
     # ------------------------------------------------------------------
@@ -444,11 +450,15 @@ class GraphLoadService:
     """Populate a :class:`Graph` from a JSON file."""
 
     def __init__(self, graph: "CausalGraph", path: str) -> None:
+        """Create a loader for ``graph`` using ``path`` as input."""
+
         self.graph = graph
         self.path = path
 
     # ------------------------------------------------------------------
     def load(self) -> None:
+        """Read ``path`` and populate ``graph`` with its contents."""
+
         with open(self.path, "r") as f:
             data = json.load(f)
         self._reset()
@@ -752,6 +762,8 @@ class BridgeApplyService:
     graph: Any
 
     def process(self) -> None:
+        """Run the bridge activation sequence for ``tick_time``."""
+
         self._gather_nodes()
         self.bridge.decay(self.tick_time)
         self.bridge.try_reform(self.tick_time, self.node_a, self.node_b)
@@ -907,6 +919,8 @@ class GlobalDiagnosticsService:
     graph: Any
 
     def export(self) -> None:
+        """Write overall diagnostics derived from simulation logs."""
+
         deco_lines = self._load_log("decoherence_log.json")
         if not deco_lines:
             return


### PR DESCRIPTION
## Summary
- add type annotations and docstrings to Observer
- document serialization services
- update services with typed public method signatures

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b6dafe3c8325a33808cb0635089f