### PR TITLE
Add interval controls for clustering and logs

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -131,8 +131,10 @@ class Config:
     forcing_ramp_ticks = 20
     # interval for saving runtime snapshots of the graph
     snapshot_interval = 10
-    # interval for expensive clustering and bridge management
+    # interval for expensive clustering operations
     cluster_interval = 10
+    # interval for dynamic bridge management
+    bridge_interval = 10
     random_seed: int | None = None
     thread_count = 1
     log_verbosity = "info"

--- a/Causal_Web/engine/tick_engine/orchestrators.py
+++ b/Causal_Web/engine/tick_engine/orchestrators.py
@@ -49,7 +49,12 @@ class MutationOrchestrator:
         self.graph.set_current_tick(tick)
         self.graph.detect_clusters()
         self.graph.update_meta_nodes(tick)
-        bridge_manager.dynamic_bridge_management(tick)
+        if (
+            tick
+            % getattr(Config, "bridge_interval", getattr(Config, "cluster_interval", 1))
+            == 0
+        ):
+            bridge_manager.dynamic_bridge_management(tick)
 
     def apply_bridges(self, tick: int) -> None:
         for bridge in self.graph.bridges:
@@ -71,6 +76,9 @@ class IOOrchestrator:
 
     def log_cluster_info(self, tick: int) -> None:
         if Config.headless:
+            return
+        interval = getattr(Config, "log_interval", 1)
+        if interval and tick % interval != 0:
             return
         log_utils.log_metrics_per_tick(tick)
         log_utils.log_bridge_states(tick)

--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ cluster. A value of `0` disables these limits. Both parameters are configurable
 via CLI flags or the Parameters window in the GUI.
 
 Cluster detection and bridge management are computationally heavy. The
-`cluster_interval` setting controls how often these operations run (default
-every 10 ticks). Node evaluation, meta-node updates and metric logging also
-run on this interval to reduce overhead.
+`cluster_interval` setting controls how often clustering occurs, while
+`bridge_interval` governs dynamic bridge formation. Both default to ten
+ticks. Metric logging frequency is determined separately by the `log_interval`
+setting.
+Node evaluation and meta-node updates still follow the clustering cadence to
+reduce overhead.
 Spatial queries are cached for the duration of each tick to avoid redundant
 lookups when clustering and managing bridges.
 


### PR DESCRIPTION
## Summary
- add `bridge_interval` setting
- respect `bridge_interval` and `log_interval` when clustering and logging
- document new setting in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688796f05314832598e1ccca0a662e6d