### PR TITLE
Implement dynamic density-based edge delays

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -142,6 +142,9 @@ class Config:
     random_seed: int | None = None
     thread_count = 1
     log_verbosity = "info"
+    use_dynamic_density = False
+    density_radius = 1
+    delay_density_scaling = 1.0
     # interval between metric logs
     log_interval = 1
     # disable observers and intermediate logging when True

--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -154,7 +154,10 @@ class EdgePropagationService:
     def _propagate_edge(self, edge: Edge, kappa: float) -> None:
         target = self.graph.get_node(edge.target)
         delay = edge.adjusted_delay(
-            self.node.law_wave_frequency, target.law_wave_frequency, kappa
+            self.node.law_wave_frequency,
+            target.law_wave_frequency,
+            kappa,
+            graph=self.graph,
         )
         shifted = self._shift_phase(edge)
         self._log_propagation(target, delay, shifted)
@@ -199,6 +202,7 @@ class EdgePropagationService:
             target.law_wave_frequency,
             alt_tgt.law_wave_frequency,
             kappa,
+            graph=self.graph,
         )
         alt_tgt.schedule_tick(
             self.tick_time + delay + alt_delay,

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -269,6 +269,8 @@ class GraphLoadService:
         self._load_bridges(data.get("bridges", []))
         self.graph.tick_sources.extend(data.get("tick_sources", []))
         self._load_meta_nodes(data.get("meta_nodes", {}))
+        if self.graph.edges:
+            self.graph.precompute_local_densities(getattr(Config, "density_radius", 1))
         self.graph.identify_boundaries()
 
     # ------------------------------------------------------------------
@@ -355,7 +357,7 @@ class GraphLoadService:
                 src,
                 tgt,
                 attenuation=edge.get("attenuation", 1.0),
-                density=edge.get("density", 0.0),
+                density=edge.get("density"),
                 delay=edge.get("delay", 1),
                 phase_shift=edge.get("phase_shift", 0.0),
                 weight=edge.get("weight"),

--- a/Causal_Web/engine/tick_engine/log_utils.py
+++ b/Causal_Web/engine/tick_engine/log_utils.py
@@ -30,7 +30,12 @@ def log_curvature_per_tick(global_tick: int) -> None:
         if not src or not tgt:
             continue
         df = abs(src.law_wave_frequency - tgt.law_wave_frequency)
-        curved = edge.adjusted_delay(src.law_wave_frequency, tgt.law_wave_frequency)
+        curved = edge.adjusted_delay(
+            src.law_wave_frequency,
+            tgt.law_wave_frequency,
+            getattr(Config, "delay_density_scaling", 1.0),
+            graph=_graph,
+        )
         log[f"{edge.source}->{edge.target}"] = {
             "delta_f": round(df, 4),
             "curved_delay": round(curved, 4),

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -28,6 +28,9 @@
   "total_max_concurrent_firings": 0,
   "max_concurrent_firings_per_cluster": 0,
   "edge_weight_range": [1.0, 1.0],
+  "use_dynamic_density": false,
+  "density_radius": 1,
+  "delay_density_scaling": 1.0,
   "propagation_control": {
     "enable_sip": true,
     "enable_csp": true

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ range when the graph loads. The weight scales the delay returned by
 `Edge.adjusted_delay` and inversely affects attenuation, allowing the network to
 model non-uniform distances or resistance.
 
+When `use_dynamic_density` is enabled each edge's delay is further modified by
+the local connection density computed within `density_radius` hops. The effect
+is scaled by `delay_density_scaling`.
+
 To model limited causal bandwidth you can restrict how many nodes may fire on a
 single tick. Set `total_max_concurrent_firings` for a global limit or
 `max_concurrent_firings_per_cluster` to cap activity within each detected

--- a/tests/test_dynamic_density.py
+++ b/tests/test_dynamic_density.py
@@ -1,0 +1,26 @@
+import math
+from Causal_Web.engine.graph import CausalGraph
+from Causal_Web.engine.node import Edge
+
+
+def test_compute_local_density():
+    g = CausalGraph()
+    for n in ["A", "B", "C"]:
+        g.add_node(n)
+    g.add_edge("A", "B")
+    g.add_edge("B", "C")
+    edge = g.get_edges_from("A")[0]
+    density = g.compute_local_density(edge, radius=1)
+    assert math.isclose(density, 2.0)
+
+
+def test_dynamic_delay_uses_computed_density():
+    g = CausalGraph()
+    for n in ["A", "B", "C"]:
+        g.add_node(n)
+    g.add_edge("A", "B", delay=2, density=None)
+    g.add_edge("B", "C")
+    g.precompute_local_densities(radius=1)
+    edge = g.get_edges_from("A")[0]
+    delay = edge.adjusted_delay(1.0, 1.0, kappa=1.0, graph=g)
+    assert delay == int(2 * (1 + 2))

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -36,11 +36,8 @@ def test_detect_clusters():
 
 def test_edge_adjusted_delay():
     edge = Edge("A", "B", attenuation=1.0, density=0.5, delay=2)
-    # with zero freq difference sin term is zero -> delay = delay + int(density)
-    assert edge.adjusted_delay(1.0, 1.0, kappa=1.0) == 2 + int(0.5)
-    # with frequency difference effect
-    delay = edge.adjusted_delay(1.0, 1.5, kappa=1.0)
-    assert delay >= 1
+    delay = edge.adjusted_delay(1.0, 1.0, kappa=1.0)
+    assert delay == int(2 * (1 + 0.5))
 
 
 def test_remove_node_cleans_references():


### PR DESCRIPTION
## Summary
- support dynamic density delays via `use_dynamic_density`, `density_radius`, and `delay_density_scaling`
- compute local density and precompute for edges
- update edge delay calculations to use local density
- expose settings in default config and document them
- add regression tests for local density logic

## Testing
- `black Causal_Web tests`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c090a79c8325938c0022bd2b5ba7