### PR TITLE
Add propagation control toggles

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -360,7 +360,11 @@ class Config:
     edge_weight_range = [1.0, 1.0]
 
     # Toggle propagation mechanisms
-    propagation_control = {"enable_sip": True, "enable_csp": True}
+    propagation_control = {
+        "enable_sip_child": True,
+        "enable_sip_recomb": True,
+        "enable_csp": True,
+    }
 
     # Database connection details
     database = {

--- a/Causal_Web/engine/tick_engine/evaluator.py
+++ b/Causal_Web/engine/tick_engine/evaluator.py
@@ -306,7 +306,7 @@ class SIPRecombinationService:
 
     def spawn_child(self, parent_a: Node, parent_b: Node, tick: int) -> None:
         """Spawn a recombination child node from ``parent_a`` and ``parent_b``."""
-        if not Config.propagation_control.get("enable_sip", True):
+        if not Config.propagation_control.get("enable_sip_recomb", True):
             return
         if self._limit_reached(parent_a.id, parent_b.id):
             self._log_limit(parent_a, parent_b, tick)
@@ -339,7 +339,7 @@ SIP_DECOHERENCE_THRESHOLD = 0.5
 
 
 def _spawn_sip_child(parent, tick: int) -> None:
-    if not Config.propagation_control.get("enable_sip", True):
+    if not Config.propagation_control.get("enable_sip_child", True):
         return
     if _spawn_counts.get(parent.id, 0) >= Config.max_children_per_node > 0:
         if Config.is_log_enabled("event", "propagation_failure_log"):
@@ -477,7 +477,7 @@ def check_propagation(tick: int) -> None:
         _spawn_tick = tick
     _check_sip_failures(tick)
     _process_csp_seeds(tick)
-    if Config.propagation_control.get("enable_sip", True):
+    if Config.propagation_control.get("enable_sip_child", True):
         for node in list(graph.nodes.values()):
             if (
                 node.sip_streak >= SIP_COHERENCE_DURATION
@@ -486,7 +486,7 @@ def check_propagation(tick: int) -> None:
                 _spawn_sip_child(node, tick)
                 node.sip_streak = 0
 
-    if Config.propagation_control.get("enable_sip", True):
+    if Config.propagation_control.get("enable_sip_recomb", True):
         for bridge in graph.bridges:
             if not bridge.active or bridge.state.name != "STABLE":
                 continue

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -215,6 +215,26 @@ class MainWindow(QMainWindow):
         self.smooth_phase_cb.setChecked(getattr(Config, "smooth_phase", False))
         layout.addRow(self.smooth_phase_cb)
 
+        self.sip_child_cb = TooltipCheckBox(
+            "SIP Budding", TOOLTIPS.get("enable_sip_child")
+        )
+        self.sip_child_cb.setChecked(
+            Config.propagation_control.get("enable_sip_child", True)
+        )
+        layout.addRow(self.sip_child_cb)
+
+        self.sip_recomb_cb = TooltipCheckBox(
+            "SIP Recombination", TOOLTIPS.get("enable_sip_recomb")
+        )
+        self.sip_recomb_cb.setChecked(
+            Config.propagation_control.get("enable_sip_recomb", True)
+        )
+        layout.addRow(self.sip_recomb_cb)
+
+        self.csp_cb = TooltipCheckBox("CSP", TOOLTIPS.get("enable_csp"))
+        self.csp_cb.setChecked(Config.propagation_control.get("enable_csp", True))
+        layout.addRow(self.csp_cb)
+
         self.density_combo = QComboBox()
         self.density_combo.addItems(
             [
@@ -322,6 +342,9 @@ class MainWindow(QMainWindow):
         mark_graph_dirty()
         Config.new_run()
         Config.smooth_phase = self.smooth_phase_cb.isChecked()
+        Config.propagation_control["enable_sip_child"] = self.sip_child_cb.isChecked()
+        Config.propagation_control["enable_sip_recomb"] = self.sip_recomb_cb.isChecked()
+        Config.propagation_control["enable_csp"] = self.csp_cb.isChecked()
         strategy = self.density_combo.currentText()
         if strategy == "modular":
             strategy = f"modular-{self.modular_combo.currentText()}"

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -38,7 +38,8 @@
   "traffic_weight": 0.1,
   "density_overlay_file": null,
   "propagation_control": {
-    "enable_sip": true,
+    "enable_sip_child": true,
+    "enable_sip_recomb": true,
     "enable_csp": true
   },
   "database": {

--- a/Causal_Web/input/tooltip.json
+++ b/Causal_Web/input/tooltip.json
@@ -65,7 +65,9 @@
   "tick_emission_log.json": "Ticks emitted by nodes",
   "tick_evaluation_log.json": "Evaluation results for each potential tick",
   "tick_propagation_log.json": "Ticks travelling across edges",
-  "tick_seed_log.json": "Activity injected by the seeder"
- ,
-  "smooth_phase": "Apply exponential smoothing to oscillator phases"
- }
+  "tick_seed_log.json": "Activity injected by the seeder",
+  "smooth_phase": "Apply exponential smoothing to oscillator phases",
+  "enable_sip_child": "Enable SIP budding propagation",
+  "enable_sip_recomb": "Enable SIP recombination propagation",
+  "enable_csp": "Enable collapse seeded propagation"
+}

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -112,6 +112,7 @@ class MainService:
         args, cfg = self._parse_args()
         _apply_overrides(args, cfg)
         self._apply_log_overrides(args)
+        self._apply_propagation_overrides(args)
         if args.init_db:
             self._init_db(args.config)
             return
@@ -142,6 +143,18 @@ class MainService:
                     label = label.strip()
                     if label:
                         cfg[label] = False
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _apply_propagation_overrides(args: argparse.Namespace) -> None:
+        """Update propagation control flags from CLI."""
+
+        if getattr(args, "disable_sip_child", False):
+            Config.propagation_control["enable_sip_child"] = False
+        if getattr(args, "disable_sip_recomb", False):
+            Config.propagation_control["enable_sip_recomb"] = False
+        if getattr(args, "disable_csp", False):
+            Config.propagation_control["enable_csp"] = False
 
     # ------------------------------------------------------------------
     def _parse_args(self) -> tuple[argparse.Namespace, dict[str, Any]]:
@@ -204,6 +217,21 @@ class MainService:
             "--disable-events",
             default="",
             help="Comma-separated event types to disable",
+        )
+        parser.add_argument(
+            "--disable-sip-child",
+            action="store_true",
+            help="Disable SIP budding propagation",
+        )
+        parser.add_argument(
+            "--disable-sip-recomb",
+            action="store_true",
+            help="Disable SIP recombination propagation",
+        )
+        parser.add_argument(
+            "--disable-csp",
+            action="store_true",
+            help="Disable collapse seeded propagation",
         )
         args = parser.parse_args(self.argv)
         Config.graph_file = args.graph

--- a/README.md
+++ b/README.md
@@ -80,5 +80,9 @@ The ingestion service also consumes these unified files, routing records to data
 
 The `smooth_phase` option applies exponential decay to each node's internal oscillator phase. Enable it from the GUI control panel or set `"smooth_phase": true` in `input/config.json`.
 
+### Propagation control
+
+Check boxes on the control panel allow SIP budding, SIP recombination and collapse seeded propagation to be disabled independently. The `propagation_control` section of `input/config.json` contains `enable_sip_child`, `enable_sip_recomb` and `enable_csp` flags. These can also be toggled via the CLI using `--disable-sip-child`, `--disable-sip-recomb` and `--disable-csp`.
+
 ## Contributing
 Unit tests live under `tests/` and can be run with `pytest`. Coding guidelines and packaging instructions are documented in [AGENTS.md](AGENTS.md) and [docs/developer_guide.md](docs/developer_guide.md).

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -33,3 +33,21 @@ def test_cli_flags_exposed_without_config(tmp_path):
         Config.max_ticks = old_max
         Config.database["host"] = old_host
         Config.density_calc = old_calc
+
+
+def test_cli_disable_propagation_flags(tmp_path):
+    cfg = tmp_path / "c.json"
+    cfg.write_text("{}")
+    original = Config.propagation_control.copy()
+    try:
+        service = MainService(
+            argv=["--config", str(cfg), "--disable-sip-child", "--disable-csp"]
+        )
+        args, data = service._parse_args()
+        _apply_overrides(args, data)
+        MainService._apply_propagation_overrides(args)
+        assert Config.propagation_control["enable_sip_child"] is False
+        assert Config.propagation_control["enable_csp"] is False
+        assert Config.propagation_control["enable_sip_recomb"] is True
+    finally:
+        Config.propagation_control = original

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,3 +42,14 @@ def test_load_smooth_phase_flag(tmp_path):
         assert Config.smooth_phase is True
     finally:
         Config.smooth_phase = original
+
+
+def test_load_propagation_flags(tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"propagation_control": {"enable_sip_child": False}}))
+    original = Config.propagation_control.copy()
+    Config.load_from_file(str(cfg))
+    try:
+        assert Config.propagation_control["enable_sip_child"] is False
+    finally:
+        Config.propagation_control = original


### PR DESCRIPTION
## Summary
- allow independent SIP budding, SIP recombination and CSP toggles
- expose propagation control checkboxes in the GUI
- support `--disable-sip-child`, `--disable-sip-recomb` and `--disable-csp` CLI flags
- document propagation control options
- test new CLI and config behaviours

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8f744f408325824a3ed9ce72ded4