### PR TITLE
Fix start simulation log failure

### DIFF
--- a/Causal_Web/engine/tick_engine/__init__.py
+++ b/Causal_Web/engine/tick_engine/__init__.py
@@ -33,6 +33,7 @@ from .core import (
     resume_simulation,
     stop_simulation,
     simulation_loop,
+    _update_simulation_state,
 )
 from .orchestrators import EvaluationOrchestrator, MutationOrchestrator, IOOrchestrator
 from .evaluator import (
@@ -76,6 +77,7 @@ __all__ = [
     "resume_simulation",
     "stop_simulation",
     "simulation_loop",
+    "_update_simulation_state",
     "evaluate_nodes",
     "mark_for_update",
     "register_firing",


### PR DESCRIPTION
## Summary
- export `_update_simulation_state` from `tick_engine`

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b68b0dbc88325ba47f510ed529bdb