### PR TITLE
Fix edge delay accumulation

### DIFF
--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -179,7 +179,6 @@ class EdgePropagationService:
             return
         if self._handle_refraction(target, delay, shifted, kappa):
             return
-        self.tick.cumulative_delay = new_delay
         target.schedule_tick(
             self.tick_time + delay,
             shifted,


### PR DESCRIPTION
## Summary
- ensure each outgoing edge uses its own delay counter

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887ccd977c48325addd5abbd384a163