### PR TITLE
Improve logging API

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -200,11 +200,16 @@ class Config:
         return "diagnostic" in mode or category in mode
 
     @classmethod
-    def is_log_enabled(cls, name: str) -> bool:
-        """Return ``True`` if ``name`` should be written based on configuration."""
-        if not cls.log_files.get(name, True):
+    def is_log_enabled(
+        cls, name: str | None = None, category: str | None = None
+    ) -> bool:
+        """Return ``True`` if a log entry should be written."""
+        if name is not None and not cls.log_files.get(name, True):
             return False
-        category = cls.category_for_file(name)
+        if category is None:
+            if name is None:
+                return True
+            category = cls.category_for_file(name)
         return cls.is_category_enabled(category)
 
     @classmethod

--- a/Causal_Web/engine/logging/log_utils.py
+++ b/Causal_Web/engine/logging/log_utils.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from ...config import Config
 from ..models.graph import CausalGraph
-from .logger import log_json, logger, log_manager
+from .logger import log_record, log_json, logger, log_manager
 from ..services.sim_services import GlobalDiagnosticsService
 from ..models.logging import StructuralGrowthLog, StructuralGrowthPayload
 
@@ -40,7 +40,12 @@ def log_curvature_per_tick(global_tick: int) -> None:
             "delta_f": round(df, 4),
             "curved_delay": round(curved, 4),
         }
-    log_json("tick", "curvature_log", log, tick=global_tick)
+    log_record(
+        category="tick",
+        label="curvature_log",
+        tick=global_tick,
+        value=log,
+    )
 
 
 def log_bridge_states(global_tick: int) -> None:
@@ -57,7 +62,12 @@ def log_bridge_states(global_tick: int) -> None:
         }
         for b in _graph.bridges
     }
-    log_json("tick", "bridge_state_log", snapshot, tick=global_tick)
+    log_record(
+        category="phenomena",
+        label="bridge_state",
+        tick=global_tick,
+        value=snapshot,
+    )
 
 
 def log_meta_node_ticks(global_tick: int) -> None:
@@ -74,7 +84,12 @@ def log_meta_node_ticks(global_tick: int) -> None:
         if member_ticks:
             events[meta_id] = member_ticks
         if events:
-            log_json("tick", "meta_node_tick_log", events, tick=global_tick)
+            log_record(
+                category="phenomena",
+                label="meta_node_ticks",
+                tick=global_tick,
+                value=events,
+            )
 
 
 def snapshot_graph(global_tick: int) -> Optional[str]:

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 
 from ...config import Config
-from ..logging.logger import log_json
+from ..logging.logger import log_record
 from ..models.node import Node, NodeType, Edge
 from ..models.tick import GLOBAL_TICK_POOL  # only for typing, no direct use
 from ..models.bridge import BridgeType, MediumType
@@ -96,14 +96,14 @@ class NodeMetricsResultService:
                 record["stable"] = 0
         if record["stable"] >= 10:
             node.refractory_period = max(1.0, node.refractory_period - 0.1)
-            log_json(
-                "event",
-                "law_drift_log",
-                {
+            log_record(
+                category="event",
+                label="law_drift_log",
+                tick=self.tick,
+                value={
                     "node": node_id,
                     "new_refractory_period": node.refractory_period,
                 },
-                tick=self.tick,
             )
             record["stable"] = 0
         if record["stable"] >= 5:
@@ -197,36 +197,80 @@ class NodeMetricsService:
         clusters = self.graph.hierarchical_clusters()
         self.graph.create_meta_nodes(clusters.get(0, []))
         if tick % getattr(Config, "log_interval", 1) == 0:
-            log_json("tick", "cluster_log", clusters, tick=tick)
+            log_record(
+                category="tick",
+                label="cluster_log",
+                tick=tick,
+                value=clusters,
+            )
 
     # ------------------------------------------------------------------
     def _write_logs(self, tick: int, logs: dict) -> None:
-        log_json("tick", "law_wave_log", logs["law_wave_log"], tick=tick)
+        log_record(
+            category="tick",
+            label="law_wave_log",
+            tick=tick,
+            value=logs["law_wave_log"],
+        )
         if logs["stable_frequency_log"]:
-            log_json(
-                "tick", "stable_frequency_log", logs["stable_frequency_log"], tick=tick
+            log_record(
+                category="tick",
+                label="stable_frequency_log",
+                tick=tick,
+                value=logs["stable_frequency_log"],
             )
-        log_json("tick", "decoherence_log", logs["decoherence_log"], tick=tick)
-        log_json("tick", "coherence_log", logs["coherence_log"], tick=tick)
-        log_json(
-            "tick", "coherence_velocity_log", logs["coherence_velocity"], tick=tick
+        log_record(
+            category="tick",
+            label="decoherence_log",
+            tick=tick,
+            value=logs["decoherence_log"],
         )
-        log_json(
-            "phenomena", "classicalization_map", logs["classical_state"], tick=tick
+        log_record(
+            category="tick",
+            label="coherence_log",
+            tick=tick,
+            value=logs["coherence_log"],
         )
-        log_json("tick", "interference_log", logs["interference_log"], tick=tick)
-        log_json("tick", "tick_density_map", logs["interference_log"], tick=tick)
-        log_json(
-            "tick",
-            "node_state_log",
-            {
+        log_record(
+            category="tick",
+            label="coherence_velocity_log",
+            tick=tick,
+            value=logs["coherence_velocity"],
+        )
+        log_record(
+            category="phenomena",
+            label="classicalization_map",
+            tick=tick,
+            value=logs["classical_state"],
+        )
+        log_record(
+            category="tick",
+            label="interference_log",
+            tick=tick,
+            value=logs["interference_log"],
+        )
+        log_record(
+            category="tick",
+            label="tick_density_map",
+            tick=tick,
+            value=logs["interference_log"],
+        )
+        log_record(
+            category="tick",
+            label="node_state_log",
+            tick=tick,
+            value={
                 "type": logs["type_log"],
                 "credit": logs["credit_log"],
                 "debt": logs["debt_log"],
             },
-            tick=tick,
         )
-        log_json("tick", "proper_time_log", logs["proper_time_log"], tick=tick)
+        log_record(
+            category="tick",
+            label="proper_time_log",
+            tick=tick,
+            value=logs["proper_time_log"],
+        )
 
 
 @dataclass

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Use `--init-db` to create PostgreSQL tables defined in the configuration and exi
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. The `logging_mode` option selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.
+Individual files can still be toggled via `log_files` for advanced filtering.
 
 ## Contributing
 Unit tests live under `tests/` and can be run with `pytest`. Coding guidelines and packaging instructions are documented in [AGENTS.md](AGENTS.md) and [docs/developer_guide.md](docs/developer_guide.md).

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,8 @@ def test_logging_mode_filters_categories():
         }
         assert Config.is_log_enabled("coherence_log.json")
         assert not Config.is_log_enabled("event_log.json")
+        assert Config.is_log_enabled(category="tick")
+        assert not Config.is_log_enabled(category="event")
     finally:
         Config.logging_mode = original_mode
         Config.log_files = original_files


### PR DESCRIPTION
## Summary
- centralize logging with `log_record`
- filter logs using categories in `Config.is_log_enabled`
- use `log_record` throughout logging utilities and services
- document advanced filtering via `log_files`
- extend config tests for category-based filtering

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a60514e4083259d49e37fbfbee410