### PR TITLE
Add graph_file config support

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -302,6 +302,8 @@ class Config:
         for key, value in data.items():
             if not hasattr(cls, key):
                 continue
+            if key == "graph_file" and not os.path.isabs(value):
+                value = os.path.join(base_dir, value)
             current = getattr(cls, key)
             if isinstance(current, dict) and isinstance(value, dict):
                 current.update(value)

--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -534,9 +534,9 @@ class CanvasWidget(QGraphicsView):
                 item.node_id
             )
         elif isinstance(item, EdgeItem):
-            actions[menu.addAction("Delete Connection")] = (
-                lambda: self.delete_connection(item.index, item.connection_type)
-            )
+            actions[
+                menu.addAction("Delete Connection")
+            ] = lambda: self.delete_connection(item.index, item.connection_type)
         elif isinstance(item, ObserverItem):
             actions[menu.addAction("Delete Observer")] = lambda: self.delete_observer(
                 item.index

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -7,6 +7,7 @@
     "analysis_dir": "./Causal_Web/output/analysis",
     "ingest_dir": "./Causal_Web/output/ingest"
   },
+  "graph_file": "./Causal_Web/input/graph.json",
   "tick_rate": 0.5,
   "max_ticks": 50,
   "seeding": {

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -100,6 +100,7 @@ class MainService:
             with open(known.config) as f:
                 config_data = json.load(f)
             Config.load_from_file(known.config)
+            initial.set_defaults(graph=Config.graph_file)
 
         parser = argparse.ArgumentParser(
             parents=[initial], description="Run Causal Web simulation"

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ Key modules include:
 - **`gui_pyside/canvas_widget.py`** – reusable ``QGraphicsView`` for graph rendering.
 - **`main.py`** – simple entry point that launches the dashboard.
 
-Graphs are stored in `input/graph.json` by default. Use the `--graph` argument or
-`Config.graph_file` to load a different file. Built-in paths resolve relative to
-the package so the module can be run from any working directory, while paths in a
-configuration file are resolved relative to that file's location. All output is
-written next to the code in the `output` directory.
+Graphs are stored in `input/graph.json` by default. Use the `--graph` argument,
+the `graph_file` entry in `config.json` or set `Config.graph_file` directly to
+load a different file. Built-in paths resolve relative to the package so the
+module can be run from any working directory, while paths in a configuration
+file are resolved relative to that file's location. All output is written next
+to the code in the `output` directory.
 
 ## Configuration
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,15 @@
+import json
+from Causal_Web.config import Config
+
+
+def test_load_from_file_resolves_graph_file(tmp_path):
+    cfg = tmp_path / "config.json"
+    graph_path = tmp_path / "g.json"
+    cfg.write_text(json.dumps({"graph_file": "g.json"}))
+    original = Config.graph_file
+    Config.load_from_file(str(cfg))
+    try:
+        assert Config.graph_file == str(graph_path)
+    finally:
+        Config.graph_file = original
+


### PR DESCRIPTION
## Summary
- allow `graph_file` entry in config.json to override default
- resolve relative `graph_file` paths in `Config.load_from_file`
- update CLI so config value becomes the default for `--graph`
- document new option in README
- add regression test for config path resolution

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b26adb108325a4a6a7a1a7c72187