### PR TITLE
Fix module imports

### DIFF
--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -270,6 +270,8 @@ class Bridge:
 
     def apply(self, tick_time: int, graph: "CausalGraph") -> None:
         """Apply the bridge logic for ``tick_time``."""
+        from .services import BridgeApplyService
+
         BridgeApplyService(self, tick_time, graph).process()
 
     def to_dict(self) -> dict:

--- a/Causal_Web/engine/tick_engine/__init__.py
+++ b/Causal_Web/engine/tick_engine/__init__.py
@@ -22,6 +22,7 @@ from .evaluator import (
     trigger_csp,
     check_propagation,
 )
+from . import bridge_manager, log_utils
 from .bridge_manager import dynamic_bridge_management
 from .log_utils import (
     log_bridge_states,


### PR DESCRIPTION
## Summary
- resolve NameError from missing BridgeApplyService import
- attach tick engine modules at runtime without NameError

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883be32638c832588802d8f8ec7a29d