### PR TITLE
Disable Start Simulation without graph loaded

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -208,6 +208,7 @@ class MainWindow(QMainWindow):
 
         self.start_button = QPushButton("Start Simulation")
         self.start_button.clicked.connect(self.start_simulation)
+        self.start_button.setEnabled(get_active_file() is not None)
         layout.addRow(self.start_button)
 
         self.pause_button = QPushButton("Pause")
@@ -239,7 +240,7 @@ class MainWindow(QMainWindow):
         self.tick_label.setText(str(tick))
         self.sim_canvas.load_model(GraphModel.from_dict(model_dict))
         if not running:
-            self.start_button.setEnabled(True)
+            self.start_button.setEnabled(get_active_file() is not None)
             self.pause_button.setEnabled(False)
             self.pause_button.setText("Pause")
             self.stop_button.setEnabled(False)
@@ -308,7 +309,7 @@ class MainWindow(QMainWindow):
     def stop_simulation(self) -> None:
         """Stop the simulation immediately."""
         tick_engine.stop_simulation()
-        self.start_button.setEnabled(True)
+        self.start_button.setEnabled(get_active_file() is not None)
         self.pause_button.setEnabled(False)
         self.pause_button.setText("Pause")
         self.stop_button.setEnabled(False)
@@ -328,10 +329,12 @@ class MainWindow(QMainWindow):
         set_graph(graph)
         set_active_file(path)
         clear_graph_dirty()
+        self.start_button.setEnabled(True)
         self.sim_canvas.load_model(graph)
         # refresh editor if it is visible
         self.canvas.load_model(GraphModel.from_dict(graph.to_dict()))
         self.edit_action.setEnabled(True)
+        self.start_button.setEnabled(True)
 
     def save_graph(self) -> None:
         """Write the current graph to disk."""
@@ -357,6 +360,7 @@ class MainWindow(QMainWindow):
         self.sim_canvas.load_model(model)
         self.canvas.load_model(GraphModel.from_dict(model.to_dict()))
         self.edit_action.setEnabled(True)
+        self.start_button.setEnabled(False)
 
     def add_node(self) -> None:
         """Insert a new node and refresh the canvas."""
@@ -432,6 +436,7 @@ class MainWindow(QMainWindow):
                 print(f"Failed to save graph: {exc}")
             else:
                 clear_graph_dirty()
+        self.start_button.setEnabled(get_active_file() is not None)
         self.canvas_dock.hide()
 
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ include **Edit Graph...**, **Undo** and **Redo** in the **Edit** menu.
 The **Graph View** dock now embeds a small toolbar offering **Add Node**,
 **Add Connection**, **Add Observer**, **Auto Layout** and a **Load Graph** button for quick access.
 The **Auto Layout** action still arranges nodes using a spring layout.
+The **Start Simulation** button remains disabled until a graph file is loaded or saved.
 When you press **Start Simulation** the current graph is saved and also copied
 to the path specified by `Config.graph_file`. A new run directory is created via `Config.new_run()` and
 the graph file is copied into the run's `input/` folder. This preserves the


### PR DESCRIPTION
## Summary
- prevent running simulation when no graph file is loaded
- describe new start button behaviour in docs

## Testing
- `python -m compileall Causal_Web`
- `pytest`
- `pip install numpy networkx pytest`
- `pip install pydantic`


------
https://chatgpt.com/codex/tasks/task_e_6887e00ba35c8325a8d2a6c74592d342