### PR TITLE
Consolidate logging API

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -158,6 +158,8 @@ class Config:
         "explanation_graph.json",
         "causal_chains.json",
         "causal_timeline.json",
+        "connectivity_log.json",
+        "classicalization_map.json",
         "interpretation_log.json",
         "inspection_log.json",
     }
@@ -183,23 +185,27 @@ class Config:
     }
 
     @classmethod
+    def category_for_file(cls, name: str) -> str:
+        """Return the logging category for *name*."""
+        if name in cls.TICK_FILES:
+            return "tick"
+        if name in cls.PHENOMENA_FILES:
+            return "phenomena"
+        return "event"
+
+    @classmethod
+    def is_category_enabled(cls, category: str) -> bool:
+        """Return ``True`` if ``category`` should be written based on mode."""
+        mode = set(getattr(cls, "logging_mode", ["diagnostic"]))
+        return "diagnostic" in mode or category in mode
+
+    @classmethod
     def is_log_enabled(cls, name: str) -> bool:
         """Return ``True`` if ``name`` should be written based on configuration."""
         if not cls.log_files.get(name, True):
             return False
-
-        mode = set(getattr(cls, "logging_mode", ["diagnostic"]))
-        if "diagnostic" in mode:
-            return True
-
-        if name in cls.TICK_FILES:
-            category = "tick"
-        elif name in cls.PHENOMENA_FILES:
-            category = "phenomena"
-        else:
-            category = "events"
-
-        return category in mode
+        category = cls.category_for_file(name)
+        return cls.is_category_enabled(category)
 
     @classmethod
     def save_log_files(cls, path: str | None = None) -> None:

--- a/Causal_Web/engine/logging/log_utils.py
+++ b/Causal_Web/engine/logging/log_utils.py
@@ -40,7 +40,7 @@ def log_curvature_per_tick(global_tick: int) -> None:
             "delta_f": round(df, 4),
             "curved_delay": round(curved, 4),
         }
-    log_json(Config.output_path("curvature_log.json"), {str(global_tick): log})
+    log_json("tick", "curvature_log", log, tick=global_tick)
 
 
 def log_bridge_states(global_tick: int) -> None:
@@ -57,7 +57,7 @@ def log_bridge_states(global_tick: int) -> None:
         }
         for b in _graph.bridges
     }
-    log_json(Config.output_path("bridge_state_log.json"), {str(global_tick): snapshot})
+    log_json("tick", "bridge_state_log", snapshot, tick=global_tick)
 
 
 def log_meta_node_ticks(global_tick: int) -> None:
@@ -74,10 +74,7 @@ def log_meta_node_ticks(global_tick: int) -> None:
         if member_ticks:
             events[meta_id] = member_ticks
         if events:
-            log_json(
-                Config.output_path("meta_node_tick_log.json"),
-                {str(global_tick): events},
-            )
+            log_json("tick", "meta_node_tick_log", events, tick=global_tick)
 
 
 def snapshot_graph(global_tick: int) -> Optional[str]:

--- a/Causal_Web/engine/models/base.py
+++ b/Causal_Web/engine/models/base.py
@@ -15,7 +15,11 @@ class LoggingMixin:
 
     def _log(self, name: str, record: dict[str, Any]) -> None:
         """Write ``record`` to the configured log ``name``."""
-        log_json(Config.output_path(name), record)
+        category = Config.category_for_file(name)
+        label = name.replace(".json", "")
+        tick = record.get("tick")
+        payload = {k: v for k, v in record.items() if k != "tick"}
+        log_json(category, label, payload, tick=tick)
 
 
 class PathLoggingMixin:
@@ -23,7 +27,12 @@ class PathLoggingMixin:
 
     def _log_path(self, path: str, record: dict[str, Any]) -> None:
         """Write ``record`` directly to ``path``."""
-        log_json(path, record)
+        name = os.path.basename(path)
+        category = Config.category_for_file(name)
+        label = name.replace(".json", "")
+        tick = record.get("tick")
+        payload = {k: v for k, v in record.items() if k != "tick"}
+        log_json(category, label, payload, tick=tick)
 
 
 class OutputDirMixin:

--- a/Causal_Web/engine/models/graph.py
+++ b/Causal_Web/engine/models/graph.py
@@ -625,9 +625,9 @@ class CausalGraph:
                 if other and other.node_type == NodeType.NULL:
                     print(f"[WARNING] Bridge {nid}<->{b} connected to NULL node")
         if self.void_nodes:
-            log_json(Config.output_path("void_node_map.json"), self.void_nodes)
+            log_json("phenomena", "void_node_map", self.void_nodes)
         if Config.is_log_enabled("connectivity_log.json"):
-            log_json(Config.output_path("connectivity_log.json"), connectivity_log)
+            log_json("phenomena", "connectivity_log", connectivity_log)
 
     # ------------------------------------------------------------
     def emit_law_wave(self, origin_id: str, tick: int, radius: int = 2) -> None:
@@ -650,6 +650,8 @@ class CausalGraph:
                     frontier.append((edge.target, dist + 1))
         if affected:
             log_json(
-                Config.output_path("law_wave_log.json"),
-                {"tick": tick, "origin": origin_id, "affected": affected},
+                "tick",
+                "law_wave_log",
+                {"origin": origin_id, "affected": affected},
+                tick=tick,
             )

--- a/Causal_Web/engine/models/logging.py
+++ b/Causal_Web/engine/models/logging.py
@@ -61,3 +61,4 @@ class GenericLogEntry(BaseLogEntry):
 
     event_type: str
     payload: Any
+    metadata: Dict[str, Any] | None = None

--- a/Causal_Web/engine/models/node.py
+++ b/Causal_Web/engine/models/node.py
@@ -694,14 +694,15 @@ class Edge:
             from ..logging.logger import log_json
 
             log_json(
-                Config.output_path("delay_density_log.json"),
+                "event",
+                "delay_density_log",
                 {
-                    "tick": getattr(Config, "current_tick", 0),
                     "edge": f"{self.source}->{self.target}",
                     "rho": rho,
                     "base": self.delay,
                     "result": delay_int,
                 },
+                tick=getattr(Config, "current_tick", 0),
             )
 
         return delay_int

--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -182,8 +182,10 @@ class NodeTickService:
 
         if self.node.node_type == NodeType.NULL:
             log_json(
-                Config.output_path("boundary_interaction_log.json"),
-                {"tick": self.tick_time, "void": self.node.id, "origin": self.origin},
+                "event",
+                "boundary_interaction_log",
+                {"void": self.node.id, "origin": self.origin},
+                tick=self.tick_time,
             )
             te.void_absorption_events += 1
             self.node._log_tick_drop(self.tick_time, "void_node")
@@ -194,8 +196,10 @@ class NodeTickService:
             return False
         if getattr(self.node, "boundary", False):
             log_json(
-                Config.output_path("boundary_interaction_log.json"),
-                {"tick": self.tick_time, "node": self.node.id, "origin": self.origin},
+                "event",
+                "boundary_interaction_log",
+                {"node": self.node.id, "origin": self.origin},
+                tick=self.tick_time,
             )
             te.boundary_interactions_count += 1
         if not te.register_firing(self.node):
@@ -226,8 +230,10 @@ class NodeTickService:
             n.phase = self.phase
             n.tick_history.append(tick_obj)
         log_json(
-            Config.output_path("tick_emission_log.json"),
-            {"tick": self.tick_time, "node_id": n.id, "phase": self.phase},
+            "event",
+            "tick_emission_log",
+            {"node_id": n.id, "phase": self.phase},
+            tick=self.tick_time,
         )
         with n.lock:
             if self.origin == "self":
@@ -292,12 +298,10 @@ class EdgePropagationService:
             e.target == self.origin for e in self.graph.get_edges_from(self.node.id)
         ):
             log_json(
-                Config.output_path("refraction_log.json"),
-                {
-                    "tick": self.tick_time,
-                    "recursion_from": self.origin,
-                    "node": self.node.id,
-                },
+                "event",
+                "refraction_log",
+                {"recursion_from": self.origin, "node": self.node.id},
+                tick=self.tick_time,
             )
 
     # ------------------------------------------------------------------
@@ -343,14 +347,15 @@ class EdgePropagationService:
     # ------------------------------------------------------------------
     def _log_propagation(self, target: Node, delay: float, shifted: float) -> None:
         log_json(
-            Config.output_path("tick_propagation_log.json"),
+            "event",
+            "tick_propagation_log",
             {
-                "tick": self.tick_time,
                 "source": self.node.id,
                 "target": target.id,
                 "arrival_time": self.tick_time + delay,
                 "phase": shifted,
             },
+            tick=self.tick_time,
         )
 
     # ------------------------------------------------------------------
@@ -378,13 +383,10 @@ class EdgePropagationService:
         )
         target.node_type = NodeType.REFRACTIVE
         log_json(
-            Config.output_path("refraction_log.json"),
-            {
-                "tick": self.tick_time,
-                "from": self.node.id,
-                "via": target.id,
-                "to": alt_tgt.id,
-            },
+            "event",
+            "refraction_log",
+            {"from": self.node.id, "via": target.id, "to": alt_tgt.id},
+            tick=self.tick_time,
         )
         return True
 
@@ -474,8 +476,10 @@ class NodeTickDecisionService:
     def _below_count(self, coherence: float) -> tuple[bool, None, str]:
         self._log_eval(coherence, False, False, "below_count")
         log_json(
-            Config.output_path("should_tick_log.json"),
-            {"tick": self.tick_time, "node": self.node.id, "reason": "below_count"},
+            "event",
+            "should_tick_log",
+            {"node": self.node.id, "reason": "below_count"},
+            tick=self.tick_time,
         )
         return False, None, "count_threshold"
 
@@ -492,8 +496,10 @@ class NodeTickDecisionService:
         resultant_phase = cmath.phase(vector_sum)
         self._log_eval(coherence, False, True)
         log_json(
-            Config.output_path("should_tick_log.json"),
-            {"tick": self.tick_time, "node": self.node.id, "reason": "threshold"},
+            "event",
+            "should_tick_log",
+            {"node": self.node.id, "reason": "threshold"},
+            tick=self.tick_time,
         )
         return True, resultant_phase, "threshold"
 
@@ -501,8 +507,10 @@ class NodeTickDecisionService:
     def _fire_by_merge(self, coherence: float, phase: float) -> tuple[bool, float, str]:
         self._log_eval(coherence, False, True, "merged")
         log_json(
-            Config.output_path("should_tick_log.json"),
-            {"tick": self.tick_time, "node": self.node.id, "reason": "merged"},
+            "event",
+            "should_tick_log",
+            {"node": self.node.id, "reason": "merged"},
+            tick=self.tick_time,
         )
         return True, phase, "merged"
 
@@ -512,13 +520,14 @@ class NodeTickDecisionService:
     ) -> tuple[bool, None, str]:
         self._log_eval(coherence, False, False, "below_threshold")
         log_json(
-            Config.output_path("magnitude_failure_log.json"),
+            "event",
+            "magnitude_failure_log",
             {
-                "tick": self.tick_time,
                 "node": self.node.id,
                 "magnitude": round(magnitude, 4),
                 "threshold": round(self.node.current_threshold, 4),
                 "phases": len(raw_items),
             },
+            tick=self.tick_time,
         )
         return False, None, "below_threshold"

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -97,12 +97,13 @@ class NodeMetricsResultService:
         if record["stable"] >= 10:
             node.refractory_period = max(1.0, node.refractory_period - 0.1)
             log_json(
-                Config.output_path("law_drift_log.json"),
+                "event",
+                "law_drift_log",
                 {
-                    "tick": self.tick,
                     "node": node_id,
                     "new_refractory_period": node.refractory_period,
                 },
+                tick=self.tick,
             )
             record["stable"] = 0
         if record["stable"] >= 5:
@@ -196,55 +197,36 @@ class NodeMetricsService:
         clusters = self.graph.hierarchical_clusters()
         self.graph.create_meta_nodes(clusters.get(0, []))
         if tick % getattr(Config, "log_interval", 1) == 0:
-            log_json(Config.output_path("cluster_log.json"), {str(tick): clusters})
+            log_json("tick", "cluster_log", clusters, tick=tick)
 
     # ------------------------------------------------------------------
     def _write_logs(self, tick: int, logs: dict) -> None:
-        log_json(
-            Config.output_path("law_wave_log.json"), {str(tick): logs["law_wave_log"]}
-        )
+        log_json("tick", "law_wave_log", logs["law_wave_log"], tick=tick)
         if logs["stable_frequency_log"]:
             log_json(
-                Config.output_path("stable_frequency_log.json"),
-                {str(tick): logs["stable_frequency_log"]},
+                "tick", "stable_frequency_log", logs["stable_frequency_log"], tick=tick
             )
+        log_json("tick", "decoherence_log", logs["decoherence_log"], tick=tick)
+        log_json("tick", "coherence_log", logs["coherence_log"], tick=tick)
         log_json(
-            Config.output_path("decoherence_log.json"),
-            {str(tick): logs["decoherence_log"]},
+            "tick", "coherence_velocity_log", logs["coherence_velocity"], tick=tick
         )
         log_json(
-            Config.output_path("coherence_log.json"), {str(tick): logs["coherence_log"]}
+            "phenomena", "classicalization_map", logs["classical_state"], tick=tick
         )
+        log_json("tick", "interference_log", logs["interference_log"], tick=tick)
+        log_json("tick", "tick_density_map", logs["interference_log"], tick=tick)
         log_json(
-            Config.output_path("coherence_velocity_log.json"),
-            {str(tick): logs["coherence_velocity"]},
-        )
-        log_json(
-            Config.output_path("classicalization_map.json"),
-            {str(tick): logs["classical_state"]},
-        )
-        log_json(
-            Config.output_path("interference_log.json"),
-            {str(tick): logs["interference_log"]},
-        )
-        log_json(
-            Config.output_path("tick_density_map.json"),
-            {str(tick): logs["interference_log"]},
-        )
-        log_json(
-            Config.output_path("node_state_log.json"),
+            "tick",
+            "node_state_log",
             {
-                str(tick): {
-                    "type": logs["type_log"],
-                    "credit": logs["credit_log"],
-                    "debt": logs["debt_log"],
-                }
+                "type": logs["type_log"],
+                "credit": logs["credit_log"],
+                "debt": logs["debt_log"],
             },
+            tick=tick,
         )
-        log_json(
-            Config.output_path("proper_time_log.json"),
-            {str(tick): logs["proper_time_log"]},
-        )
+        log_json("tick", "proper_time_log", logs["proper_time_log"], tick=tick)
 
 
 @dataclass

--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -94,7 +94,7 @@ def _update_simulation_state(
     }
     if snapshot is not None:
         state["graph_snapshot"] = snapshot
-    log_json(Config.output_path("simulation_state.json"), state)
+    log_json("event", "simulation_state", state, tick=tick)
 
 
 def pause_simulation() -> None:

--- a/Causal_Web/engine/tick_engine/orchestrators.py
+++ b/Causal_Web/engine/tick_engine/orchestrators.py
@@ -108,8 +108,10 @@ class IOOrchestrator:
             obs.observe(self.graph, tick)
             inferred = obs.infer_field_state()
             log_json(
-                Config.output_path("observer_perceived_field.json"),
-                {"tick": tick, "observer": obs.id, "state": inferred},
+                "event",
+                "observer_perceived_field",
+                {"observer": obs.id, "state": inferred},
+                tick=tick,
             )
             actual = {n.id: len(n.tick_history) for n in self.graph.nodes.values()}
             diff = {
@@ -119,6 +121,8 @@ class IOOrchestrator:
             }
             if diff:
                 log_json(
-                    Config.output_path("observer_disagreement_log.json"),
-                    {"tick": tick, "observer": obs.id, "diff": diff},
+                    "event",
+                    "observer_disagreement_log",
+                    {"observer": obs.id, "diff": diff},
+                    tick=tick,
                 )

--- a/Causal_Web/engine/tick_engine/tick_router.py
+++ b/Causal_Web/engine/tick_engine/tick_router.py
@@ -42,5 +42,15 @@ class TickRouter:
                 "to": new_layer,
                 "trace_id": tick.trace_id,
             }
-            log_json(Config.output_path("layer_transition_log.json"), record)
+            log_json(
+                "event",
+                "layer_transition_log",
+                {
+                    "node": node.id,
+                    "from": tick.layer,
+                    "to": new_layer,
+                    "trace_id": tick.trace_id,
+                },
+                tick=tick.time,
+            )
             tick.layer = new_layer

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Use `--init-db` to create PostgreSQL tables defined in the configuration and exi
 
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. The `logging_mode` option selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
+Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.
 
 ## Contributing
 Unit tests live under `tests/` and can be run with `pytest`. Coding guidelines and packaging instructions are documented in [AGENTS.md](AGENTS.md) and [docs/developer_guide.md](docs/developer_guide.md).


### PR DESCRIPTION
## Summary
- add category-based logging helpers
- drop file-based routing in favour of consolidated logs
- update service modules for new `log_json` API
- document consolidated log files in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5b73df848325bc27bb6e32f6e561