### PR TITLE
Fix CLI arg duplication

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -43,7 +43,7 @@ def _add_config_args(
         arg_name = f"--{prefix}{key}"
         dest = f"{prefix}{key}".replace(".", "_")
         if isinstance(value, dict):
-            _add_config_args(parser, value, prefix=f"{key}.")
+            _add_config_args(parser, value, prefix=f"{prefix}{key}.")
             continue
         arg_type = type(value)
         if isinstance(value, bool):

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Runtime parameters are loaded from `input/config.json`. Any value can be overrid
 ```bash
 python -m Causal_Web.main --no-gui --max_ticks 20
 ```
+CLI flags for nested `log_files` entries now include the full path prefix to avoid duplicate
+argument names. For example, use `--log_files.tick.coherence_log false` to disable a single tick log.
 Use `--init-db` to create PostgreSQL tables defined in the configuration and exit.
 Additional flags allow enabling or disabling specific logs without editing
 `config.json`:


### PR DESCRIPTION
## Summary
- avoid duplicate CLI flag names by preserving prefixes
- document the nested log flag prefix behavior

## Testing
- `pip install numpy networkx pytest pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a76c058ac832581755066f3f52812