### PR TITLE
Add requirements file and update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,17 @@ Example:
 
 ## Running the simulation
 
-1. Install the dependencies (`numpy`, `networkx`, `pydantic`, `pytest` and `pyside6` for the GUI) using:
+1. Install the dependencies. The core packages are listed in
+   `requirements.txt` and can be installed with:
 
    ```bash
-   pip install numpy networkx pydantic pytest pyside6
+   pip install -r requirements.txt
+   ```
+
+   For the GUI, also install `pyside6`:
+
+   ```bash
+   pip install pyside6
    ```
 
    An X11-compatible display is needed to create the window. If running on a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+networkx
+pytest
+pydantic


### PR DESCRIPTION
## Summary
- add `requirements.txt` listing runtime and test dependencies
- document installing packages from `requirements.txt` in setup docs

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6889177da8b883259fb9c2ab20003cae