### PR TITLE
Relocate meta_node and analytics modules

### DIFF
--- a/Causal_Web/Causal_Web.pyproj
+++ b/Causal_Web/Causal_Web.pyproj
@@ -28,12 +28,12 @@
     <Compile Include="database\__init__.py" />
     <Compile Include="engine\base.py" />
     <Compile Include="engine\models\bridge.py" />
-    <Compile Include="engine\causal_analyst.py" />
-    <Compile Include="engine\explanation_rules.py" />
+    <Compile Include="engine\logging\causal_analyst.py" />
+    <Compile Include="engine\logging\explanation_rules.py" />
     <Compile Include="engine\models\graph.py" />
     <Compile Include="engine\logging\logger.py" />
     <Compile Include="engine\models\logging.py" />
-    <Compile Include="engine\meta_node.py" />
+    <Compile Include="engine\models\meta_node.py" />
     <Compile Include="engine\models\node.py" />
     <Compile Include="engine\tick_engine\node_manager.py" />
     <Compile Include="engine\models\observer.py" />

--- a/Causal_Web/engine/logging/causal_analyst.py
+++ b/Causal_Web/engine/logging/causal_analyst.py
@@ -14,8 +14,8 @@ class ExplanationEvent:
     explanation_text: str
 
 
-from .models.base import OutputDirMixin, JsonLinesMixin
-from ..config import Config
+from ..models.base import OutputDirMixin, JsonLinesMixin
+from ...config import Config
 
 
 class CausalAnalyst(OutputDirMixin, JsonLinesMixin):
@@ -25,7 +25,7 @@ class CausalAnalyst(OutputDirMixin, JsonLinesMixin):
         self, output_dir: Optional[str] = None, input_dir: Optional[str] = None
     ) -> None:
         super().__init__(output_dir=output_dir)
-        base = os.path.join(os.path.dirname(__file__), "..")
+        base = os.path.join(os.path.dirname(__file__), "..", "..")
         self.input_dir = input_dir or os.path.join(base, "input")
         self.logs: Dict[str, Dict[int, Dict]] = {}
         self.graph: Dict = {}

--- a/Causal_Web/engine/logging/explanation_rules.py
+++ b/Causal_Web/engine/logging/explanation_rules.py
@@ -5,7 +5,7 @@ import os
 from typing import Dict, List
 
 from .causal_analyst import ExplanationEvent, CausalAnalyst
-from .models.base import OutputDirMixin
+from ..models.base import OutputDirMixin
 
 
 class ExplanationRuleMatcher(OutputDirMixin):

--- a/Causal_Web/engine/logging/log_interpreter.py
+++ b/Causal_Web/engine/logging/log_interpreter.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Dict, List
 
-from ..causal_analyst import CausalAnalyst
+from .causal_analyst import CausalAnalyst
 from ..models.base import OutputDirMixin, JsonLinesMixin
 from ...config import Config
 

--- a/Causal_Web/engine/models/graph.py
+++ b/Causal_Web/engine/models/graph.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from .bridge import Bridge, BridgeType, MediumType
 from .node import Node, Edge, NodeType
 from .tick import GLOBAL_TICK_POOL
-from ..meta_node import MetaNode
+from .meta_node import MetaNode
 from ...config import Config
 import json
 from ..logging.logger import log_json

--- a/Causal_Web/engine/models/meta_node.py
+++ b/Causal_Web/engine/models/meta_node.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from .models.node import Node
+from .node import Node
 
 
 @dataclass

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -388,7 +388,7 @@ class GraphLoadService:
     # ------------------------------------------------------------------
     def _load_meta_nodes(self, meta_nodes: dict) -> None:
         g = self.graph
-        from ..meta_node import MetaNode
+        from ..models.meta_node import MetaNode
 
         for mid, meta in meta_nodes.items():
             members = list(meta.get("members", []))

--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -534,9 +534,9 @@ class CanvasWidget(QGraphicsView):
                 item.node_id
             )
         elif isinstance(item, EdgeItem):
-            actions[
-                menu.addAction("Delete Connection")
-            ] = lambda: self.delete_connection(item.index, item.connection_type)
+            actions[menu.addAction("Delete Connection")] = (
+                lambda: self.delete_connection(item.index, item.connection_type)
+            )
         elif isinstance(item, ObserverItem):
             actions[menu.addAction("Delete Observer")] = lambda: self.delete_observer(
                 item.index

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Key modules include:
 - **`engine/tick_engine/tick_router.py`** – moves ticks through LCCM layers and logs transitions.
 - **`engine/tick_engine/tick_seeder.py`** – seeds periodic ticks based on the configuration file.
 - **`engine/logging/log_interpreter.py`** – parses the generated logs and aggregates statistics.
-- **`engine/causal_analyst.py`** – infers causal chains and produces explanation files.
-- **`engine/meta_node.py`** – groups clusters of nodes into collapsed meta nodes.
+ - **`engine/logging/causal_analyst.py`** – infers causal chains and produces explanation files.
+ - **`engine/models/meta_node.py`** – groups clusters of nodes into collapsed meta nodes.
 - **`engine/tick_engine/node_manager.py`** – NumPy-backed container for bulk node updates
   using dynamically resized pre-allocated arrays.
 - **`engine/models/observer.py`** – observers that infer hidden state from tick history.
@@ -654,14 +654,14 @@ for utilities like the tick seeder.
 - `engine/services/sim_services.py:NodeMetricsService.log_metrics` – 45 lines
 - `engine/tick_engine/core.py:simulation_loop` – 98 lines
 - `engine/tick_engine/core.py:SimulationRunner.run` – 93 lines
-- `engine/causal_analyst.py:infer_causal_chains` – 53 lines
+ - `engine/logging/causal_analyst.py:infer_causal_chains` – 53 lines
 - `engine/models/bridge.py:apply` – 125 lines
 - `engine/models/node.py:__init__` – 97 lines
 - `engine/models/node.py:should_tick` – 111 lines
 - `engine/models/node.py:apply_tick` – 143 lines
 - `engine/models/graph.py:detect_clusters` – 55 lines
 - `engine/models/graph.py:load_from_file` – 138 lines
-- `engine/explanation_rules.py:_match_emergence_events` – 51 lines
+ - `engine/logging/explanation_rules.py:_match_emergence_events` – 51 lines
 - `gui_pyside/toolbar_builder.py:ToolbarBuilder.__init__` – 57 lines
 - `gui_pyside/toolbar_builder.py:AnotherClass.__init__` – 101 lines
 - `gui_pyside/toolbar_builder.py:commit` – 99 lines


### PR DESCRIPTION
## Summary
- move `meta_node.py` under models package
- move `causal_analyst.py` and `explanation_rules.py` into logging package
- update imports and references after moving files
- adjust documentation and project file for new paths
- run `black`, `compileall` and tests

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688909fff2708325bd1471aad5300e8c