### PR TITLE
Refactor logging utilities

### DIFF
--- a/Causal_Web/engine/base.py
+++ b/Causal_Web/engine/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Shared base classes and mixins for engine components."""
 
+import os
 from typing import Any
 
 from ..config import Config
@@ -14,3 +15,16 @@ class LoggingMixin:
     def _log(self, name: str, record: dict[str, Any]) -> None:
         """Write ``record`` to the configured log ``name``."""
         log_json(Config.output_path(name), record)
+
+
+class OutputDirMixin:
+    """Provide an ``output_dir`` attribute and path resolution helper."""
+
+    def __init__(self, output_dir: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        base = os.path.join(os.path.dirname(__file__), "..")
+        self.output_dir = output_dir or os.path.join(base, "output")
+
+    def _path(self, name: str) -> str:
+        """Return absolute path for ``name`` inside :attr:`output_dir`."""
+        return os.path.join(self.output_dir, name)

--- a/Causal_Web/engine/causal_analyst.py
+++ b/Causal_Web/engine/causal_analyst.py
@@ -84,14 +84,17 @@ class ExplanationEvent:
     explanation_text: str
 
 
-class CausalAnalyst:
+from .base import OutputDirMixin
+
+
+class CausalAnalyst(OutputDirMixin):
     """Analyze logs to generate causal explanations."""
 
     def __init__(
         self, output_dir: Optional[str] = None, input_dir: Optional[str] = None
     ) -> None:
+        super().__init__(output_dir=output_dir)
         base = os.path.join(os.path.dirname(__file__), "..")
-        self.output_dir = output_dir or os.path.join(base, "output")
         self.input_dir = input_dir or os.path.join(base, "input")
         self.logs: Dict[str, Dict[int, Dict]] = {}
         self.graph: Dict = {}
@@ -99,10 +102,6 @@ class CausalAnalyst:
         self.causal_chains: List[Dict] = []
         self.params = {"window": 8}
         self.summary: Dict[str, Dict] = {}
-
-    # ------------------------------------------------------------
-    def _path(self, name: str) -> str:
-        return os.path.join(self.output_dir, name)
 
     # ------------------------------------------------------------
     def load_logs(self) -> None:

--- a/Causal_Web/engine/log_interpreter.py
+++ b/Causal_Web/engine/log_interpreter.py
@@ -3,6 +3,7 @@ import os
 from typing import Dict, List
 
 from .causal_analyst import CausalAnalyst
+from .base import OutputDirMixin
 
 
 def _load_json_lines(path: str) -> Dict[str, Dict]:
@@ -22,21 +23,17 @@ def _load_json_lines(path: str) -> Dict[str, Dict]:
     return data
 
 
-class CWTLogInterpreter:
+class CWTLogInterpreter(OutputDirMixin):
     """Simple multilayer interpreter for CWT logs."""
 
     def __init__(
         self, output_dir: str | None = None, graph_path: str | None = None
     ) -> None:
+        super().__init__(output_dir=output_dir)
         base = os.path.join(os.path.dirname(__file__), "..")
-        self.output_dir = output_dir or os.path.join(base, "output")
         self.graph_path = graph_path or os.path.join(base, "input", "graph.json")
         self.graph = {}
         self.summary: Dict[str, Dict] = {}
-
-    # ------------------------------------------------------------
-    def _path(self, name: str) -> str:
-        return os.path.join(self.output_dir, name)
 
     # ------------------------------------------------------------
     def load_graph(self) -> None:

--- a/README.md
+++ b/README.md
@@ -597,6 +597,8 @@ Recent refactors introduced `ConnectionDisplayService` for showing existing
 links, `GlobalDiagnosticsService` for exporting run metrics and
 `SIPRecombinationService` for recombination-based spawning. A lightweight
 `LoggingMixin` now centralises JSON logging for classes like `Node` and `Bridge`.
+`OutputDirMixin` adds a common `_path` helper used by the log interpreter and
+causal analyst.
 
 ### Identified long functions
 


### PR DESCRIPTION
## Summary
- share output directory helpers via new `OutputDirMixin`
- refactor `CWTLogInterpreter` and `CausalAnalyst` to inherit the mixin
- document the mixin in the README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c4c295e88325b7862110d5aec6a1