### PR TITLE
Improve add connection workflow

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -100,10 +100,13 @@ class NodeItem(QGraphicsEllipseItem):
 
     def mousePressEvent(self, event: QMouseEvent) -> None:  # type: ignore[override]
         if event.button() == Qt.LeftButton:
-            set_selected_node(self.node_id)
-            self.canvas.node_selected.emit(self.node_id)
-            if self.canvas.editable:
-                self._drag_start = self.pos()
+            if not self.canvas._connect_mode:
+                set_selected_node(self.node_id)
+                self.canvas.node_selected.emit(self.node_id)
+                if self.canvas.editable:
+                    self._drag_start = self.pos()
+            else:
+                self._drag_start = None
         super().mousePressEvent(event)
 
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:  # type: ignore[override]
@@ -527,6 +530,15 @@ class CanvasWidget(QGraphicsView):
         if self._temp_edge and self.scene():
             self.scene().removeItem(self._temp_edge)
         self._temp_edge = None
+
+    def cancel_connection_mode(self) -> None:
+        """Abort interactive connection mode and clear temporary state."""
+        if self._temp_edge and self.scene():
+            self.scene().removeItem(self._temp_edge)
+        self._temp_edge = None
+        self._connect_start = None
+        self._connect_dragged = False
+        self._connect_mode = False
 
     def node_moved(self, node_id: str, start: QPointF, end: QPointF) -> None:
         if not self.editable:

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -108,6 +108,7 @@ class MainWindow(QMainWindow):
         # ``self.graph_window`` to be available.
         self.graph_window = QMainWindow()
 
+        self.adding_connection = False
         toolbar = build_toolbar(self)
 
         central = QWidget()
@@ -478,8 +479,23 @@ class MainWindow(QMainWindow):
         self.meta_node_panel.open_new(meta_id)
 
     def start_add_connection(self) -> None:
-        """Enable interactive connection mode."""
-        self.canvas.enable_connection_mode()
+        """Toggle interactive connection mode for adding edges."""
+        if self.adding_connection:
+            self.canvas.cancel_connection_mode()
+            if hasattr(self, "add_conn_action"):
+                self.add_conn_action.setText("Add Connection")
+            self.adding_connection = False
+        else:
+            self.canvas.enable_connection_mode()
+            if hasattr(self, "add_conn_action"):
+                self.add_conn_action.setText("Cancel Connection")
+            self.adding_connection = True
+
+    def finish_add_connection(self) -> None:
+        """Reset the Add Connection button after a connection is created."""
+        if hasattr(self, "add_conn_action"):
+            self.add_conn_action.setText("Add Connection")
+        self.adding_connection = False
 
     def _show_graph_editor(self) -> None:
         """Display the graph editor window."""

--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -246,6 +246,7 @@ class ConnectionPanel(QDockWidget, PanelMixin):
         model = get_graph()
         ConnectionCommitService(self, model).commit()
         self.hide()
+        self.main_window.finish_add_connection()
         self.source = self.target = None
         self.current_index = None
         self.dirty = False

--- a/Causal_Web/gui_pyside/toolbar_services.py
+++ b/Causal_Web/gui_pyside/toolbar_services.py
@@ -40,6 +40,7 @@ class ToolbarBuildService:
         add_conn_action = QAction("Add Connection", mw)
         add_conn_action.triggered.connect(mw.start_add_connection)
         toolbar.addAction(add_conn_action)
+        mw.add_conn_action = add_conn_action
 
         add_obs_action = QAction("Add Observer", mw)
         add_obs_action.triggered.connect(mw.add_observer)


### PR DESCRIPTION
## Summary
- allow toggling connection mode via Add Connection button
- prevent node panel from appearing while adding a connection
- reset button text after connection is created

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9446d4d88325b38efc785b9ac5c1