### PR TITLE
Refactor services into package

### DIFF
--- a/Causal_Web/engine/bridge.py
+++ b/Causal_Web/engine/bridge.py
@@ -270,7 +270,7 @@ class Bridge(LoggingMixin):
 
     def apply(self, tick_time: int, graph: "CausalGraph") -> None:
         """Apply the bridge logic for ``tick_time``."""
-        from .services import BridgeApplyService
+        from .services.sim_services import BridgeApplyService
 
         BridgeApplyService(self, tick_time, graph).process()
 

--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -495,7 +495,7 @@ class CausalGraph:
     def load_from_file(self, path: str) -> None:
         """Populate the graph from a JSON file."""
 
-        from .services import GraphLoadService
+        from .services.sim_services import GraphLoadService
 
         GraphLoadService(self, path).load()
 

--- a/Causal_Web/engine/node.py
+++ b/Causal_Web/engine/node.py
@@ -434,7 +434,7 @@ class Node(LoggingMixin):
     def should_tick(self, tick_time: float) -> tuple[bool, float | None, str]:
         """Return whether the node should fire at ``tick_time``."""
 
-        from .services import NodeTickDecisionService
+        from .services.node_services import NodeTickDecisionService
 
         return NodeTickDecisionService(self, tick_time).decide()
 
@@ -450,7 +450,7 @@ class Node(LoggingMixin):
     ) -> None:
         """Emit a tick and propagate resulting phases to neighbours."""
 
-        from .services import NodeTickService
+        from .services.node_services import NodeTickService
 
         NodeTickService(self, tick_time, phase, graph, origin).process()
 

--- a/Causal_Web/engine/services/__init__.py
+++ b/Causal_Web/engine/services/__init__.py
@@ -1,0 +1,25 @@
+"""Service modules for the engine package."""
+
+from .node_services import (
+    NodeTickService,
+    EdgePropagationService,
+    NodeTickDecisionService,
+)
+from .sim_services import (
+    NodeMetricsResultService,
+    NodeMetricsService,
+    GraphLoadService,
+    BridgeApplyService,
+    GlobalDiagnosticsService,
+)
+
+__all__ = [
+    "NodeTickService",
+    "EdgePropagationService",
+    "NodeTickDecisionService",
+    "NodeMetricsResultService",
+    "NodeMetricsService",
+    "GraphLoadService",
+    "BridgeApplyService",
+    "GlobalDiagnosticsService",
+]

--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -1,0 +1,353 @@
+"""Node-level service classes split from services.py."""
+
+from __future__ import annotations
+
+import uuid
+import cmath
+import math
+from dataclasses import dataclass
+from typing import Any
+import numpy as np
+
+from ...config import Config
+from ..logger import log_json
+from ..tick import Tick, GLOBAL_TICK_POOL
+from ..node import Node, NodeType, Edge
+
+
+@dataclass
+class NodeTickService:
+    """Lifecycle manager for :meth:`~Causal_Web.engine.node.Node.apply_tick`."""
+
+    node: Node
+    tick_time: int
+    phase: float
+    graph: Any
+    origin: str = "self"
+
+    def process(self) -> None:
+        """Execute the node tick lifecycle for ``tick_time``."""
+
+        if not self._pre_check():
+            return
+        self._register_tick()
+        self._propagate_edges()
+        if self.origin == "self":
+            collapsed = self.node.propagate_collapse(self.tick_time, self.graph)
+            if collapsed:
+                self.node._log_collapse_chain(self.tick_time, collapsed)
+
+    # ------------------------------------------------------------------
+    def _pre_check(self) -> bool:
+        from .. import tick_engine as te
+
+        if self.node.node_type == NodeType.NULL:
+            log_json(
+                Config.output_path("boundary_interaction_log.json"),
+                {"tick": self.tick_time, "void": self.node.id, "origin": self.origin},
+            )
+            te.void_absorption_events += 1
+            self.node._log_tick_drop(self.tick_time, "void_node")
+            return False
+        if self.node.is_classical:
+            print(f"[{self.node.id}] Classical node cannot emit ticks")
+            self.node._log_tick_drop(self.tick_time, "classical")
+            return False
+        if getattr(self.node, "boundary", False):
+            log_json(
+                Config.output_path("boundary_interaction_log.json"),
+                {"tick": self.tick_time, "node": self.node.id, "origin": self.origin},
+            )
+            te.boundary_interactions_count += 1
+        if not te.register_firing(self.node):
+            self.node._log_tick_drop(self.tick_time, "bandwidth_limit")
+            return False
+        if self.origin == "self" and self.tick_time in self.node.emitted_tick_times:
+            self.node._log_tick_drop(self.tick_time, "duplicate")
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    def _register_tick(self) -> Tick:
+        trace_id = str(uuid.uuid4())
+        tick_obj = GLOBAL_TICK_POOL.acquire()
+        tick_obj.origin = self.origin
+        tick_obj.time = self.tick_time
+        tick_obj.amplitude = 1.0
+        tick_obj.phase = self.phase
+        tick_obj.layer = "tick"
+        tick_obj.trace_id = trace_id
+
+        n = self.node
+        n.current_tick += 1
+        n.subjective_ticks += 1
+        n.last_tick_time = self.tick_time
+        n.current_threshold = min(n.current_threshold + 0.05, 1.0)
+        n.phase = self.phase
+        n.tick_history.append(tick_obj)
+        log_json(
+            Config.output_path("tick_emission_log.json"),
+            {"node_id": n.id, "tick_time": self.tick_time, "phase": self.phase},
+        )
+        if self.origin == "self":
+            n.emitted_tick_times.add(self.tick_time)
+        else:
+            n.received_tick_times.add(self.tick_time)
+        n._tick_phase_lookup[self.tick_time] = self.phase
+        from ..tick_router import TickRouter
+
+        TickRouter.route_tick(n, tick_obj)
+        n.collapse_origin[self.tick_time] = self.origin
+        print(
+            f"[{n.id}] Tick at {self.tick_time} via {self.origin.upper()} | Phase: {self.phase:.2f}"
+        )
+        n._update_memory(self.tick_time, self.origin)
+        n._adapt_behavior()
+        n.update_node_type()
+        return tick_obj
+
+    # ------------------------------------------------------------------
+    def _propagate_edges(self) -> None:
+        EdgePropagationService(
+            node=self.node,
+            tick_time=self.tick_time,
+            phase=self.phase,
+            origin=self.origin,
+            graph=self.graph,
+        ).propagate()
+
+
+@dataclass
+class EdgePropagationService:
+    """Handle tick propagation across outgoing edges."""
+
+    node: Node
+    tick_time: int
+    phase: float
+    origin: str
+    graph: Any
+
+    def propagate(self) -> None:
+        """Propagate the tick across all outgoing edges."""
+
+        self._log_recursion()
+        from ..tick_engine import kappa
+
+        for edge in self.node._fanout_edges(self.graph):
+            self._propagate_edge(edge, kappa)
+
+    # ------------------------------------------------------------------
+    def _log_recursion(self) -> None:
+        if self.origin != "self" and any(
+            e.target == self.origin for e in self.graph.get_edges_from(self.node.id)
+        ):
+            log_json(
+                Config.output_path("refraction_log.json"),
+                {
+                    "tick": self.tick_time,
+                    "recursion_from": self.origin,
+                    "node": self.node.id,
+                },
+            )
+
+    # ------------------------------------------------------------------
+    def _propagate_edge(self, edge: Edge, kappa: float) -> None:
+        target = self.graph.get_node(edge.target)
+        delay = edge.adjusted_delay(
+            self.node.law_wave_frequency, target.law_wave_frequency, kappa
+        )
+        shifted = self._shift_phase(edge)
+        self._log_propagation(target, delay, shifted)
+        if self._handle_refraction(target, delay, shifted, kappa):
+            return
+        target.schedule_tick(
+            self.tick_time + delay,
+            shifted,
+            origin=self.node.id,
+            created_tick=self.tick_time,
+        )
+
+    # ------------------------------------------------------------------
+    def _shift_phase(self, edge: Edge) -> float:
+        return self.phase * edge.attenuation + edge.phase_shift
+
+    # ------------------------------------------------------------------
+    def _log_propagation(self, target: Node, delay: float, shifted: float) -> None:
+        log_json(
+            Config.output_path("tick_propagation_log.json"),
+            {
+                "source": self.node.id,
+                "target": target.id,
+                "tick_time": self.tick_time,
+                "arrival_time": self.tick_time + delay,
+                "phase": shifted,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    def _handle_refraction(
+        self, target: Node, delay: float, shifted: float, kappa: float
+    ) -> bool:
+        if target.node_type != NodeType.DECOHERENT:
+            return False
+        alts = self.graph.get_edges_from(target.id)
+        if not alts:
+            return False
+        alt = alts[0]
+        alt_tgt = self.graph.get_node(alt.target)
+        alt_delay = alt.adjusted_delay(
+            target.law_wave_frequency,
+            alt_tgt.law_wave_frequency,
+            kappa,
+        )
+        alt_tgt.schedule_tick(
+            self.tick_time + delay + alt_delay,
+            shifted,
+            origin=self.node.id,
+            created_tick=self.tick_time,
+        )
+        target.node_type = NodeType.REFRACTIVE
+        log_json(
+            Config.output_path("refraction_log.json"),
+            {
+                "tick": self.tick_time,
+                "from": self.node.id,
+                "via": target.id,
+                "to": alt_tgt.id,
+            },
+        )
+        return True
+
+
+@dataclass
+class NodeTickDecisionService:
+    """Evaluate whether a node should emit a tick at a given time."""
+
+    node: Node
+    tick_time: int
+
+    # ------------------------------------------------------------------
+    def decide(self) -> tuple[bool, float | None, str]:
+        """Return firing decision, phase and reason."""
+        in_refractory = self._is_in_refractory()
+        (
+            raw_items,
+            vector_sum,
+            magnitude,
+            coherence,
+            tick_energy,
+        ) = self._phase_metrics()
+
+        if tick_energy < getattr(Config, "tick_threshold", 1):
+            return self._below_count(coherence)
+
+        if in_refractory:
+            return self._during_refractory(coherence)
+
+        if coherence >= self.node.current_threshold:
+            return self._fire_by_threshold(coherence, vector_sum)
+
+        merged, phase = self.node._resolve_interference(
+            self.tick_time, raw_items, vector_sum
+        )
+        if merged:
+            return self._fire_by_merge(coherence, phase)
+
+        return self._fail_below_threshold(coherence, magnitude, raw_items)
+
+    # ------------------------------------------------------------------
+    def _is_in_refractory(self) -> bool:
+        if self.node.current_tick > 0 and self.node.last_tick_time is not None:
+            return (
+                self.tick_time - self.node.last_tick_time < self.node.refractory_period
+            )
+        return False
+
+    # ------------------------------------------------------------------
+    def _phase_metrics(self) -> tuple[list, complex, float, float, float]:
+        raw_items = self.node.incoming_phase_queue[self.tick_time]
+        complex_phases = []
+        weights = []
+        for item in raw_items:
+            if isinstance(item, (tuple, list)) and len(item) == 2:
+                ph, created = item
+                decay = getattr(Config, "tick_decay_factor", 1.0) ** (
+                    max(0, Config.current_tick - created)
+                )
+            else:
+                ph = item
+                decay = 1.0
+            complex_phases.append(decay * cmath.rect(1.0, ph % (2 * math.pi)))
+            weights.append(decay)
+        vector_sum = sum(complex_phases)
+        magnitude = abs(vector_sum)
+        total_weight = sum(weights) if weights else 0.0
+        coherence = magnitude / total_weight if total_weight else 1.0
+        tick_energy = total_weight
+        return raw_items, vector_sum, magnitude, coherence, tick_energy
+
+    # ------------------------------------------------------------------
+    def _log_eval(
+        self, coherence: float, refractory: bool, fired: bool, reason: str | None = None
+    ) -> None:
+        self.node._log_tick_evaluation(
+            self.tick_time,
+            coherence,
+            self.node.current_threshold,
+            refractory,
+            fired,
+            reason,
+        )
+
+    # ------------------------------------------------------------------
+    def _below_count(self, coherence: float) -> tuple[bool, None, str]:
+        self._log_eval(coherence, False, False, "below_count")
+        log_json(
+            Config.output_path("should_tick_log.json"),
+            {"tick": self.tick_time, "node": self.node.id, "reason": "below_count"},
+        )
+        return False, None, "count_threshold"
+
+    # ------------------------------------------------------------------
+    def _during_refractory(self, coherence: float) -> tuple[bool, None, str]:
+        self._log_eval(coherence, True, False, "refractory")
+        print(f"[{self.node.id}] Suppressed by refractory period at {self.tick_time}")
+        return False, None, "refractory"
+
+    # ------------------------------------------------------------------
+    def _fire_by_threshold(
+        self, coherence: float, vector_sum
+    ) -> tuple[bool, float, str]:
+        resultant_phase = cmath.phase(vector_sum)
+        self._log_eval(coherence, False, True)
+        log_json(
+            Config.output_path("should_tick_log.json"),
+            {"tick": self.tick_time, "node": self.node.id, "reason": "threshold"},
+        )
+        return True, resultant_phase, "threshold"
+
+    # ------------------------------------------------------------------
+    def _fire_by_merge(self, coherence: float, phase: float) -> tuple[bool, float, str]:
+        self._log_eval(coherence, False, True, "merged")
+        log_json(
+            Config.output_path("should_tick_log.json"),
+            {"tick": self.tick_time, "node": self.node.id, "reason": "merged"},
+        )
+        return True, phase, "merged"
+
+    # ------------------------------------------------------------------
+    def _fail_below_threshold(
+        self, coherence: float, magnitude: float, raw_items
+    ) -> tuple[bool, None, str]:
+        self._log_eval(coherence, False, False, "below_threshold")
+        log_json(
+            Config.output_path("magnitude_failure_log.json"),
+            {
+                "tick": self.tick_time,
+                "node": self.node.id,
+                "magnitude": round(magnitude, 4),
+                "threshold": round(self.node.current_threshold, 4),
+                "phases": len(raw_items),
+            },
+        )
+        return False, None, "below_threshold"

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -1,238 +1,20 @@
-"""Service objects encapsulating large behaviour blocks."""
+"""Simulation-level service classes from the old services module."""
 
 from __future__ import annotations
 
 import json
-import uuid
+import math
+import cmath
 from dataclasses import dataclass, field
 from typing import Any
 from concurrent.futures import ThreadPoolExecutor
-import math
-import cmath
 import numpy as np
 
-from ..config import Config
-from .logger import log_json
-from .tick import Tick, GLOBAL_TICK_POOL
-from .node import Node, NodeType, Edge
-from .graph import CausalGraph
-from . import tick_engine as te
-
-
-@dataclass
-class NodeTickService:
-    """Lifecycle manager for :meth:`Node.apply_tick`."""
-
-    node: Node
-    tick_time: int
-    phase: float
-    graph: Any
-    origin: str = "self"
-
-    def process(self) -> None:
-        """Execute the node tick lifecycle for ``tick_time``."""
-
-        if not self._pre_check():
-            return
-        self._register_tick()
-        self._propagate_edges()
-        if self.origin == "self":
-            collapsed = self.node.propagate_collapse(self.tick_time, self.graph)
-            if collapsed:
-                self.node._log_collapse_chain(self.tick_time, collapsed)
-
-    # ------------------------------------------------------------------
-    def _pre_check(self) -> bool:
-        from . import tick_engine as te
-
-        if self.node.node_type == NodeType.NULL:
-            log_json(
-                Config.output_path("boundary_interaction_log.json"),
-                {
-                    "tick": self.tick_time,
-                    "void": self.node.id,
-                    "origin": self.origin,
-                },
-            )
-            te.void_absorption_events += 1
-            self.node._log_tick_drop(self.tick_time, "void_node")
-            return False
-        if self.node.is_classical:
-            print(f"[{self.node.id}] Classical node cannot emit ticks")
-            self.node._log_tick_drop(self.tick_time, "classical")
-            return False
-        if getattr(self.node, "boundary", False):
-            log_json(
-                Config.output_path("boundary_interaction_log.json"),
-                {
-                    "tick": self.tick_time,
-                    "node": self.node.id,
-                    "origin": self.origin,
-                },
-            )
-            te.boundary_interactions_count += 1
-        if not te.register_firing(self.node):
-            self.node._log_tick_drop(self.tick_time, "bandwidth_limit")
-            return False
-        if self.origin == "self" and self.tick_time in self.node.emitted_tick_times:
-            self.node._log_tick_drop(self.tick_time, "duplicate")
-            return False
-        return True
-
-    # ------------------------------------------------------------------
-    def _register_tick(self) -> Tick:
-        trace_id = str(uuid.uuid4())
-        tick_obj = GLOBAL_TICK_POOL.acquire()
-        tick_obj.origin = self.origin
-        tick_obj.time = self.tick_time
-        tick_obj.amplitude = 1.0
-        tick_obj.phase = self.phase
-        tick_obj.layer = "tick"
-        tick_obj.trace_id = trace_id
-
-        n = self.node
-        n.current_tick += 1
-        n.subjective_ticks += 1
-        n.last_tick_time = self.tick_time
-        n.current_threshold = min(n.current_threshold + 0.05, 1.0)
-        n.phase = self.phase
-        n.tick_history.append(tick_obj)
-        log_json(
-            Config.output_path("tick_emission_log.json"),
-            {
-                "node_id": n.id,
-                "tick_time": self.tick_time,
-                "phase": self.phase,
-            },
-        )
-        if self.origin == "self":
-            n.emitted_tick_times.add(self.tick_time)
-        else:
-            n.received_tick_times.add(self.tick_time)
-        n._tick_phase_lookup[self.tick_time] = self.phase
-        from .tick_router import TickRouter
-
-        TickRouter.route_tick(n, tick_obj)
-        n.collapse_origin[self.tick_time] = self.origin
-        print(
-            f"[{n.id}] Tick at {self.tick_time} via {self.origin.upper()} | Phase: {self.phase:.2f}"
-        )
-        n._update_memory(self.tick_time, self.origin)
-        n._adapt_behavior()
-        n.update_node_type()
-        return tick_obj
-
-    # ------------------------------------------------------------------
-    def _propagate_edges(self) -> None:
-        EdgePropagationService(
-            node=self.node,
-            tick_time=self.tick_time,
-            phase=self.phase,
-            origin=self.origin,
-            graph=self.graph,
-        ).propagate()
-
-
-@dataclass
-class EdgePropagationService:
-    """Handle tick propagation across outgoing edges."""
-
-    node: Node
-    tick_time: int
-    phase: float
-    origin: str
-    graph: Any
-
-    def propagate(self) -> None:
-        """Propagate the tick across all outgoing edges."""
-
-        self._log_recursion()
-        from .tick_engine import kappa
-
-        for edge in self.node._fanout_edges(self.graph):
-            self._propagate_edge(edge, kappa)
-
-    # ------------------------------------------------------------------
-    def _log_recursion(self) -> None:
-        if self.origin != "self" and any(
-            e.target == self.origin for e in self.graph.get_edges_from(self.node.id)
-        ):
-            log_json(
-                Config.output_path("refraction_log.json"),
-                {
-                    "tick": self.tick_time,
-                    "recursion_from": self.origin,
-                    "node": self.node.id,
-                },
-            )
-
-    # ------------------------------------------------------------------
-    def _propagate_edge(self, edge: Edge, kappa: float) -> None:
-        target = self.graph.get_node(edge.target)
-        delay = edge.adjusted_delay(
-            self.node.law_wave_frequency, target.law_wave_frequency, kappa
-        )
-        shifted = self._shift_phase(edge)
-        self._log_propagation(target, delay, shifted)
-        if self._handle_refraction(target, delay, shifted, kappa):
-            return
-        target.schedule_tick(
-            self.tick_time + delay,
-            shifted,
-            origin=self.node.id,
-            created_tick=self.tick_time,
-        )
-
-    # ------------------------------------------------------------------
-    def _shift_phase(self, edge: Edge) -> float:
-        return self.phase * edge.attenuation + edge.phase_shift
-
-    # ------------------------------------------------------------------
-    def _log_propagation(self, target: Node, delay: float, shifted: float) -> None:
-        log_json(
-            Config.output_path("tick_propagation_log.json"),
-            {
-                "source": self.node.id,
-                "target": target.id,
-                "tick_time": self.tick_time,
-                "arrival_time": self.tick_time + delay,
-                "phase": shifted,
-            },
-        )
-
-    # ------------------------------------------------------------------
-    def _handle_refraction(
-        self, target: Node, delay: float, shifted: float, kappa: float
-    ) -> bool:
-        if target.node_type != NodeType.DECOHERENT:
-            return False
-        alts = self.graph.get_edges_from(target.id)
-        if not alts:
-            return False
-        alt = alts[0]
-        alt_tgt = self.graph.get_node(alt.target)
-        alt_delay = alt.adjusted_delay(
-            target.law_wave_frequency,
-            alt_tgt.law_wave_frequency,
-            kappa,
-        )
-        alt_tgt.schedule_tick(
-            self.tick_time + delay + alt_delay,
-            shifted,
-            origin=self.node.id,
-            created_tick=self.tick_time,
-        )
-        target.node_type = NodeType.REFRACTIVE
-        log_json(
-            Config.output_path("refraction_log.json"),
-            {
-                "tick": self.tick_time,
-                "from": self.node.id,
-                "via": target.id,
-                "to": alt_tgt.id,
-            },
-        )
-        return True
+from ...config import Config
+from ..logger import log_json
+from ..node import Node, NodeType, Edge
+from ..tick import GLOBAL_TICK_POOL  # only for typing, no direct use
+from .. import tick_engine as te
 
 
 @dataclass
@@ -402,8 +184,7 @@ class NodeMetricsService:
     # ------------------------------------------------------------------
     def _write_logs(self, tick: int, logs: dict) -> None:
         log_json(
-            Config.output_path("law_wave_log.json"),
-            {str(tick): logs["law_wave_log"]},
+            Config.output_path("law_wave_log.json"), {str(tick): logs["law_wave_log"]}
         )
         if logs["stable_frequency_log"]:
             log_json(
@@ -415,8 +196,7 @@ class NodeMetricsService:
             {str(tick): logs["decoherence_log"]},
         )
         log_json(
-            Config.output_path("coherence_log.json"),
-            {str(tick): logs["coherence_log"]},
+            Config.output_path("coherence_log.json"), {str(tick): logs["coherence_log"]}
         )
         log_json(
             Config.output_path("coherence_velocity_log.json"),
@@ -446,6 +226,7 @@ class NodeMetricsService:
         )
 
 
+@dataclass
 class GraphLoadService:
     """Populate a :class:`Graph` from a JSON file."""
 
@@ -541,7 +322,7 @@ class GraphLoadService:
             if src is None or tgt is None:
                 continue
             if src == tgt:
-                g.tick_sources.append(
+                self.graph.tick_sources.append(
                     {
                         "node_id": src,
                         "tick_interval": edge.get("delay", 1),
@@ -549,7 +330,7 @@ class GraphLoadService:
                     }
                 )
                 continue
-            g.add_edge(
+            self.graph.add_edge(
                 src,
                 tgt,
                 attenuation=edge.get("attenuation", 1.0),
@@ -584,7 +365,7 @@ class GraphLoadService:
     # ------------------------------------------------------------------
     def _load_meta_nodes(self, meta_nodes: dict) -> None:
         g = self.graph
-        from .meta_node import MetaNode
+        from ..meta_node import MetaNode
 
         for mid, meta in meta_nodes.items():
             members = list(meta.get("members", []))
@@ -605,152 +386,6 @@ class GraphLoadService:
                 y=y,
                 id=mid,
             )
-
-
-@dataclass
-class NodeTickDecisionService:
-    """Evaluate whether a node should emit a tick at a given time."""
-
-    node: Node
-    tick_time: int
-
-    # ------------------------------------------------------------------
-    def decide(self) -> tuple[bool, float | None, str]:
-        """Return firing decision, phase and reason."""
-        in_refractory = self._is_in_refractory()
-        (
-            raw_items,
-            vector_sum,
-            magnitude,
-            coherence,
-            tick_energy,
-        ) = self._phase_metrics()
-
-        if tick_energy < getattr(Config, "tick_threshold", 1):
-            return self._below_count(coherence)
-
-        if in_refractory:
-            return self._during_refractory(coherence)
-
-        if coherence >= self.node.current_threshold:
-            return self._fire_by_threshold(coherence, vector_sum)
-
-        merged, phase = self.node._resolve_interference(
-            self.tick_time, raw_items, vector_sum
-        )
-        if merged:
-            return self._fire_by_merge(coherence, phase)
-
-        return self._fail_below_threshold(coherence, magnitude, raw_items)
-
-    # ------------------------------------------------------------------
-    def _is_in_refractory(self) -> bool:
-        if self.node.current_tick > 0 and self.node.last_tick_time is not None:
-            return (
-                self.tick_time - self.node.last_tick_time < self.node.refractory_period
-            )
-        return False
-
-    # ------------------------------------------------------------------
-    def _phase_metrics(self) -> tuple[list, complex, float, float, float]:
-        raw_items = self.node.incoming_phase_queue[self.tick_time]
-        complex_phases = []
-        weights = []
-        for item in raw_items:
-            if isinstance(item, (tuple, list)) and len(item) == 2:
-                ph, created = item
-                decay = getattr(Config, "tick_decay_factor", 1.0) ** (
-                    max(0, Config.current_tick - created)
-                )
-            else:
-                ph = item
-                decay = 1.0
-            complex_phases.append(decay * cmath.rect(1.0, ph % (2 * math.pi)))
-            weights.append(decay)
-        vector_sum = sum(complex_phases)
-        magnitude = abs(vector_sum)
-        total_weight = sum(weights) if weights else 0.0
-        coherence = magnitude / total_weight if total_weight else 1.0
-        tick_energy = total_weight
-        return raw_items, vector_sum, magnitude, coherence, tick_energy
-
-    # ------------------------------------------------------------------
-    def _log_eval(
-        self,
-        coherence: float,
-        refractory: bool,
-        fired: bool,
-        reason: str | None = None,
-    ) -> None:
-        self.node._log_tick_evaluation(
-            self.tick_time,
-            coherence,
-            self.node.current_threshold,
-            refractory,
-            fired,
-            reason,
-        )
-
-    # ------------------------------------------------------------------
-    def _below_count(self, coherence: float) -> tuple[bool, None, str]:
-        self._log_eval(coherence, False, False, "below_count")
-        log_json(
-            Config.output_path("should_tick_log.json"),
-            {
-                "tick": self.tick_time,
-                "node": self.node.id,
-                "reason": "below_count",
-            },
-        )
-        return False, None, "count_threshold"
-
-    # ------------------------------------------------------------------
-    def _during_refractory(self, coherence: float) -> tuple[bool, None, str]:
-        self._log_eval(coherence, True, False, "refractory")
-        print(f"[{self.node.id}] Suppressed by refractory period at {self.tick_time}")
-        return False, None, "refractory"
-
-    # ------------------------------------------------------------------
-    def _fire_by_threshold(
-        self, coherence: float, vector_sum
-    ) -> tuple[bool, float, str]:
-        resultant_phase = cmath.phase(vector_sum)
-        self._log_eval(coherence, False, True)
-        log_json(
-            Config.output_path("should_tick_log.json"),
-            {
-                "tick": self.tick_time,
-                "node": self.node.id,
-                "reason": "threshold",
-            },
-        )
-        return True, resultant_phase, "threshold"
-
-    # ------------------------------------------------------------------
-    def _fire_by_merge(self, coherence: float, phase: float) -> tuple[bool, float, str]:
-        self._log_eval(coherence, False, True, "merged")
-        log_json(
-            Config.output_path("should_tick_log.json"),
-            {"tick": self.tick_time, "node": self.node.id, "reason": "merged"},
-        )
-        return True, phase, "merged"
-
-    # ------------------------------------------------------------------
-    def _fail_below_threshold(
-        self, coherence: float, magnitude: float, raw_items
-    ) -> tuple[bool, None, str]:
-        self._log_eval(coherence, False, False, "below_threshold")
-        log_json(
-            Config.output_path("magnitude_failure_log.json"),
-            {
-                "tick": self.tick_time,
-                "node": self.node.id,
-                "magnitude": round(magnitude, 4),
-                "threshold": round(self.node.current_threshold, 4),
-                "phases": len(raw_items),
-            },
-        )
-        return False, None, "below_threshold"
 
 
 @dataclass
@@ -852,8 +487,6 @@ class BridgeApplyService:
         self.bridge.rupture_history.append((self.tick_time, avg_decoherence))
         self.bridge.trust_score = max(0.0, self.bridge.trust_score - 0.1)
         self.bridge.reinforcement_streak = 0
-        from . import tick_engine as te
-
         te.trigger_csp(
             self.bridge.bridge_id, self.node_a.x, self.node_a.y, self.tick_time
         )

--- a/Causal_Web/engine/tick_engine/log_utils.py
+++ b/Causal_Web/engine/tick_engine/log_utils.py
@@ -9,7 +9,7 @@ from typing import Optional
 from ...config import Config
 from ..graph import CausalGraph
 from ..logger import log_json, logger, log_manager
-from ..services import GlobalDiagnosticsService
+from ..services.sim_services import GlobalDiagnosticsService
 from ..logging_models import StructuralGrowthLog, StructuralGrowthPayload
 
 # The global graph instance is injected at runtime
@@ -89,7 +89,7 @@ def snapshot_graph(global_tick: int) -> Optional[str]:
 
 
 def log_metrics_per_tick(global_tick: int) -> None:
-    from ..services import NodeMetricsService
+    from ..services.sim_services import NodeMetricsService
 
     assert _graph is not None
     NodeMetricsService(_graph).log_metrics(global_tick)

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ isolates the tick decision logic from `Node.should_tick`. Serialization and
 narrative generation are now handled by `GraphSerializationService` and
 `NarrativeGeneratorService`. GUI setup moved to `ToolbarBuildService` and
 `NodePanelSetupService`. All
-services live in `Causal_Web/engine/services.py` or the GUI package.
+services now live in `Causal_Web/engine/services/` or the GUI package.
 Recent refactors introduced `ConnectionDisplayService` for showing existing
 links, `GlobalDiagnosticsService` for exporting run metrics and
 `SIPRecombinationService` for recombination-based spawning. A lightweight
@@ -606,7 +606,7 @@ for utilities like the tick seeder.
 - `main.py:main` – 66 lines
 - `graph/model.py:add_connection` – 56 lines
 - `engine/tick_engine/evaluator.py:_process_csp_seeds` – 83 lines
-- `engine/services.py:NodeMetricsService.log_metrics` – 45 lines
+- `engine/services/sim_services.py:NodeMetricsService.log_metrics` – 45 lines
 - `engine/tick_engine/core.py:simulation_loop` – 98 lines
 - `engine/tick_engine/core.py:SimulationRunner.run` – 93 lines
 - `engine/causal_analyst.py:infer_causal_chains` – 53 lines


### PR DESCRIPTION
## Summary
- move service classes into `engine/services` package
- split node lifecycle helpers into `node_services.py`
- group simulation utilities in `sim_services.py`
- update imports and README documentation

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6883e8e8ce008325b9114385ea299fe2