### PR TITLE
Fix PySide QAction import and config paths

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -534,9 +534,9 @@ class CanvasWidget(QGraphicsView):
                 item.node_id
             )
         elif isinstance(item, EdgeItem):
-            actions[
-                menu.addAction("Delete Connection")
-            ] = lambda: self.delete_connection(item.index, item.connection_type)
+            actions[menu.addAction("Delete Connection")] = (
+                lambda: self.delete_connection(item.index, item.connection_type)
+            )
         elif isinstance(item, ObserverItem):
             actions[menu.addAction("Delete Observer")] = lambda: self.delete_observer(
                 item.index

--- a/Causal_Web/gui_pyside/toolbar_services.py
+++ b/Causal_Web/gui_pyside/toolbar_services.py
@@ -7,7 +7,7 @@ from typing import Any
 
 try:
     from PySide6.QtGui import QAction
-except ModuleNotFoundError:  # pragma: no cover - fallback for older PySide6
+except ImportError:  # pragma: no cover - fallback for older PySide6
     from PySide6.QtWidgets import QAction
 from PySide6.QtWidgets import QToolBar
 from PySide6.QtCore import Qt

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -1,13 +1,13 @@
 {
   "paths": {
-    "input_dir": "./Causal_Web/input",
-    "output_root": "./Causal_Web/output",
-    "runs_dir": "./Causal_Web/output/runs",
-    "archive_dir": "./Causal_Web/output/archive",
-    "analysis_dir": "./Causal_Web/output/analysis",
-    "ingest_dir": "./Causal_Web/output/ingest"
+    "input_dir": "./",
+    "output_root": "../output",
+    "runs_dir": "../output/runs",
+    "archive_dir": "../output/archive",
+    "analysis_dir": "../output/analysis",
+    "ingest_dir": "../output/ingest"
   },
-  "graph_file": "./Causal_Web/input/graph.json",
+  "graph_file": "graph.json",
   "tick_rate": 0.5,
   "max_ticks": 50,
   "seeding": {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ module can be run from any working directory, while paths in a configuration
 file are resolved relative to that file's location. All output is written next
 to the code in the `output` directory.
 
+The default `config.json` uses simple relative paths. For example `graph_file`
+is specified as just ``"graph.json"`` so it resolves to the same folder as the
+configuration file.
+
 ## Configuration
 
 Runtime parameters such as tick rate or seeding strategy can be overridden by


### PR DESCRIPTION
## Summary
- fix import fallback for QAction for old PySide6
- correct default paths in `config.json`
- clarify config path behaviour in README
- format canvas_widget with `black`

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b6667e8483259502b20d560e4cd7