### PR TITLE
Fix JSON serialization issue in inspect_superpositions

### DIFF
--- a/Causal_Web/engine/graph.py
+++ b/Causal_Web/engine/graph.py
@@ -327,7 +327,7 @@ class CausalGraph:
                             {
                                 "between": [bridge.node_a_id, bridge.node_b_id],
                                 "active": bridge.active,
-                                "type": bridge.bridge_type,
+                                "type": bridge.bridge_type.value,
                                 "drift_tolerance": bridge.drift_tolerance,
                                 "decoherence_limit": bridge.decoherence_limit,
                             }


### PR DESCRIPTION
## Summary
- fix `inspect_superpositions` to serialize `BridgeType` values as strings

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887b86c768883258149e6e119a4e3c3