### PR TITLE
Add entangled tick logging

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -118,6 +118,10 @@ class Config:
             "tick_seed_log": True,
             "event_log": True,
         },
+        "entangled": {
+            "entangled_tick": True,
+            "measurement": True,
+        },
     }
 
     # Default runtime copy

--- a/Causal_Web/engine/models/node.py
+++ b/Causal_Web/engine/models/node.py
@@ -655,8 +655,13 @@ class Node(LoggingMixin):
                 )
                 return
             should_fire, phase, reason = self.should_tick(tick_key)
+            entangled_id = None
+            for item in self.incoming_phase_queue.get(tick_key, []):
+                if len(item) > 6 and item[6] is not None:
+                    entangled_id = item[6]
+                    break
             if should_fire and not self.is_classical:
-                self.apply_tick(tick_key, phase, graph)
+                self.apply_tick(tick_key, phase, graph, entangled_id=entangled_id)
             else:
                 drop_reason = "classical" if self.is_classical else reason
                 self._log_tick_drop(tick_key, drop_reason)

--- a/Causal_Web/engine/models/observer.py
+++ b/Causal_Web/engine/models/observer.py
@@ -98,6 +98,18 @@ class Observer:
                     },
                     tick=tick_time,
                 )
+                log_json(
+                    "entangled",
+                    "measurement",
+                    {
+                        "tick_id": ev["tick_id"],
+                        "observer_id": self.id,
+                        "entangled_id": ent_id,
+                        "measurement_setting": setting,
+                        "binary_outcome": outcome,
+                    },
+                    tick=tick_time,
+                )
         self.memory.append({"tick": tick_time, "events": events})
         if len(self.memory) > self.window:
             self.memory.pop(0)

--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -241,6 +241,18 @@ class NodeTickService:
             {"node_id": n.id, "phase": self.phase},
             tick=self.tick_time,
         )
+        if tick_obj.entangled_id is not None:
+            log_json(
+                "entangled",
+                "entangled_tick",
+                {
+                    "node_id": n.id,
+                    "tick_id": tick_obj.trace_id,
+                    "entangled_id": tick_obj.entangled_id,
+                    "origin": self.origin,
+                },
+                tick=self.tick_time,
+            )
         with n.lock:
             if self.origin == "self":
                 n.emitted_tick_times.add(self.tick_time)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ is tagged with an `entangled_id` used by observers to generate deterministic
 measurement outcomes for Bell-type experiments.
 Observers can enable a *Detector Mode* that records a binary outcome whenever a
 tick from an entangled bridge is detected.
+These detector events are additionally written to `entangled_log.jsonl` for
+Bell inequality analysis.
 
 Runs produce a set of JSON logs in `output/`. The script `bundle_run.py` can be used after a simulation to archive the results. Full descriptions of each log file and their fields are available in [docs/log_schemas.md](docs/log_schemas.md).
 
@@ -76,6 +78,8 @@ The `density_calc` option controls how edge density is computed. Set one of:
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `logging_mode` option selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.
 Individual files can still be toggled via `log_files` for advanced filtering.
+Entangled tick metadata and detector outcomes are stored separately in
+`entangled_log.jsonl`.
 Law-wave propagation events now appear as `law_wave_event` records in the `events` log.
 Per-tick law-wave frequencies are still written under the `law_wave_log` label in `ticks_log.jsonl`.
 The interpreter provides `records_for_tick()` and `assemble_timeline()` helpers to query these consolidated logs.

--- a/docs/log_schemas.md
+++ b/docs/log_schemas.md
@@ -242,6 +242,12 @@ The following lists describe the JSON keys recorded in each output file.
 - event-driven record with `tick_id`, `observer_id`, `entangled_id`,
   `measurement_setting` and `binary_outcome` for each detected entangled tick.
 
+#### `entangled_log.jsonl`
+- JSON lines file capturing entangled tick activity. `label` values include
+  `entangled_tick` when a node emits a tick with an `entangled_id` and
+  `measurement` for observer outcomes. Each entry stores `tick`, `tick_id`,
+  `entangled_id` and related metadata for Bell analysis.
+
 #### `propagation_failure_log.json`
 - heterogeneous records describing why propagation failed. Common
   fields include `node` or `parent`, failure `type` and `reason`.


### PR DESCRIPTION
## Summary
- propagate entangled tick metadata when nodes fire
- log entangled ticks and measurement events to `entangled_log.jsonl`
- expose new log category in the config
- document entangled log in README and log schemas

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb704f32483258fcbf1a751aacbab