### PR TITLE
Fix config path resolution

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -274,7 +274,8 @@ class Config:
 
         Only keys that already exist as attributes on ``Config`` will be
         assigned. Nested dictionaries are merged recursively when the existing
-        attribute is also a ``dict``.
+        attribute is also a ``dict``. Relative paths under the ``paths`` section
+        are resolved relative to the directory containing ``path``.
 
         Parameters
         ----------
@@ -288,11 +289,14 @@ class Config:
         with open(path) as f:
             data = json.load(f)
         cls.config_file = os.path.abspath(path)
+        base_dir = os.path.dirname(cls.config_file)
 
         paths = data.get("paths")
         if isinstance(paths, dict):
             for key, value in paths.items():
                 if hasattr(cls, key):
+                    if not os.path.isabs(value):
+                        value = os.path.join(base_dir, value)
                     setattr(cls, key, os.path.abspath(value))
 
         for key, value in data.items():

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Key modules include:
 - **`gui_pyside/canvas_widget.py`** – reusable ``QGraphicsView`` for graph rendering.
 - **`main.py`** – simple entry point that launches the dashboard.
 
-Graphs are stored in `input/graph.json` by default. Use the `--graph` argument or `Config.graph_file` to load a different file. Paths are resolved relative to the package so the module can be run from any working directory. All output is written next to the code in the `output` directory.
+Graphs are stored in `input/graph.json` by default. Use the `--graph` argument or
+`Config.graph_file` to load a different file. Built-in paths resolve relative to
+the package so the module can be run from any working directory, while paths in a
+configuration file are resolved relative to that file's location. All output is
+written next to the code in the `output` directory.
 
 ## Configuration
 
@@ -282,7 +286,8 @@ subdirectory so every run has a frozen copy of its inputs. Basic metadata
 about the run, including timestamps generated in UTC to avoid timezone
 discrepancies, is inserted into the PostgreSQL `runs` table automatically. The
 location of `runs/` and other output folders can be customised using the
-`paths` section in `input/config.json`.
+`paths` section in `input/config.json`. Relative entries are resolved against
+the directory containing the configuration file.
 Logging for each file can be enabled or disabled individually using
 **Settings > Log Files...** in the GUI or via the `log_files` section of the
 configuration file.


### PR DESCRIPTION
## Summary
- handle relative paths in Config.load_from_file relative to config file
- clarify path resolution behaviour in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887b17443448325b12e180e15bb3de4