### PR TITLE
Fix config timestamp

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -230,9 +230,9 @@ class Config:
         str
             Absolute path to the newly created directory.
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
-        ts = datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
         run_dir = os.path.join(cls.runs_dir, f"{ts}__{slug}")
         os.makedirs(run_dir, exist_ok=True)
 

--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -49,7 +49,6 @@ class Bridge:
         seeded: bool = True,
         formed_at_tick: int = 0,
     ) -> None:
-
         """Create a new bridge between two node identifiers."""
         self.node_a_id = node_a_id
         self.node_b_id = node_b_id

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ directories for each run. A new run directory is created via
 `graph.json` and `config.json` files are copied into each run's `input/`
 subdirectory so every run has a frozen copy of its inputs. Basic metadata
 about the run is inserted into the PostgreSQL `runs` table automatically. The
+Timestamps are generated in UTC to avoid timezone discrepancies.
 location of `runs/` and other output folders can be customised using the
 `paths` section in `input/config.json`.
 Logging for each file can be enabled or disabled individually using


### PR DESCRIPTION
## Summary
- use timezone-aware UTC timestamp in `Config.new_run`
- document UTC timestamps for run folders
- code formatting

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883bd24bc048325802e3a1daada37dc