### PR TITLE
Refactor logging utilities

### DIFF
--- a/Causal_Web/engine/base.py
+++ b/Causal_Web/engine/base.py
@@ -18,6 +18,14 @@ class LoggingMixin:
         log_json(Config.output_path(name), record)
 
 
+class PathLoggingMixin:
+    """Provide helper method for logging to an explicit file path."""
+
+    def _log_path(self, path: str, record: dict[str, Any]) -> None:
+        """Write ``record`` directly to ``path``."""
+        log_json(path, record)
+
+
 class OutputDirMixin:
     """Provide an ``output_dir`` attribute and path resolution helper."""
 

--- a/Causal_Web/engine/explanation_rules.py
+++ b/Causal_Web/engine/explanation_rules.py
@@ -5,15 +5,16 @@ import os
 from typing import Dict, List
 
 from .causal_analyst import ExplanationEvent, CausalAnalyst
+from .base import OutputDirMixin
 
 
-class ExplanationRuleMatcher:
+class ExplanationRuleMatcher(OutputDirMixin):
     """Service object to evaluate explanation rules."""
 
     def __init__(self, analyst: CausalAnalyst) -> None:
+        super().__init__(output_dir=analyst.output_dir)
         self.analyst = analyst
         self.logs = analyst.logs
-        self.output_dir = analyst.output_dir
         self.explanations: List[ExplanationEvent] = analyst.explanations
 
     # lifecycle stages
@@ -144,7 +145,7 @@ class ExplanationRuleMatcher:
                 )
 
     def _match_emergence_events(self) -> None:
-        emergence_path = os.path.join(self.output_dir, "node_emergence_log.json")
+        emergence_path = self._path("node_emergence_log.json")
         if not os.path.exists(emergence_path):
             return
         with open(emergence_path) as f:
@@ -175,9 +176,7 @@ class ExplanationRuleMatcher:
                     c = rec.get("id")
                     tick = rec.get("tick", 0)
                     collapse_id = None
-                    collapse_log_path = os.path.join(
-                        self.output_dir, "collapse_chain_log.json"
-                    )
+                    collapse_log_path = self._path("collapse_chain_log.json")
                     if os.path.exists(collapse_log_path):
                         with open(collapse_log_path) as cf:
                             for ln in cf:
@@ -196,7 +195,7 @@ class ExplanationRuleMatcher:
                     )
 
     def _match_propagation_failures(self) -> None:
-        fail_path = os.path.join(self.output_dir, "propagation_failure_log.json")
+        fail_path = self._path("propagation_failure_log.json")
         if not os.path.exists(fail_path):
             return
         with open(fail_path) as f:

--- a/Causal_Web/engine/log_interpreter.py
+++ b/Causal_Web/engine/log_interpreter.py
@@ -14,9 +14,7 @@ class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
     ) -> None:
         super().__init__(output_dir=output_dir)
         base = os.path.join(os.path.dirname(__file__), "..")
-        self.graph_path = graph_path or os.path.join(
-            base, "input", "graph.json"
-        )
+        self.graph_path = graph_path or os.path.join(base, "input", "graph.json")
         self.graph = {}
         self.summary: Dict[str, Dict] = {}
 
@@ -43,9 +41,7 @@ class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
         for entry in records:
             for edge in entry.get("edges", []):
                 key = f"{edge['source']}->{edge['target']}"
-                stats.setdefault(
-                    key, {"min": float("inf"), "max": float("-inf")}
-                )
+                stats.setdefault(key, {"min": float("inf"), "max": float("-inf")})
                 d = edge.get("delay", 0)
                 if d < stats[key]["min"]:
                     stats[key]["min"] = d
@@ -57,7 +53,7 @@ class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
 
     # ------------------------------------------------------------
     def interpret_collapse(self) -> None:
-        path = os.path.join(self.output_dir, "classicalization_map.json")
+        path = self._path("classicalization_map.json")
         lines = self.load_json_lines(path)
         if not lines:
             return
@@ -74,7 +70,7 @@ class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
 
     # ------------------------------------------------------------
     def interpret_coherence(self) -> None:
-        path = os.path.join(self.output_dir, "coherence_log.json")
+        path = self._path("coherence_log.json")
         lines = self.load_json_lines(path)
         if not lines:
             return
@@ -90,7 +86,7 @@ class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
 
     # ------------------------------------------------------------
     def interpret_law_wave(self) -> None:
-        path = os.path.join(self.output_dir, "law_wave_log.json")
+        path = self._path("law_wave_log.json")
         lines = self.load_json_lines(path)
         if not lines:
             return
@@ -317,8 +313,7 @@ class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
         with open(path) as f:
             data = json.load(f)
         counts = {
-            nid: len(n.get("ticks", []))
-            for nid, n in data.get("nodes", {}).items()
+            nid: len(n.get("ticks", [])) for nid, n in data.get("nodes", {}).items()
         }
         layer_summary: Dict[str, Dict[str, int]] = {}
         for nid, n in data.get("nodes", {}).items():
@@ -384,11 +379,11 @@ class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
         self.interpret_tick_trace()
         self.interpret_inspection()
         self.interpret_console_log()
-        out_path = os.path.join(self.output_dir, "interpretation_log.json")
+        out_path = self._path("interpretation_log.json")
         with open(out_path, "w") as f:
             json.dump(self.summary, f, indent=2)
         text_summary = self.generate_narrative()
-        text_path = os.path.join(self.output_dir, "interpretation_summary.txt")
+        text_path = self._path("interpretation_summary.txt")
         with open(text_path, "w") as f:
             f.write(text_summary)
         print(f"✅ Interpretation saved to {out_path}")
@@ -416,9 +411,7 @@ def run_interpreter(
         Optional path to the input graph JSON used for the run.
     """
 
-    interpreter = CWTLogInterpreter(
-        output_dir=output_dir, graph_path=graph_path
-    )
+    interpreter = CWTLogInterpreter(output_dir=output_dir, graph_path=graph_path)
     interpreter.run()
 
 

--- a/Causal_Web/engine/tick_seeder.py
+++ b/Causal_Web/engine/tick_seeder.py
@@ -4,10 +4,10 @@ from typing import Dict, List, Optional
 
 from .graph import CausalGraph
 from ..config import Config
-from .logger import log_json
+from .base import PathLoggingMixin
 
 
-class TickSeeder:
+class TickSeeder(PathLoggingMixin):
     """Injects ticks into the graph under configurable strategies."""
 
     def __init__(
@@ -32,7 +32,7 @@ class TickSeeder:
 
     # ------------------------------------------------------------
     def _log(self, record: Dict) -> None:
-        log_json(self.log_path, record)
+        self._log_path(self.log_path, record)
         self.seed_count += 1
 
     # ------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -598,7 +598,8 @@ links, `GlobalDiagnosticsService` for exporting run metrics and
 `SIPRecombinationService` for recombination-based spawning. A lightweight
 `LoggingMixin` now centralises JSON logging for classes like `Node` and `Bridge`.
 `OutputDirMixin` adds a common `_path` helper used by the log interpreter and
-causal analyst.
+causal analyst. `PathLoggingMixin` offers direct logging to arbitrary file paths
+for utilities like the tick seeder.
 
 ### Identified long functions
 


### PR DESCRIPTION
## Summary
- add `PathLoggingMixin` for logging to arbitrary paths
- use `OutputDirMixin` in `ExplanationRuleMatcher`
- standardize path usage in causal analysis modules
- switch `TickSeeder` to use the new mixin
- document mixin in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e612c23c8325b5f2cc5130cb2a9f