### PR TITLE
Add logging mode with categories

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -98,10 +98,108 @@ class Config:
         "tick_seed_log.json": True,
     }
 
+    #: Allowed logging modes. ``diagnostic`` enables all logs. ``tick`` enables
+    #: per-tick metrics, ``phenomena`` enables aggregated summaries and
+    #: ``events`` enables event driven logs.
+    logging_mode = ["diagnostic"]
+
+    #: Files written on a per-tick basis. Derived from :mod:`logger`.
+    PERIODIC_FILES = {
+        "cluster_influence_matrix.json",
+        "curvature_map.json",
+        "global_diagnostics.json",
+        "regional_pressure_map.json",
+        "void_node_map.json",
+        "explanation_graph.json",
+        "causal_chains.json",
+        "causal_timeline.json",
+        "boundary_interaction_log.json",
+        "bridge_decay_log.json",
+        "bridge_dynamics_log.json",
+        "bridge_reformation_log.json",
+        "bridge_rupture_log.json",
+        "bridge_state_log.json",
+        "classicalization_map.json",
+        "cluster_log.json",
+        "coherence_log.json",
+        "coherence_velocity_log.json",
+        "collapse_chain_log.json",
+        "collapse_front_log.json",
+        "connectivity_log.json",
+        "curvature_log.json",
+        "decoherence_log.json",
+        "event_log.json",
+        "inspection_log.json",
+        "interference_log.json",
+        "law_drift_log.json",
+        "law_wave_log.json",
+        "stable_frequency_log.json",
+        "layer_transition_log.json",
+        "layer_transition_events.json",
+        "meta_node_tick_log.json",
+        "node_emergence_log.json",
+        "node_state_log.json",
+        "node_state_map.json",
+        "observer_disagreement_log.json",
+        "observer_perceived_field.json",
+        "proper_time_log.json",
+        "refraction_log.json",
+        "structural_growth_log.json",
+        "tick_density_map.json",
+    }
+
+    #: Files summarising emergent behaviour rather than raw events.
+    PHENOMENA_FILES = {
+        "cluster_influence_matrix.json",
+        "curvature_map.json",
+        "global_diagnostics.json",
+        "regional_pressure_map.json",
+        "void_node_map.json",
+        "explanation_graph.json",
+        "causal_chains.json",
+        "causal_timeline.json",
+        "interpretation_log.json",
+        "inspection_log.json",
+    }
+
+    #: Files generated each tick or at regular intervals.
+    TICK_FILES = {
+        "bridge_state_log.json",
+        "cluster_log.json",
+        "coherence_log.json",
+        "coherence_velocity_log.json",
+        "curvature_log.json",
+        "decoherence_log.json",
+        "interference_log.json",
+        "law_wave_log.json",
+        "meta_node_tick_log.json",
+        "node_state_log.json",
+        "proper_time_log.json",
+        "structural_growth_log.json",
+        "tick_delivery_log.json",
+        "tick_evaluation_log.json",
+        "tick_seed_log.json",
+        "stable_frequency_log.json",
+    }
+
     @classmethod
     def is_log_enabled(cls, name: str) -> bool:
-        """Return ``True`` if the given log file should be written."""
-        return cls.log_files.get(name, True)
+        """Return ``True`` if ``name`` should be written based on configuration."""
+        if not cls.log_files.get(name, True):
+            return False
+
+        mode = set(getattr(cls, "logging_mode", ["diagnostic"]))
+        if "diagnostic" in mode:
+            return True
+
+        if name in cls.TICK_FILES:
+            category = "tick"
+        elif name in cls.PHENOMENA_FILES:
+            category = "phenomena"
+        else:
+            category = "events"
+
+        return category in mode
 
     @classmethod
     def save_log_files(cls, path: str | None = None) -> None:

--- a/Causal_Web/engine/logging/logger.py
+++ b/Causal_Web/engine/logging/logger.py
@@ -72,49 +72,7 @@ def log_json(path: str, data: Any) -> None:
     name = os.path.basename(path)
     if not Config.is_log_enabled(name):
         return
-    PERIODIC_FILES = {
-        "cluster_influence_matrix.json",
-        "curvature_map.json",
-        "global_diagnostics.json",
-        "regional_pressure_map.json",
-        "void_node_map.json",
-        "explanation_graph.json",
-        "causal_chains.json",
-        "causal_timeline.json",
-        "boundary_interaction_log.json",
-        "bridge_decay_log.json",
-        "bridge_dynamics_log.json",
-        "bridge_reformation_log.json",
-        "bridge_rupture_log.json",
-        "bridge_state_log.json",
-        "classicalization_map.json",
-        "cluster_log.json",
-        "coherence_log.json",
-        "coherence_velocity_log.json",
-        "collapse_chain_log.json",
-        "collapse_front_log.json",
-        "connectivity_log.json",
-        "curvature_log.json",
-        "decoherence_log.json",
-        "event_log.json",
-        "inspection_log.json",
-        "interference_log.json",
-        "law_drift_log.json",
-        "law_wave_log.json",
-        "stable_frequency_log.json",
-        "layer_transition_log.json",
-        "layer_transition_events.json",
-        "meta_node_tick_log.json",
-        "node_emergence_log.json",
-        "node_state_log.json",
-        "node_state_map.json",
-        "observer_disagreement_log.json",
-        "observer_perceived_field.json",
-        "proper_time_log.json",
-        "refraction_log.json",
-        "structural_growth_log.json",
-        "tick_density_map.json",
-    }
+    PERIODIC_FILES = Config.PERIODIC_FILES
 
     if isinstance(data, BaseModel):
         entry = data

--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -534,9 +534,9 @@ class CanvasWidget(QGraphicsView):
                 item.node_id
             )
         elif isinstance(item, EdgeItem):
-            actions[menu.addAction("Delete Connection")] = (
-                lambda: self.delete_connection(item.index, item.connection_type)
-            )
+            actions[
+                menu.addAction("Delete Connection")
+            ] = lambda: self.delete_connection(item.index, item.connection_type)
         elif isinstance(item, ObserverItem):
             actions[menu.addAction("Delete Observer")] = lambda: self.delete_observer(
                 item.index

--- a/Causal_Web/gui_pyside/log_files_window.py
+++ b/Causal_Web/gui_pyside/log_files_window.py
@@ -95,12 +95,31 @@ class LogFilesWindow(QMainWindow):
         container = QWidget()
         checks = QVBoxLayout(container)
 
-        for name in sorted(Config.log_files):
-            desc = LOG_TIPS.get(name, "")
-            cb = TooltipCheckBox(name, desc)
-            cb.setChecked(Config.log_files.get(name, True))
-            self._checkboxes[name] = cb
-            checks.addWidget(cb)
+        tick_logs = sorted(n for n in Config.log_files if n in Config.TICK_FILES)
+        phen_logs = sorted(n for n in Config.log_files if n in Config.PHENOMENA_FILES)
+        event_logs = sorted(
+            n
+            for n in Config.log_files
+            if n not in Config.TICK_FILES and n not in Config.PHENOMENA_FILES
+        )
+
+        for title, names in [
+            ("Tick", tick_logs),
+            ("Phenomena", phen_logs),
+            ("Events", event_logs),
+        ]:
+            if not names:
+                continue
+            header = QLabel(title)
+            header.setStyleSheet("font-weight: bold")
+            checks.addWidget(header)
+            for name in names:
+                desc = LOG_TIPS.get(name, "")
+                cb = TooltipCheckBox(name, desc)
+                cb.setChecked(Config.log_files.get(name, True))
+                self._checkboxes[name] = cb
+                checks.addWidget(cb)
+            checks.addSpacing(10)
         checks.addStretch()
 
         scroll.setWidget(container)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ python -m Causal_Web.main --no-gui --max_ticks 20
 Use `--init-db` to create PostgreSQL tables defined in the configuration and exit.
 
 ## Output Logs
-Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`.
+Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. The `logging_mode` option selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 
 ## Contributing
 Unit tests live under `tests/` and can be run with `pytest`. Coding guidelines and packaging instructions are documented in [AGENTS.md](AGENTS.md) and [docs/developer_guide.md](docs/developer_guide.md).

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,3 +13,19 @@ def test_load_from_file_resolves_graph_file(tmp_path):
     finally:
         Config.graph_file = original
 
+
+def test_logging_mode_filters_categories():
+    original_mode = getattr(Config, "logging_mode", ["diagnostic"])
+    original_files = dict(Config.log_files)
+    try:
+        Config.logging_mode = ["tick"]
+        Config.log_files = {
+            "coherence_log.json": True,
+            "event_log.json": True,
+        }
+        assert Config.is_log_enabled("coherence_log.json")
+        assert not Config.is_log_enabled("event_log.json")
+    finally:
+        Config.logging_mode = original_mode
+        Config.log_files = original_files
+


### PR DESCRIPTION
## Summary
- add `logging_mode` option with tick/phenomena/event categories
- organize log files in GUI by category
- expose log categories in README
- update config test for new option

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a578756c08325b85ceaa919aaa44b