### PR TITLE
Add configurable graph path

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -17,12 +17,15 @@ class Config:
         Number of ticks between metric log writes.
     headless:
         When ``True`` disables observers and intermediate logging.
+    graph_file:
+        Path to the current graph JSON file used by the engine.
     """
 
     # Base directories for package resources
     base_dir = os.path.abspath(os.path.dirname(__file__))
     input_dir = os.path.join(base_dir, "input")
     config_file = os.path.join(input_dir, "config.json")
+    graph_file = os.path.join(input_dir, "graph.json")
     output_root = os.path.join(base_dir, "output")
     runs_dir = os.path.join(output_root, "runs")
     archive_dir = os.path.join(output_root, "archive")
@@ -241,9 +244,11 @@ class Config:
 
         input_dest = os.path.join(run_dir, "input")
         os.makedirs(input_dest, exist_ok=True)
-        graph_src = cls.input_path("graph.json")
+        graph_src = cls.graph_file
         if os.path.exists(graph_src):
-            shutil.copy2(graph_src, os.path.join(input_dest, "graph.json"))
+            shutil.copy2(
+                graph_src, os.path.join(input_dest, os.path.basename(graph_src))
+            )
         if os.path.exists(cls.config_file):
             shutil.copy2(cls.config_file, os.path.join(input_dest, "config.json"))
 
@@ -255,7 +260,7 @@ class Config:
             record_run(
                 os.path.basename(run_dir),
                 os.path.join(input_dest, "config.json"),
-                os.path.join(input_dest, "graph.json"),
+                os.path.join(input_dest, os.path.basename(graph_src)),
                 run_dir,
             )
         except Exception:

--- a/Causal_Web/engine/causal_analyst.py
+++ b/Causal_Web/engine/causal_analyst.py
@@ -15,6 +15,7 @@ class ExplanationEvent:
 
 
 from .base import OutputDirMixin, JsonLinesMixin
+from ..config import Config
 
 
 class CausalAnalyst(OutputDirMixin, JsonLinesMixin):
@@ -66,7 +67,7 @@ class CausalAnalyst(OutputDirMixin, JsonLinesMixin):
                     except json.JSONDecodeError:
                         self.logs[key] = {}
 
-        graph_path = os.path.join(self.input_dir, "graph.json")
+        graph_path = Config.graph_file
         if os.path.exists(graph_path):
             with open(graph_path) as f:
                 try:

--- a/Causal_Web/engine/log_interpreter.py
+++ b/Causal_Web/engine/log_interpreter.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 from .causal_analyst import CausalAnalyst
 from .base import OutputDirMixin, JsonLinesMixin
+from ..config import Config
 
 
 class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
@@ -14,7 +15,7 @@ class CWTLogInterpreter(OutputDirMixin, JsonLinesMixin):
     ) -> None:
         super().__init__(output_dir=output_dir)
         base = os.path.join(os.path.dirname(__file__), "..")
-        self.graph_path = graph_path or os.path.join(base, "input", "graph.json")
+        self.graph_path = graph_path or Config.graph_file
         self.graph = {}
         self.summary: Dict[str, Dict] = {}
 

--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -58,7 +58,7 @@ def clear_output_directory() -> None:
 
 def build_graph() -> None:
     clear_output_directory()
-    graph.load_from_file(Config.input_path("graph.json"))
+    graph.load_from_file(Config.graph_file)
     global seeder
     seeder = TickSeeder(graph)
     _ensure_attached()

--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -534,9 +534,9 @@ class CanvasWidget(QGraphicsView):
                 item.node_id
             )
         elif isinstance(item, EdgeItem):
-            actions[
-                menu.addAction("Delete Connection")
-            ] = lambda: self.delete_connection(item.index, item.connection_type)
+            actions[menu.addAction("Delete Connection")] = (
+                lambda: self.delete_connection(item.index, item.connection_type)
+            )
         elif isinstance(item, ObserverItem):
             actions[menu.addAction("Delete Observer")] = lambda: self.delete_observer(
                 item.index

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -272,12 +272,12 @@ class MainWindow(QMainWindow):
         # apply edits from the graph editor if it is currently visible
         if self.canvas_dock.isVisible():
             self._load_into_main()
-        path = get_active_file() or Config.input_path("graph.json")
+        path = get_active_file() or Config.graph_file
         os.makedirs(os.path.dirname(path), exist_ok=True)
         save_graph(path, get_graph())
         # always write the runtime graph to the package input directory so the
         # engine uses the latest edits regardless of the loaded file location
-        save_graph(Config.input_path("graph.json"), get_graph())
+        save_graph(Config.graph_file, get_graph())
         clear_graph_dirty()
         mark_graph_dirty()
         Config.new_run()

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -78,6 +78,11 @@ class MainService:
             help="Path to JSON configuration file",
         )
         initial.add_argument(
+            "--graph",
+            default=Config.graph_file,
+            help="Path to graph JSON file",
+        )
+        initial.add_argument(
             "--no-gui",
             action="store_true",
             help="Run simulation without launching the GUI",
@@ -88,6 +93,7 @@ class MainService:
             help="Initialize PostgreSQL schema and exit.",
         )
         known, _ = initial.parse_known_args(self.argv)
+        Config.graph_file = known.graph
 
         config_data: dict[str, Any] = {}
         if known.config and os.path.exists(known.config):
@@ -100,6 +106,7 @@ class MainService:
         )
         _add_config_args(parser, config_data)
         args = parser.parse_args(self.argv)
+        Config.graph_file = args.graph
         return args, config_data
 
     # ------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Key modules include:
 - **`gui_pyside/canvas_widget.py`** – reusable ``QGraphicsView`` for graph rendering.
 - **`main.py`** – simple entry point that launches the dashboard.
 
-Graphs are stored in `input/graph.json` inside the package. Paths are resolved relative to the package so the module can be run from any working directory. All output is written next to the code in the `output` directory.
+Graphs are stored in `input/graph.json` by default. Use the `--graph` argument or `Config.graph_file` to load a different file. Paths are resolved relative to the package so the module can be run from any working directory. All output is written next to the code in the `output` directory.
 
 ## Configuration
 
@@ -214,12 +214,12 @@ The **Graph View** dock now embeds a small toolbar offering **Add Node**,
 **Add Connection**, **Add Observer**, **Auto Layout** and a **Load Graph** button for quick access.
 The **Auto Layout** action still arranges nodes using a spring layout.
 When you press **Start Simulation** the current graph is saved and also copied
-to `input/graph.json`. A new run directory is created via `Config.new_run()` and
+to the path specified by `Config.graph_file`. A new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the
 exact input used for each run. Any unsaved edits in the **Graph View** are
 applied automatically so the main window reflects the latest changes when the
 simulation begins.
-These actions operate on the `graph.json` format and update the shared in-memory model.
+These actions operate on the graph file format and update the shared in-memory model.
 The dashboard also includes a **Graph View** tab which renders the loaded graph and displays
 basic information for the currently selected node. The **Graph View** window
 now includes **Add Node**, **Add Connection**, **Add Observer**, **Auto Layout** and **Load Graph**
@@ -254,7 +254,7 @@ A resize handler bug that halted GUI updates after resizing has been fixed.
 Dragging connections between nodes now works again across PySide6 versions.
 
 Rendering is now event driven so the canvas only updates when the graph changes, greatly reducing idle CPU usage.
-Graph editing panels are now docked within the Graph View window. They close automatically when the view is hidden and prompt about unapplied changes before closing. Panels minimize when they lose focus and restore when clicked again, warning about unsaved edits if you switch to a different object. The Graph View also warns when in-memory edits have not been saved to ``graph.json``.
+Graph editing panels are now docked within the Graph View window. They close automatically when the view is hidden and prompt about unapplied changes before closing. Panels minimize when they lose focus and restore when clicked again, warning about unsaved edits if you switch to a different object. The Graph View also warns when in-memory edits have not been saved to the graph file.
 
 ### Analysing the output
 
@@ -276,7 +276,7 @@ This command loads the logs and generates several summary files:
 Simulation results are organised under `output/` which now contains separate
 directories for each run. A new run directory is created via
 `Config.new_run()` and has the form `runs/<timestamp>__<slug>`. The current
-`graph.json` and `config.json` files are copied into each run's `input/`
+graph file and `config.json` are copied into each run's `input/`
 subdirectory so every run has a frozen copy of its inputs. Basic metadata
 about the run, including timestamps generated in UTC to avoid timezone
 discrepancies, is inserted into the PostgreSQL `runs` table automatically. The

--- a/tests/test_run_integration.py
+++ b/tests/test_run_integration.py
@@ -12,6 +12,7 @@ def test_new_run_copies_graph(tmp_path, monkeypatch):
     monkeypatch.setattr(Config, "input_dir", str(input_dir))
     monkeypatch.setattr(Config, "runs_dir", str(runs_dir))
     monkeypatch.setattr(Config, "config_file", str(input_dir / "config.json"))
+    monkeypatch.setattr(Config, "graph_file", str(input_dir / "graph.json"))
 
     graph = GraphModel.blank(True)
     graph_path = input_dir / "graph.json"
@@ -19,7 +20,7 @@ def test_new_run_copies_graph(tmp_path, monkeypatch):
     (input_dir / "config.json").write_text("{}")
 
     run_dir = Config.new_run("test")
-    copied = os.path.join(run_dir, "input", "graph.json")
+    copied = os.path.join(run_dir, "input", os.path.basename(graph_path))
     assert os.path.exists(copied)
     loaded = load_graph(copied)
     assert loaded.nodes


### PR DESCRIPTION
## Summary
- support alternate graph files via `Config.graph_file`
- allow `--graph` CLI override
- update GUI start routine and analysis helpers
- document new option and adapt integration test
- run `black`, `compileall`, `pytest`

## Testing
- `pip install numpy networkx pytest`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ab6f003883259c27ffd16cbd6256