### PR TITLE
Expose config defaults as CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ automatically once this limit is reached.
 
 Only keys matching attributes on `Causal_Web.config.Config` are applied. Nested
 dictionaries merge with the existing values.
+If a configuration file omits a key, the CLI still exposes a flag for it using
+the default defined on `Config`.
 
 To set up a PostgreSQL database using the credentials in the configuration file,
 invoke the module with the `--init-db` flag. The application will create the

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -1,0 +1,30 @@
+import json
+from Causal_Web.main import MainService, _apply_overrides
+from Causal_Web.config import Config
+
+
+def test_cli_flags_exposed_without_config(tmp_path):
+    cfg = tmp_path / "c.json"
+    cfg.write_text("{}")
+    old_max = Config.max_ticks
+    old_host = Config.database["host"]
+    try:
+        service = MainService(
+            argv=[
+                "--config",
+                str(cfg),
+                "--max_ticks",
+                "5",
+                "--database.host",
+                "example.com",
+            ]
+        )
+        args, data = service._parse_args()
+        assert args.max_ticks == 5
+        assert args.database_host == "example.com"
+        _apply_overrides(args, data)
+        assert Config.max_ticks == 5
+        assert Config.database["host"] == "example.com"
+    finally:
+        Config.max_ticks = old_max
+        Config.database["host"] = old_host


### PR DESCRIPTION
## Summary
- ensure all config options are accessible from the CLI
- document CLI fallback behaviour
- test that overrides work with an empty config file

## Testing
- `black Causal_Web tests/test_cli_defaults.py`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887bbcc2b1c8325a090b538f3d0a72b