### PR TITLE
Add periodic log schema

### DIFF
--- a/Causal_Web/engine/logging/causal_analyst.py
+++ b/Causal_Web/engine/logging/causal_analyst.py
@@ -179,7 +179,7 @@ class CausalAnalyst(OutputDirMixin, JsonLinesMixin):
 
         path = self._path("causal_chains.json")
         with open(path, "w") as f:
-            json.dump(chains, f, indent=2)
+            json.dump({"label": "causal_chains", "value": chains}, f, indent=2)
         return chains
 
     # ------------------------------------------------------------
@@ -286,7 +286,7 @@ class CausalAnalyst(OutputDirMixin, JsonLinesMixin):
         graph = {"nodes": nodes, "edges": edges}
         path = self._path("explanation_graph.json")
         with open(path, "w") as f:
-            json.dump(graph, f, indent=2)
+            json.dump({"label": "explanation_graph", "value": graph}, f, indent=2)
         return graph
 
     # ------------------------------------------------------------
@@ -325,7 +325,7 @@ class CausalAnalyst(OutputDirMixin, JsonLinesMixin):
         data = [{"tick": t, "events": timeline[t]} for t in sorted(timeline)]
         path = self._path("causal_timeline.json")
         with open(path, "w") as f:
-            json.dump(data, f, indent=2)
+            json.dump({"label": "causal_timeline", "value": data}, f, indent=2)
         return data
 
     # ------------------------------------------------------------
@@ -340,7 +340,9 @@ class CausalAnalyst(OutputDirMixin, JsonLinesMixin):
                 counts[node][to_layer] += 1
         path = self._path("layer_transition_events.json")
         with open(path, "w") as f:
-            json.dump(counts, f, indent=2)
+            json.dump(
+                {"label": "layer_transition_events", "value": counts}, f, indent=2
+            )
         self.summary["layer_transition_events"] = counts
 
     # ------------------------------------------------------------

--- a/Causal_Web/engine/logging/log_utils.py
+++ b/Causal_Web/engine/logging/log_utils.py
@@ -116,7 +116,13 @@ def export_curvature_map() -> None:
                     }
                     for k, v in edges.items()
                 ]
-                grid.append({"tick": int(tick), "edges": records})
+                grid.append(
+                    {
+                        "tick": int(tick),
+                        "label": "curvature_map",
+                        "value": records,
+                    }
+                )
     except FileNotFoundError:
         return
 
@@ -150,9 +156,23 @@ def export_regional_maps() -> None:
         matrix[key] = matrix.get(key, 0) + 1
 
     with open(Config.output_path("regional_pressure_map.json"), "w") as f:
-        json.dump(regional_pressure, f, indent=2)
+        json.dump(
+            {
+                "label": "regional_pressure_map",
+                "value": regional_pressure,
+            },
+            f,
+            indent=2,
+        )
     with open(Config.output_path("cluster_influence_matrix.json"), "w") as f:
-        json.dump(matrix, f, indent=2)
+        json.dump(
+            {
+                "label": "cluster_influence_matrix",
+                "value": matrix,
+            },
+            f,
+            indent=2,
+        )
     print("✅ Regional influence maps exported")
 
 

--- a/Causal_Web/engine/logging/logger.py
+++ b/Causal_Web/engine/logging/logger.py
@@ -7,7 +7,7 @@ from typing import Any, DefaultDict, List
 from pydantic import BaseModel
 
 from ...config import Config
-from ..models.logging import GenericLogEntry
+from ..models.logging import GenericLogEntry, PeriodicLogEntry
 
 
 class LogBuffer:
@@ -72,16 +72,76 @@ def log_json(path: str, data: Any) -> None:
     name = os.path.basename(path)
     if not Config.is_log_enabled(name):
         return
+    PERIODIC_FILES = {
+        "cluster_influence_matrix.json",
+        "curvature_map.json",
+        "global_diagnostics.json",
+        "regional_pressure_map.json",
+        "void_node_map.json",
+        "explanation_graph.json",
+        "causal_chains.json",
+        "causal_timeline.json",
+        "boundary_interaction_log.json",
+        "bridge_decay_log.json",
+        "bridge_dynamics_log.json",
+        "bridge_reformation_log.json",
+        "bridge_rupture_log.json",
+        "bridge_state_log.json",
+        "classicalization_map.json",
+        "cluster_log.json",
+        "coherence_log.json",
+        "coherence_velocity_log.json",
+        "collapse_chain_log.json",
+        "collapse_front_log.json",
+        "connectivity_log.json",
+        "curvature_log.json",
+        "decoherence_log.json",
+        "event_log.json",
+        "inspection_log.json",
+        "interference_log.json",
+        "law_drift_log.json",
+        "law_wave_log.json",
+        "stable_frequency_log.json",
+        "layer_transition_log.json",
+        "layer_transition_events.json",
+        "meta_node_tick_log.json",
+        "node_emergence_log.json",
+        "node_state_log.json",
+        "node_state_map.json",
+        "observer_disagreement_log.json",
+        "observer_perceived_field.json",
+        "proper_time_log.json",
+        "refraction_log.json",
+        "structural_growth_log.json",
+        "tick_density_map.json",
+    }
+
     if isinstance(data, BaseModel):
         entry = data
     else:
-        if isinstance(data, dict):
-            tick = data.get("tick", 0)
-            payload = {k: v for k, v in data.items() if k != "tick"}
+        if name in PERIODIC_FILES:
+            if isinstance(data, dict):
+                tick = data.pop("tick", None)
+                if len(data) == 1 and next(iter(data)).isdigit():
+                    k = next(iter(data))
+                    tick = int(k)
+                    value = data[k]
+                else:
+                    value = data
+            else:
+                tick = None
+                value = data
+            entry = PeriodicLogEntry(
+                tick=tick, label=name.replace(".json", ""), value=value
+            )
         else:
-            tick = 0
-            payload = data
-        entry = GenericLogEntry(
-            event_type=name.replace(".json", ""), tick=tick, payload=payload
-        )
+            if isinstance(data, dict):
+                tick = data.get("tick", 0)
+                payload = {k: v for k, v in data.items() if k != "tick"}
+            else:
+                tick = 0
+                payload = data
+            entry = GenericLogEntry(
+                event_type=name.replace(".json", ""), tick=tick, payload=payload
+            )
     log_manager.log(path, entry)

--- a/Causal_Web/engine/models/logging.py
+++ b/Causal_Web/engine/models/logging.py
@@ -19,15 +19,26 @@ class BaseLogEntry(BaseModel):
     correlation_id: Optional[str] = None
 
 
+class PeriodicLogEntry(BaseModel):
+    """Simpler schema for periodic or summary records."""
+
+    tick: int | None = None
+    label: str
+    value: Any
+    metadata: Dict[str, Any] | None = None
+
+
 class NodeEmergencePayload(BaseModel):
     node_id: str
     origin_type: str
     parents: List[str]
 
 
-class NodeEmergenceLog(BaseLogEntry):
-    event_type: str = "NodeEmerged"
-    payload: NodeEmergencePayload
+class NodeEmergenceLog(PeriodicLogEntry):
+    """Record the appearance of a new node."""
+
+    label: str = "node_emergence"
+    value: NodeEmergencePayload
 
 
 class StructuralGrowthPayload(BaseModel):
@@ -38,9 +49,11 @@ class StructuralGrowthPayload(BaseModel):
     avg_coherence: float
 
 
-class StructuralGrowthLog(BaseLogEntry):
-    event_type: str = "StructuralGrowthSnapshot"
-    payload: StructuralGrowthPayload
+class StructuralGrowthLog(PeriodicLogEntry):
+    """Snapshot of overall network growth metrics."""
+
+    label: str = "structural_growth"
+    value: StructuralGrowthPayload
 
 
 class GenericLogEntry(BaseLogEntry):

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -601,7 +601,9 @@ class GlobalDiagnosticsService:
             "network_adaptivity_index": round(adaptivity, 3),
         }
         with open(Config.output_path("global_diagnostics.json"), "w") as f:
-            json.dump(diagnostics, f, indent=2)
+            json.dump(
+                {"label": "global_diagnostics", "value": diagnostics}, f, indent=2
+            )
         print("✅ Global diagnostics exported")
 
     # ------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -334,10 +334,10 @@ disk writes. The frequency of metric logging is controlled by the
 in the **Log Files** window.
 Hovering over any log entry now shows a brief description of that log file.
 All records are wrapped by Pydantic models from
-`engine/models/logging.py`. Generic logs use ``GenericLogEntry`` while
-specialised events such as ``NodeEmergenceLog`` retain their dedicated
-payloads. This provides consistent metadata across files and simplifies
-downstream analysis.
+`engine/models/logging.py`. Diagnostic entries use ``GenericLogEntry``
+while higher level summaries rely on ``PeriodicLogEntry`` (e.g.
+``NodeEmergenceLog`` or structural growth snapshots). This provides
+consistent metadata across files and simplifies downstream analysis.
 
 - `boundary_interaction_log.json` – interactions with void or boundary nodes.
 - `bridge_decay_log.json` – gradual weakening of inactive bridges.
@@ -402,9 +402,8 @@ and event-driven records are structured across these files.
 The following lists describe the JSON keys recorded in each output file.
 
 #### `boundary_interaction_log.json`
-- `tick` – simulation tick of the event.
-- `origin` – node that emitted the triggering tick.
-- `node`/`void` – identifier of the boundary or void node affected.
+- event-driven record with `tick`, `label` as the affected node and
+  `value` containing the tick `origin`.
 
 #### `bridge_decay_log.json`
 - `tick` – tick when decay occurred.
@@ -449,7 +448,8 @@ The following lists describe the JSON keys recorded in each output file.
 - keyed by tick with `{node: bool}` indicating if a node is classicalised.
 
 #### `cluster_influence_matrix.json`
-- `{ "regionA->regionB": count }` mapping between regions based on edges.
+- periodic entry labelled `cluster_influence_matrix` mapping
+  `{ "regionA->regionB": count }` between regions based on edges.
 
 #### `cluster_log.json`
 - keyed by tick with hierarchical cluster assignments per level.
@@ -480,7 +480,9 @@ The following lists describe the JSON keys recorded in each output file.
   - `curved_delay` – resulting delay value.
 
 #### `curvature_map.json`
-- list of `{tick, edges:[{source, target, delay}]}` for visualisation.
+- list of periodic records using `tick`, `label` set to
+  `curvature_map` and `value` containing `{source, target, delay}`
+  entries for visualisation.
 
 #### `decoherence_log.json`
 - keyed by tick with `{node: decoherence}` values.
@@ -491,9 +493,9 @@ The following lists describe the JSON keys recorded in each output file.
     `coherence_at_event`.
 
 #### `global_diagnostics.json`
-- run-level metrics:
-  - `coherence_stability_score`, `entropy_delta`,
-    `collapse_resilience_index`, `network_adaptivity_index`.
+- event-driven entry labelled `global_diagnostics` containing
+  `coherence_stability_score`, `entropy_delta`,
+  `collapse_resilience_index` and `network_adaptivity_index`.
 
 #### `inspection_log.json`
 - list of superposition inspections with keys:
@@ -557,7 +559,8 @@ The following lists describe the JSON keys recorded in each output file.
   `recursion_from` or `from`/`via`/`to` paths.
 
 #### `regional_pressure_map.json`
-- mapping of regions to averaged decoherence pressure.
+- periodic entry labelled `regional_pressure_map` with averaged
+  decoherence pressure per region.
 
 #### `should_tick_log.json`
 - decisions from `should_tick` with `node` and `reason`.
@@ -595,7 +598,8 @@ The following lists describe the JSON keys recorded in each output file.
 - complete graph snapshot including nodes, edges, bridges and tick history.
 
 #### `void_node_map.json`
-- list of node ids with no connections.
+- periodic entry labelled `void_node_map` listing node ids with no
+  connections.
 
 #### `manifest.json`
 - summary produced by `bundle_run.py` containing run metadata such as
@@ -616,15 +620,17 @@ The following lists describe the JSON keys recorded in each output file.
 - human readable narrative of the explanation events.
 
 #### `explanation_graph.json`
-- DAG describing causal chains with nodes (`id`, `tick`, `type`, `node`, `description`)
-  and edges (`source`, `target`, `label`).
+- periodic record labelled `explanation_graph` containing a DAG with
+  nodes (`id`, `tick`, `type`, `node`, `description`) and edges
+  (`source`, `target`, `label`).
 
 #### `causal_chains.json`
-- list of causal chains each containing `root_event`, `chain` steps
-  and overall `confidence`.
+- event-driven entry labelled `causal_chains` containing each chain's
+  `root_event`, `chain` steps and overall `confidence`.
 
 #### `causal_timeline.json`
-- ordered list of `{tick, events}` where each event notes a `type` and involved nodes.
+- periodic log labelled `causal_timeline` where each item stores
+  `tick` and a list of event descriptors.
 
 #### `cwt_console.txt`
 - captured console output from the run.


### PR DESCRIPTION
## Summary
- implement `PeriodicLogEntry`
- convert node emergence and structural growth logs to periodic schema
- adapt `log_json` to wrap summary logs in PeriodicLogEntry
- adjust log exporters to use the new schema
- document periodic logging in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688a3eebe31c8325bd97454b6af3deec