### PR TITLE
Add deterministic tick termination

### DIFF
--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -131,6 +131,7 @@ class SimulationRunner:
         threading.Thread(target=self.run, daemon=True).start()
 
     def run(self) -> None:
+        """Main processing loop executed in a background thread."""
         global _stop_requested
         _stop_requested = False
         self._seed_random()
@@ -143,10 +144,6 @@ class SimulationRunner:
                 _update_simulation_state(False, True, self.global_tick, snapshot)
                 log_utils.write_output()
                 break
-            if not running:
-                time.sleep(0.1)
-                continue
-            self._process_tick()
             if limit and limit != -1 and self.global_tick >= limit:
                 with Config.state_lock:
                     Config.is_running = False
@@ -154,6 +151,10 @@ class SimulationRunner:
                 _update_simulation_state(False, True, self.global_tick, snapshot)
                 log_utils.write_output()
                 break
+            if not running:
+                time.sleep(0.1)
+                continue
+            self._process_tick()
             self.global_tick += 1
             time.sleep(rate)
 

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -118,6 +118,7 @@ class MainService:
 
     # ------------------------------------------------------------------
     def _run_headless(self) -> None:
+        """Run the simulation without launching the GUI."""
         from .engine import tick_engine
 
         tick_engine.build_graph()
@@ -130,11 +131,13 @@ class MainService:
                 with Config.state_lock:
                     running = Config.is_running
                     tick = Config.current_tick
-                if not running and (not limit or tick >= limit):
+                if limit and limit != -1 and tick >= limit:
+                    tick_engine.stop_simulation()
+                if not running:
                     break
                 time.sleep(0.1)
         except KeyboardInterrupt:
-            pass
+            tick_engine.stop_simulation()
 
     # ------------------------------------------------------------------
     @staticmethod

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ python -m Causal_Web.main --no-gui --max_ticks 20
 ```
 
 The `max_ticks` value takes effect when `allow_tick_override` is enabled in
-the configuration (the default behaviour).
+the configuration (the default behaviour). Headless runs terminate
+automatically once this limit is reached.
 
 Only keys matching attributes on `Causal_Web.config.Config` are applied. Nested
 dictionaries merge with the existing values.


### PR DESCRIPTION
## Summary
- stop simulation runner before executing ticks beyond max tick limit
- stop headless runs automatically when max tick count is reached
- document headless auto-termination

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ad65b0d083259bb8f10053fe4df9