### PR TITLE
Implement unified per-tick log schema

### DIFF
--- a/Causal_Web/engine/logging/logger.py
+++ b/Causal_Web/engine/logging/logger.py
@@ -75,8 +75,13 @@ def log_json(path: str, data: Any) -> None:
     if isinstance(data, BaseModel):
         entry = data
     else:
-        tick = data.get("tick", 0) if isinstance(data, dict) else 0
+        if isinstance(data, dict):
+            tick = data.get("tick", 0)
+            payload = {k: v for k, v in data.items() if k != "tick"}
+        else:
+            tick = 0
+            payload = data
         entry = GenericLogEntry(
-            event_type=name.replace(".json", ""), tick=tick, payload=data
+            event_type=name.replace(".json", ""), tick=tick, payload=payload
         )
     log_manager.log(path, entry)

--- a/Causal_Web/engine/models/node.py
+++ b/Causal_Web/engine/models/node.py
@@ -456,9 +456,9 @@ class Node(LoggingMixin):
             self._log(
                 "tick_delivery_log.json",
                 {
+                    "tick": tick_time,
                     "source": origin,
                     "node_id": self.id,
-                    "tick_time": tick_time,
                     "stored_phase": incoming_phase,
                 },
             )
@@ -696,6 +696,7 @@ class Edge:
             log_json(
                 Config.output_path("delay_density_log.json"),
                 {
+                    "tick": getattr(Config, "current_tick", 0),
                     "edge": f"{self.source}->{self.target}",
                     "rho": rho,
                     "base": self.delay,

--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -227,7 +227,7 @@ class NodeTickService:
             n.tick_history.append(tick_obj)
         log_json(
             Config.output_path("tick_emission_log.json"),
-            {"node_id": n.id, "tick_time": self.tick_time, "phase": self.phase},
+            {"tick": self.tick_time, "node_id": n.id, "phase": self.phase},
         )
         with n.lock:
             if self.origin == "self":
@@ -345,9 +345,9 @@ class EdgePropagationService:
         log_json(
             Config.output_path("tick_propagation_log.json"),
             {
+                "tick": self.tick_time,
                 "source": self.node.id,
                 "target": target.id,
-                "tick_time": self.tick_time,
                 "arrival_time": self.tick_time + delay,
                 "phase": shifted,
             },

--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -88,13 +88,13 @@ def _update_simulation_state(
     paused: bool, stopped: bool, tick: int, snapshot: str | None
 ) -> None:
     state = {
+        "tick": tick,
         "paused": paused,
         "stopped": stopped,
-        "current_tick": tick,
-        "graph_snapshot": snapshot,
     }
-    with open(Config.output_path("simulation_state.json"), "w") as f:
-        json.dump(state, f, indent=2)
+    if snapshot is not None:
+        state["graph_snapshot"] = snapshot
+    log_json(Config.output_path("simulation_state.json"), state)
 
 
 def pause_simulation() -> None:

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ The following lists describe the JSON keys recorded in each output file.
   `{node: {layer: count}}`.
 
 #### `magnitude_failure_log.json`
-- `tick`, `node`, `magnitude`, `threshold` and number of `phases` when a tick fails.
+- `node`, `magnitude`, `threshold` and number of `phases` when a tick fails.
 
 #### `meta_node_tick_log.json`
 - keyed by tick with `{meta_id: [member_nodes]}` entries.
@@ -547,7 +547,7 @@ The following lists describe the JSON keys recorded in each output file.
 
 #### `propagation_failure_log.json`
 - heterogeneous records describing why propagation failed. Common
-  fields include `tick`, `node` or `parent`, failure `type` and `reason`.
+  fields include `node` or `parent`, failure `type` and `reason`.
 
 #### `proper_time_log.json`
 - keyed by tick with `{node: subjective_ticks}` values.
@@ -560,35 +560,35 @@ The following lists describe the JSON keys recorded in each output file.
 - mapping of regions to averaged decoherence pressure.
 
 #### `should_tick_log.json`
-- decisions from `should_tick` with `tick`, `node` and `reason`.
+- decisions from `should_tick` with `node` and `reason`.
 
 #### `simulation_state.json`
-- `paused`, `stopped`, `current_tick` and optional `graph_snapshot` path.
+- `paused`, `stopped` and optional `graph_snapshot` path.
 
 #### `structural_growth_log.json`
 - per tick record of node counts and SIP/CSP success/failure totals.
 
 #### `tick_delivery_log.json`
-- `source`, `node_id`, `tick_time` and `stored_phase` for incoming ticks.
+- `source`, `node_id` and `stored_phase` for incoming ticks.
 
 #### `tick_density_map.json`
 - keyed by tick mirroring `interference_log` densities.
 
 #### `tick_drop_log.json`
-- dropped tick info: `tick`, `node`, `reason`, `coherence`, `node_type`.
+- dropped tick info: `node`, `reason`, `coherence`, `node_type`.
 
 #### `tick_emission_log.json`
-- emitted ticks with `node_id`, `tick_time` and `phase`.
+- emitted ticks with `node_id` and `phase`.
 
 #### `tick_evaluation_log.json`
 - evaluation outcome fields:
-  `tick`, `node`, `coherence`, `threshold`, `refractory`, `fired`, `reason`.
+  `node`, `coherence`, `threshold`, `refractory`, `fired`, `reason`.
 
 #### `tick_propagation_log.json`
-- `source`, `target`, `tick_time`, `arrival_time` and propagated `phase`.
+- `source`, `target`, `arrival_time` and propagated `phase`.
 
 #### `tick_seed_log.json`
-- seeder actions recording `tick`, `node`, `phase`, `strategy`,
+- seeder actions recording `node`, `phase`, `strategy`,
   `coherence`, `threshold`, `success` and optional `failure_reason`.
 
 #### `tick_trace.json`

--- a/docs/log_schemas.md
+++ b/docs/log_schemas.md
@@ -26,7 +26,7 @@ unless nested structures are required for clarity. Example entries:
   "tick": 42,
   "timestamp": "2024-05-01T12:00:00Z",
   "event_type": "tick_emission_log",
-  "payload": {"node_id": "n1", "tick_time": 42, "phase": 1.57}
+  "payload": {"node_id": "n1", "phase": 1.57}
 }
 ```
 


### PR DESCRIPTION
## Summary
- centralise GenericLogEntry payload cleanup so `tick` only appears in schema
- record ticks correctly for propagation and emission logs
- log deliveries and delay density with tick metadata
- write simulation_state.json as newline-delimited log entries
- document new payload formats

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889a569fcc4832582933d378c25ffd1