### PR TITLE
Implement variable density strategies

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -281,6 +281,10 @@ class Config:
     use_dynamic_density = False
     density_radius = 1
     delay_density_scaling = 1.0
+    density_calc = "local_tick_saturation"
+    traffic_decay = 0.9
+    traffic_weight = 0.1
+    density_overlay_file: str | None = None
     # interval between metric logs
     log_interval = 1
     # disable observers and intermediate logging when True

--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -60,6 +60,9 @@ def clear_output_directory() -> None:
 def build_graph() -> None:
     clear_output_directory()
     graph.load_from_file(Config.graph_file)
+    overlay = getattr(Config, "density_overlay_file", None)
+    if overlay:
+        graph.load_density_overlay(overlay)
     global seeder
     seeder = TickSeeder(graph)
     _ensure_attached()

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -33,6 +33,10 @@
   "use_dynamic_density": false,
   "density_radius": 1,
   "delay_density_scaling": 1.0,
+  "density_calc": "local_tick_saturation",
+  "traffic_decay": 0.9,
+  "traffic_weight": 0.1,
+  "density_overlay_file": null,
   "propagation_control": {
     "enable_sip": true,
     "enable_csp": true

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -46,6 +46,11 @@ def _add_config_args(
             _add_config_args(parser, value, prefix=f"{prefix}{key}.")
             continue
         arg_type = type(value)
+        if dest == "density_calc":
+            parser.add_argument(
+                "--density-calc", f"--{prefix}{key}", type=arg_type, dest=dest
+            )
+            continue
         if isinstance(value, bool):
             parser.add_argument(arg_name, type=lambda x: x.lower() == "true", dest=dest)
         else:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ python -m Causal_Web.main --disable-tick=coherence_log,interference_log \
     --enable-events=bridge_rupture_log
 ```
 
+The `density_calc` option controls how edge density is computed. Set one of:
+
+- `local_tick_saturation` (default) – density increases with recent traffic
+- `modular-<mode>` – use a registered modular function (`tick_history`,
+  `node_coherence`, `spatial_field`, `bridge_saturation`)
+- `manual_overlay` – sample values from an external overlay file defined by
+  `density_overlay_file`.
+
+`density_calc` can also be specified via `--density-calc` on the command line.
+
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `logging_mode` option selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -8,6 +8,7 @@ def test_cli_flags_exposed_without_config(tmp_path):
     cfg.write_text("{}")
     old_max = Config.max_ticks
     old_host = Config.database["host"]
+    old_calc = getattr(Config, "density_calc", "local_tick_saturation")
     try:
         service = MainService(
             argv=[
@@ -17,14 +18,18 @@ def test_cli_flags_exposed_without_config(tmp_path):
                 "5",
                 "--database.host",
                 "example.com",
+                "--density-calc=manual_overlay",
             ]
         )
         args, data = service._parse_args()
         assert args.max_ticks == 5
         assert args.database_host == "example.com"
+        assert args.density_calc == "manual_overlay"
         _apply_overrides(args, data)
         assert Config.max_ticks == 5
         assert Config.database["host"] == "example.com"
+        assert Config.density_calc == "manual_overlay"
     finally:
         Config.max_ticks = old_max
         Config.database["host"] = old_host
+        Config.density_calc = old_calc

--- a/tests/test_density_calc.py
+++ b/tests/test_density_calc.py
@@ -1,0 +1,16 @@
+import math
+from Causal_Web.engine.models.graph import CausalGraph
+from Causal_Web.config import Config
+
+
+def test_tick_saturation_density():
+    g = CausalGraph()
+    g.add_node("A")
+    g.add_node("B")
+    g.add_edge("A", "B")
+    edge = g.get_edges_from("A")[0]
+    Config.density_calc = "local_tick_saturation"
+    edge.propagate_phase(0.0, 0, g)
+    rho = g.compute_edge_density(edge)
+    assert rho > 0
+


### PR DESCRIPTION
## Summary
- add density calculation options to config and CLI
- implement density overlay and modular strategies in graph
- track edge tick traffic and integrate with delay calculation
- expose density strategy controls via GUI
- document new options and add regression tests

## Testing
- `pip install numpy networkx pytest pydantic`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8ba0ab888325b4f8c5d22f5b11a8