### PR TITLE
Fix tick engine counters

### DIFF
--- a/Causal_Web/engine/tick_engine/__init__.py
+++ b/Causal_Web/engine/tick_engine/__init__.py
@@ -1,4 +1,25 @@
-"""Modular tick engine package."""
+"""Modular tick engine package.
+
+This module exposes the public API of the tick engine and initialises a
+number of diagnostic counters accessed by other services. These counters are
+used during headless runs where the GUI is not active and therefore must
+exist at import time.
+"""
+
+boundary_interactions_count = 0
+"""Number of times ticks interacted with boundary nodes."""
+
+void_absorption_events = 0
+"""Ticks absorbed by void nodes."""
+
+bridges_reformed_count = 0
+"""Count of bridges reactivated after rupture."""
+
+_law_wave_stability: dict[str, dict] = {}
+"""Internal record of node law-wave frequency stability."""
+
+_decay_durations: list[int] = []
+"""Durations for which bridges decayed until deactivation."""
 
 from .core import (
     SimulationRunner,


### PR DESCRIPTION
## Summary
- init tick engine counters on import so services can update them during headless runs

## Testing
- `black Causal_Web/engine/tick_engine/__init__.py`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a82b998c83259eabaefbf583321d