### PR TITLE
Cache spatial_index lookups per tick

### DIFF
--- a/Causal_Web/engine/tick_engine/orchestrators.py
+++ b/Causal_Web/engine/tick_engine/orchestrators.py
@@ -46,6 +46,7 @@ class MutationOrchestrator:
         self._propagate(tick)
 
     def cluster_ops(self, tick: int) -> None:
+        self.graph.set_current_tick(tick)
         self.graph.detect_clusters()
         self.graph.update_meta_nodes(tick)
         bridge_manager.dynamic_bridge_management(tick)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Cluster detection and bridge management are computationally heavy. The
 `cluster_interval` setting controls how often these operations run (default
 every 10 ticks). Node evaluation, meta-node updates and metric logging also
 run on this interval to reduce overhead.
+Spatial queries are cached for the duration of each tick to avoid redundant
+lookups when clustering and managing bridges.
 
 The `propagation_control` section toggles node growth mechanisms. Set
 `enable_sip` or `enable_csp` to `false` to disable Stability-Induced or


### PR DESCRIPTION
## Summary
- add per-tick cache for neighbourhood queries in `CausalGraph`
- reset cache at the start of each clustering/bridge cycle
- document the optimisation in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878d7e398c83259402b952c49739eb