### PR TITLE
Fix graph loading feedback

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -114,9 +114,9 @@ class MainWindow(QMainWindow):
         layout.setSpacing(0)
         layout.addWidget(toolbar)
         layout.addWidget(self.canvas)
-        load_btn = QPushButton("Load Graph")
-        load_btn.clicked.connect(self._load_into_main)
-        layout.addWidget(load_btn)
+        apply_btn = QPushButton("Apply Changes")
+        apply_btn.clicked.connect(self._load_into_main)
+        layout.addWidget(apply_btn)
 
         self.graph_window.setCentralWidget(central)
 
@@ -324,7 +324,9 @@ class MainWindow(QMainWindow):
         try:
             graph = load_graph(path)
         except Exception as exc:
-            print(f"Failed to load graph: {exc}")
+            from PySide6.QtWidgets import QMessageBox
+
+            QMessageBox.warning(self, "Load Failed", str(exc))
             return
         set_graph(graph)
         set_active_file(path)
@@ -346,7 +348,9 @@ class MainWindow(QMainWindow):
         try:
             save_graph(path, get_graph())
         except Exception as exc:
-            print(f"Failed to save graph: {exc}")
+            from PySide6.QtWidgets import QMessageBox
+
+            QMessageBox.warning(self, "Save Failed", str(exc))
             return
         set_active_file(path)
         clear_graph_dirty()
@@ -433,7 +437,9 @@ class MainWindow(QMainWindow):
             try:
                 save_graph(path, model)
             except Exception as exc:
-                print(f"Failed to save graph: {exc}")
+                from PySide6.QtWidgets import QMessageBox
+
+                QMessageBox.warning(self, "Save Failed", str(exc))
             else:
                 clear_graph_dirty()
         self.start_button.setEnabled(get_active_file() is not None)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Clone the repository and install the packages listed in `requirements.txt`. The 
 ## Usage
 Graphs are stored as JSON files under `input/`. Each file defines `nodes`, `edges`, optional `bridges`, `tick_sources`, `observers` and `meta_nodes`. See [docs/graph_format.md](docs/graph_format.md) for the complete schema and an example.
 
-The GUI allows interactive editing of graphs. Drag nodes to reposition them and use the toolbar to add connections or observers. Details on all GUI actions are provided in [docs/gui_usage.md](docs/gui_usage.md).
+The GUI allows interactive editing of graphs. Drag nodes to reposition them and use the toolbar to add connections or observers. After editing, click **Apply Changes** in the Graph View to update the simulation and save the file. Details on all GUI actions are provided in [docs/gui_usage.md](docs/gui_usage.md).
 
 Runs produce a set of JSON logs in `output/`. The script `bundle_run.py` can be used after a simulation to archive the results. Full descriptions of each log file and their fields are available in [docs/log_schemas.md](docs/log_schemas.md).
 

--- a/docs/gui_usage.md
+++ b/docs/gui_usage.md
@@ -13,3 +13,5 @@ When a node or edge is selected a panel appears allowing its parameters to be ed
 The **Control Panel** window lets you start, pause or stop the simulation and set the tick limit and rate. A tick counter shows the current tick. Window resizing keeps the graph responsive and rendering updates only when the graph changes to reduce idle CPU usage.
 
 Saved graphs are copied into each run directory when the simulation starts so the exact input is preserved. The GUI also exposes a **Log Files** window to enable or disable specific logs.
+
+Changes made in the Graph View are applied back to the main window using the **Apply Changes** button. This action also writes the current graph to disk when a file is loaded.


### PR DESCRIPTION
## Summary
- rename graph editor button to **Apply Changes**
- show a warning dialog if loading or saving the graph fails
- document the Apply Changes workflow

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688a6a3c31a083258844d803335c9564