### PR TITLE
Fix missing TooltipCheckBox import

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -36,6 +36,7 @@ from .canvas_widget import CanvasWidget
 from .toolbar_builder import build_toolbar
 from ..gui.command_stack import AddNodeCommand, AddObserverCommand
 from ..engine import tick_engine
+from .shared import TooltipCheckBox, TOOLTIPS
 
 
 class GraphDockWidget(QDockWidget):
@@ -175,6 +176,7 @@ class MainWindow(QMainWindow):
         settings_menu.addAction(log_action)
 
     def _create_docks(self) -> None:
+        """Create and populate the control panel dock widgets."""
         dock = QDockWidget("Control Panel", self)
         dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
         panel = QWidget()


### PR DESCRIPTION
## Summary
- import TooltipCheckBox and TOOLTIPS in `main_window`
- document `_create_docks` in the GUI main window

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae96927108325a4e7907da9c45a5b