### PR TITLE
Fix PySide6 QAction import

### DIFF
--- a/Causal_Web/gui_pyside/toolbar_services.py
+++ b/Causal_Web/gui_pyside/toolbar_services.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from PySide6.QtWidgets import QAction, QToolBar
+try:
+    from PySide6.QtGui import QAction
+except ModuleNotFoundError:  # pragma: no cover - fallback for older PySide6
+    from PySide6.QtWidgets import QAction
+from PySide6.QtWidgets import QToolBar
 from PySide6.QtCore import Qt
 
 from .toolbar_builder import NodePanel, ConnectionPanel, ObserverPanel, MetaNodePanel


### PR DESCRIPTION
## Summary
- avoid importing QAction from QtWidgets because it fails on newer PySide6
- fall back to QtWidgets when QtGui QAction is unavailable

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887b562bb08832593331d42af8cc370