### PR TITLE
Fix PySide GUI startup error

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QWidget,
     QVBoxLayout,
+    QComboBox,
 )
 
 from ..config import Config


### PR DESCRIPTION
## Summary
- fix `NameError` for `QComboBox` on GUI startup
- run formatting and tests

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688aea74400c8325a2bae0b981a7d749