### PR TITLE
Refactor logging to use common mixin

### DIFF
--- a/Causal_Web/engine/base.py
+++ b/Causal_Web/engine/base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Shared base classes and mixins for engine components."""
+
+from typing import Any
+
+from ..config import Config
+from .logger import log_json
+
+
+class LoggingMixin:
+    """Provide helper methods for JSON event logging."""
+
+    def _log(self, name: str, record: dict[str, Any]) -> None:
+        """Write ``record`` to the configured log ``name``."""
+        log_json(Config.output_path(name), record)

--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -6,7 +6,7 @@ from random import random
 from typing import Optional, TYPE_CHECKING
 import json
 from ..config import Config
-from .logger import log_json
+from .base import LoggingMixin
 
 if TYPE_CHECKING:
     from .node import Node
@@ -34,7 +34,7 @@ class BridgeEvent:
     coherence_at_event: Optional[float] = None
 
 
-class Bridge:
+class Bridge(LoggingMixin):
     def __init__(
         self,
         node_a_id: str,
@@ -110,7 +110,7 @@ class Bridge:
         }
         if conditions is not None:
             record["conditions"] = conditions
-        log_json(Config.output_path("bridge_dynamics_log.json"), record)
+        self._log("bridge_dynamics_log.json", record)
 
     def update_state(self, tick: int) -> None:
         """Update ``self.state`` based on fatigue and activation."""
@@ -156,7 +156,7 @@ class Bridge:
             target=self.node_b_id,
             coherence_at_event=value,
         )
-        log_json(Config.output_path("event_log.json"), event.__dict__)
+        self._log("event_log.json", event.__dict__)
 
     def _log_rupture(self, tick: int, reason: str, coherence: float | None) -> None:
         record = {
@@ -168,7 +168,7 @@ class Bridge:
             "coherence": round(coherence, 4) if coherence is not None else None,
             "fatigue": round(self.fatigue, 3),
         }
-        log_json(Config.output_path("bridge_rupture_log.json"), record)
+        self._log("bridge_rupture_log.json", record)
 
     def probabilistic_bridge_failure(
         self,
@@ -196,8 +196,8 @@ class Bridge:
         ):
             self.current_strength = max(0.0, self.current_strength - 0.1)
             duration = tick_time - self.last_active_tick
-            log_json(
-                Config.output_path("bridge_decay_log.json"),
+            self._log(
+                "bridge_decay_log.json",
                 {
                     "tick": tick_time,
                     "bridge": self.bridge_id,
@@ -231,8 +231,8 @@ class Bridge:
             self.active = True
             self.last_reform_tick = tick_time
             self.coherence_at_reform = coherence
-            log_json(
-                Config.output_path("bridge_reformation_log.json"),
+            self._log(
+                "bridge_reformation_log.json",
                 {
                     "tick": tick_time,
                     "bridge": self.bridge_id,

--- a/README.md
+++ b/README.md
@@ -595,7 +595,8 @@ narrative generation are now handled by `GraphSerializationService` and
 services live in `Causal_Web/engine/services.py` or the GUI package.
 Recent refactors introduced `ConnectionDisplayService` for showing existing
 links, `GlobalDiagnosticsService` for exporting run metrics and
-`SIPRecombinationService` for recombination-based spawning.
+`SIPRecombinationService` for recombination-based spawning. A lightweight
+`LoggingMixin` now centralises JSON logging for classes like `Node` and `Bridge`.
 
 ### Identified long functions
 


### PR DESCRIPTION
## Summary
- centralize JSON logging helpers with `LoggingMixin`
- update `Node` and `Bridge` to inherit from new mixin
- use mixin in logging calls
- document logging refactor in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c2882b3c83259b55f7dc1ebfcff3