### PR TITLE
Implement proper-time logging

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -82,6 +82,7 @@ class Config:
         "node_state_log.json": True,
         "observer_disagreement_log.json": True,
         "propagation_failure_log.json": True,
+        "proper_time_log.json": True,
         "refraction_log.json": True,
         "should_tick_log.json": True,
         "stable_frequency_log.json": True,

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ simplifying downstream analysis.
 - `observer_disagreement_log.json` – difference between observers and reality.
 - `observer_perceived_field.json` – tick counts inferred by observers.
 - `propagation_failure_log.json` – reasons tick propagation failed.
+- `proper_time_log.json` – cumulative subjective ticks per node.
 - `refraction_log.json` – rerouted ticks through alternative paths.
 - `regional_pressure_map.json` – decoherence pressure per region.
 - `should_tick_log.json` – results of tick emission checks.
@@ -498,6 +499,9 @@ The following lists describe the JSON keys recorded in each output file.
 #### `propagation_failure_log.json`
 - heterogeneous records describing why propagation failed. Common
   fields include `tick`, `node` or `parent`, failure `type` and `reason`.
+
+#### `proper_time_log.json`
+- keyed by tick with `{node: subjective_ticks}` values.
 
 #### `refraction_log.json`
 - rerouting information containing `tick` and either


### PR DESCRIPTION
## Summary
- track each node's subjective tick count in NodeMetricsService
- persist the new metrics to `proper_time_log.json`
- enable `proper_time_log.json` in the default configuration
- document the log in the README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a9dfb1c88325808bbdce2fc1d60b