### PR TITLE
Fix circular import in GUI modules

### DIFF
--- a/Causal_Web/gui_pyside/panel_services.py
+++ b/Causal_Web/gui_pyside/panel_services.py
@@ -18,13 +18,8 @@ from PySide6.QtWidgets import (
     QListWidget,
 )
 
-from .toolbar_builder import (
-    TooltipLabel,
-    TOOLTIPS,
-    _FocusWatcher,
-    mark_graph_dirty,
-)
-from ..gui.state import get_graph
+from .shared import TooltipLabel, TOOLTIPS, _FocusWatcher
+from ..gui.state import get_graph, mark_graph_dirty
 
 
 @dataclass

--- a/Causal_Web/gui_pyside/shared.py
+++ b/Causal_Web/gui_pyside/shared.py
@@ -1,0 +1,60 @@
+"""Shared Qt helpers for the GUI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Dict, Callable
+
+from PySide6.QtCore import QObject, QEvent, QTimer
+from PySide6.QtWidgets import QLabel
+
+# ---------------------------------------------------------------------------
+# Load tooltip text for GUI fields
+_TOOLTIP_PATH = Path(__file__).resolve().parents[1] / "input" / "tooltip.json"
+try:
+    with open(_TOOLTIP_PATH, "r", encoding="utf-8") as fh:
+        TOOLTIPS: Dict[str, str] = json.load(fh)
+except FileNotFoundError:  # pragma: no cover - tooltips optional
+    TOOLTIPS = {}
+
+
+class TooltipLabel(QLabel):
+    """QLabel displaying a tooltip after 0.5s of hover."""
+
+    def __init__(self, text: str, tip: str | None = None) -> None:
+        super().__init__(text)
+        self.tip = tip or ""
+        self._timer = QTimer(self)
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self._show_tooltip)
+
+    def enterEvent(self, event: QEvent) -> None:  # type: ignore[override]
+        if self.tip:
+            self._timer.start(500)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event: QEvent) -> None:  # type: ignore[override]
+        self._timer.stop()
+        QLabel.setToolTip(self, "")
+        super().leaveEvent(event)
+
+    def _show_tooltip(self) -> None:
+        if self.tip:
+            from PySide6.QtWidgets import QToolTip
+
+            pos = self.mapToGlobal(self.rect().bottomRight())
+            QToolTip.showText(pos, self.tip, self)
+
+
+class _FocusWatcher(QObject):
+    """Call a function when the watched widget loses focus."""
+
+    def __init__(self, callback: Callable[[], None]) -> None:
+        super().__init__()
+        self.callback = callback
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # type: ignore[override]
+        if event.type() == QEvent.FocusOut:
+            self.callback()
+        return False

--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Optional, Any, Dict, Callable
+from typing import Optional, Any, Dict
 
-from pathlib import Path
-import json
-
-from PySide6.QtCore import QObject, Qt, QEvent, QTimer
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QAction, QCursor, QCloseEvent
 from PySide6.QtWidgets import (
     QComboBox,
@@ -20,12 +17,12 @@ from PySide6.QtWidgets import (
     QToolBar,
     QWidget,
     QCheckBox,
-    QLabel,
     QLineEdit,
     QVBoxLayout,
 )
 
 from .panel_mixins import PanelMixin
+from .shared import TooltipLabel, TOOLTIPS, _FocusWatcher
 
 from ..gui.state import (
     get_graph,
@@ -40,15 +37,6 @@ from .panel_services import (
     ConnectionDisplayService,
 )
 
-# ---------------------------------------------------------------------------
-# Load tooltip text for GUI fields
-_TOOLTIP_PATH = Path(__file__).resolve().parents[1] / "input" / "tooltip.json"
-try:
-    with open(_TOOLTIP_PATH, "r", encoding="utf-8") as fh:
-        TOOLTIPS: Dict[str, str] = json.load(fh)
-except FileNotFoundError:  # pragma: no cover - tooltips optional
-    TOOLTIPS = {}
-
 EVENT_TYPES = [
     "collapse",
     "law_wave",
@@ -57,47 +45,6 @@ EVENT_TYPES = [
     "phase",
     "region",
 ]
-
-
-class TooltipLabel(QLabel):
-    """QLabel displaying a tooltip after 0.5s of hover."""
-
-    def __init__(self, text: str, tip: str | None = None) -> None:
-        super().__init__(text)
-        self.tip = tip or ""
-        self._timer = QTimer(self)
-        self._timer.setSingleShot(True)
-        self._timer.timeout.connect(self._show_tooltip)
-
-    def enterEvent(self, event: QEvent) -> None:  # type: ignore[override]
-        if self.tip:
-            self._timer.start(500)
-        super().enterEvent(event)
-
-    def leaveEvent(self, event: QEvent) -> None:  # type: ignore[override]
-        self._timer.stop()
-        QLabel.setToolTip(self, "")
-        super().leaveEvent(event)
-
-    def _show_tooltip(self) -> None:
-        if self.tip:
-            from PySide6.QtWidgets import QToolTip
-
-            pos = self.mapToGlobal(self.rect().bottomRight())
-            QToolTip.showText(pos, self.tip, self)
-
-
-class _FocusWatcher(QObject):
-    """Call a function when the watched widget loses focus."""
-
-    def __init__(self, callback: Callable[[], None]):
-        super().__init__()
-        self.callback = callback
-
-    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # type: ignore[override]
-        if event.type() == QEvent.FocusOut:
-            self.callback()
-        return False
 
 
 class NodePanel(QDockWidget, PanelMixin):


### PR DESCRIPTION
## Summary
- extract tooltip helpers into a new `shared.py` module
- update `toolbar_builder` and `panel_services` to use the shared helpers
- install missing test dependency `pydantic`

## Testing
- `black Causal_Web/gui_pyside/panel_services.py Causal_Web/gui_pyside/toolbar_builder.py Causal_Web/gui_pyside/shared.py`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887b3e36ea483258afaf23e4ced6804