### PR TITLE
Add configurable tick intervals for heavy operations

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -15,6 +15,10 @@ class Config:
         toggle the two propagation mechanisms.
     log_interval:
         Number of ticks between metric log writes.
+    cluster_interval:
+        Number of ticks between cluster detection cycles.
+    bridge_interval:
+        Number of ticks between dynamic bridge management cycles.
     headless:
         When ``True`` disables observers and intermediate logging.
     """
@@ -131,8 +135,10 @@ class Config:
     forcing_ramp_ticks = 20
     # interval for saving runtime snapshots of the graph
     snapshot_interval = 10
-    # interval for expensive clustering and bridge management
+    # interval for expensive clustering operations
     cluster_interval = 10
+    # interval for dynamic bridge formation and decay checks
+    bridge_interval = 10
     random_seed: int | None = None
     thread_count = 1
     log_verbosity = "info"

--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -181,9 +181,16 @@ class SimulationRunner:
         self.mutation.pre_process(self.global_tick)
 
         cluster_cycle = self.global_tick % getattr(Config, "cluster_interval", 1) == 0
-        if cluster_cycle:
-            self.mutation.cluster_ops(self.global_tick)
-            self.evaluation.evaluate(self.global_tick)
+        bridge_cycle = self.global_tick % getattr(Config, "bridge_interval", 1) == 0
+        log_cycle = self.global_tick % getattr(Config, "log_interval", 1) == 0
+
+        self.mutation.cluster_ops(
+            self.global_tick,
+            run_cluster=cluster_cycle,
+            run_bridges=bridge_cycle,
+        )
+        self.evaluation.evaluate(self.global_tick)
+        if log_cycle:
             self.io.log_cluster_info(self.global_tick)
 
         self.evaluation.finalize(self.global_tick)

--- a/Causal_Web/engine/tick_engine/orchestrators.py
+++ b/Causal_Web/engine/tick_engine/orchestrators.py
@@ -45,10 +45,19 @@ class MutationOrchestrator:
         self._emit(tick)
         self._propagate(tick)
 
-    def cluster_ops(self, tick: int) -> None:
-        self.graph.detect_clusters()
-        self.graph.update_meta_nodes(tick)
-        bridge_manager.dynamic_bridge_management(tick)
+    def cluster_ops(
+        self,
+        tick: int,
+        *,
+        run_cluster: bool = True,
+        run_bridges: bool = True,
+    ) -> None:
+        """Run cluster detection and bridge management operations."""
+        if run_cluster:
+            self.graph.detect_clusters()
+            self.graph.update_meta_nodes(tick)
+        if run_bridges:
+            bridge_manager.dynamic_bridge_management(tick)
 
     def apply_bridges(self, tick: int) -> None:
         for bridge in self.graph.bridges:

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -14,9 +14,12 @@
     "probability": 0.2
   },
   "snapshot_interval": 5,
+  "cluster_interval": 10,
+  "bridge_interval": 10,
   "random_seed": 42,
   "thread_count": 4,
   "log_verbosity": "info",
+  "log_interval": 1,
   "memory_window": 20,
   "initial_coherence_threshold": 0.6,
   "steady_coherence_threshold": 0.85,

--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ single tick. Set `total_max_concurrent_firings` for a global limit or
 cluster. A value of `0` disables these limits. Both parameters are configurable
 via CLI flags or the Parameters window in the GUI.
 
-Cluster detection and bridge management are computationally heavy. The
-`cluster_interval` setting controls how often these operations run (default
-every 10 ticks). Node evaluation, meta-node updates and metric logging also
-run on this interval to reduce overhead.
+Cluster detection, bridge formation checks and metric logging can be heavy for
+large graphs. The `cluster_interval`, `bridge_interval` and `log_interval`
+settings control how often these operations run. By default clustering and
+bridge management occur every 10 ticks while logs flush every tick. Adjust
+these values in `input/config.json` to trade accuracy for performance.
 
 The `propagation_control` section toggles node growth mechanisms. Set
 `enable_sip` or `enable_csp` to `false` to disable Stability-Induced or


### PR DESCRIPTION
## Summary
- expose `bridge_interval` in `Config` to control bridge management cadence
- update tick engine to respect `cluster_interval`, `bridge_interval` and `log_interval`
- allow `MutationOrchestrator.cluster_ops` to selectively run clustering and bridge logic
- document new settings in README
- default intervals specified in `input/config.json`

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878e16154883259e2313d647323ba9