### PR TITLE
Ensure all logs use pydantic models

### DIFF
--- a/Causal_Web/engine/logger.py
+++ b/Causal_Web/engine/logger.py
@@ -1,4 +1,3 @@
-import json
 import os
 import threading
 import time
@@ -8,6 +7,7 @@ from typing import Any, DefaultDict, List
 from pydantic import BaseModel
 
 from ..config import Config
+from .logging_models import GenericLogEntry
 
 
 class LogBuffer:
@@ -73,6 +73,10 @@ def log_json(path: str, data: Any) -> None:
     if not Config.is_log_enabled(name):
         return
     if isinstance(data, BaseModel):
-        logger.log(path, data.model_dump_json() + "\n")
+        entry = data
     else:
-        logger.log(path, json.dumps(data) + "\n")
+        tick = data.get("tick", 0) if isinstance(data, dict) else 0
+        entry = GenericLogEntry(
+            event_type=name.replace(".json", ""), tick=tick, payload=data
+        )
+    log_manager.log(path, entry)

--- a/Causal_Web/engine/logging_models.py
+++ b/Causal_Web/engine/logging_models.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -41,3 +41,10 @@ class StructuralGrowthPayload(BaseModel):
 class StructuralGrowthLog(BaseLogEntry):
     event_type: str = "StructuralGrowthSnapshot"
     payload: StructuralGrowthPayload
+
+
+class GenericLogEntry(BaseLogEntry):
+    """Fallback model for logs without a dedicated payload class."""
+
+    event_type: str
+    payload: Any

--- a/README.md
+++ b/README.md
@@ -321,9 +321,11 @@ disk writes. The frequency of metric logging is controlled by the
 `log_interval` setting which defaults to `1` tick. This value can be adjusted
 in the **Log Files** window.
 Hovering over any log entry now shows a brief description of that log file.
-Each record now conforms to Pydantic models defined in
-`engine/logging_models.py`, ensuring consistent structure across files and
-simplifying downstream analysis.
+All records are wrapped by Pydantic models from
+`engine/logging_models.py`. Generic logs use ``GenericLogEntry`` while
+specialised events such as ``NodeEmergenceLog`` retain their dedicated
+payloads. This provides consistent metadata across files and simplifies
+downstream analysis.
 
 - `boundary_interaction_log.json` – interactions with void or boundary nodes.
 - `bridge_decay_log.json` – gradual weakening of inactive bridges.


### PR DESCRIPTION
## Summary
- add `GenericLogEntry` model for arbitrary logs
- wrap `log_json` calls with `GenericLogEntry`
- mention the canonical logging format in the README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888eb7325f083258727b773479f49a7