### PR TITLE
Add Bell inequality analysis tool

### DIFF
--- a/Causal_Web/analysis/bell.py
+++ b/Causal_Web/analysis/bell.py
@@ -1,0 +1,115 @@
+"""Bell inequality analysis utilities."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Tuple, List
+
+from ..config import Config
+
+
+def compute_bell_statistics(
+    log_file: str | None = None,
+) -> Tuple[float, Dict[Tuple[str, str], float]]:
+    """Return CHSH ``S`` value from ``entangled_log.jsonl``.
+
+    Parameters
+    ----------
+    log_file:
+        Optional path to ``entangled_log.jsonl``. Defaults to the current
+        run directory.
+
+    Returns
+    -------
+    float
+        The calculated ``S`` value.
+    Dict[Tuple[str, str], float]
+        Mapping of setting pair to expectation value ``E(A_i,B_j)``.
+    """
+
+    log_path = Path(log_file or Config.output_path("entangled_log.jsonl"))
+    if not log_path.exists():
+        return 0.0, {}
+
+    events: List[dict] = []
+    with log_path.open() as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+            if (
+                obj.get("event_type") == "measurement"
+                or obj.get("label") == "measurement"
+            ):
+                payload = obj.get("payload") or obj.get("value") or {}
+                events.append(
+                    {
+                        "tick": obj.get("tick"),
+                        "entangled_id": payload.get("entangled_id"),
+                        "observer_id": payload.get("observer_id"),
+                        "setting": payload.get("measurement_setting"),
+                        "outcome": payload.get("binary_outcome"),
+                    }
+                )
+
+    if not events:
+        return 0.0, {}
+
+    # Determine observers and setting labels
+    observer_ids = sorted({e["observer_id"] for e in events})[:2]
+    if len(observer_ids) < 2:
+        return 0.0, {}
+    obs_map = {observer_ids[0]: "A", observer_ids[1]: "B"}
+    setting_names: Dict[str, Dict[float, str]] = defaultdict(dict)
+
+    for e in events:
+        obs = e["observer_id"]
+        if obs not in obs_map:
+            continue
+        names = setting_names[obs]
+        if e["setting"] not in names:
+            label = "1" if not names else "2"
+            names[e["setting"]] = f"{obs_map[obs]}{label}"
+
+    # Group events by entangled_id and tick
+    pairs: Dict[Tuple[str, int], Dict[str, Tuple[str, int]]] = defaultdict(dict)
+    for e in events:
+        obs = e["observer_id"]
+        if obs not in obs_map:
+            continue
+        setting_label = setting_names[obs][e["setting"]]
+        key = (e["entangled_id"], int(e["tick"]))
+        pairs[key][obs_map[obs]] = (setting_label, int(e["outcome"]))
+
+    # Count outcome combinations per setting pair
+    counts: Dict[Tuple[str, str], Dict[Tuple[int, int], int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
+    for pair in pairs.values():
+        if "A" not in pair or "B" not in pair:
+            continue
+        a_setting, a_out = pair["A"]
+        b_setting, b_out = pair["B"]
+        counts[(a_setting, b_setting)][(a_out, b_out)] += 1
+
+    expectations: Dict[Tuple[str, str], float] = {}
+    for key, combo in counts.items():
+        n_pp = combo.get((1, 1), 0)
+        n_pm = combo.get((1, -1), 0)
+        n_mp = combo.get((-1, 1), 0)
+        n_mm = combo.get((-1, -1), 0)
+        total = n_pp + n_pm + n_mp + n_mm
+        if total:
+            expectations[key] = (n_pp - n_pm - n_mp + n_mm) / total
+        else:
+            expectations[key] = 0.0
+
+    e_a1_b1 = expectations.get(("A1", "B1"), 0.0)
+    e_a1_b2 = expectations.get(("A1", "B2"), 0.0)
+    e_a2_b1 = expectations.get(("A2", "B1"), 0.0)
+    e_a2_b2 = expectations.get(("A2", "B2"), 0.0)
+    s_value = e_a1_b1 - e_a1_b2 + e_a2_b1 + e_a2_b2
+
+    return s_value, expectations

--- a/Causal_Web/gui_pyside/bell_window.py
+++ b/Causal_Web/gui_pyside/bell_window.py
@@ -1,0 +1,69 @@
+"""Display results of Bell inequality analysis."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+try:
+    from PySide6.QtCharts import (
+        QChart,
+        QChartView,
+        QBarSet,
+        QBarSeries,
+        QBarCategoryAxis,
+    )
+    from PySide6.QtGui import QAction
+except Exception:  # pragma: no cover - optional dependency
+    QChart = object  # type: ignore
+    QChartView = object  # type: ignore
+    QBarSet = object  # type: ignore
+    QBarSeries = object  # type: ignore
+    QBarCategoryAxis = object  # type: ignore
+
+from PySide6.QtWidgets import QMainWindow, QVBoxLayout, QWidget, QLabel
+
+from ..analysis.bell import compute_bell_statistics
+
+
+class BellAnalysisWindow(QMainWindow):
+    """Window presenting CHSH results and expectation histogram."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Bell Inequality Analysis")
+        self.resize(400, 300)
+
+        central = QWidget()
+        layout = QVBoxLayout(central)
+        self.result_label = QLabel()
+        layout.addWidget(self.result_label)
+        self.setCentralWidget(central)
+
+        self.chart_view: QChartView | None = None
+        self._run_analysis()
+
+    # ------------------------------------------------------------------
+    def _run_analysis(self) -> None:
+        """Compute statistics and update the display."""
+        s_value, expectations = compute_bell_statistics()
+        self.result_label.setText(f"S = {s_value:.3f}")
+        if QChartView is object:
+            return
+
+        chart = QChart()
+        bar_set = QBarSet("E")
+        keys = ["A1B1", "A1B2", "A2B1", "A2B2"]
+        for key in keys:
+            bar_set << expectations.get((key[:2], key[2:]), 0.0)
+        series = QBarSeries()
+        series.append(bar_set)
+        chart.addSeries(series)
+        axis = QBarCategoryAxis()
+        axis.append(keys)
+        chart.createDefaultAxes()
+        chart.setAxisX(axis, series)
+        if self.chart_view is None:
+            self.chart_view = QChartView(chart)
+            self.centralWidget().layout().addWidget(self.chart_view)
+        else:
+            self.chart_view.setChart(chart)

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -177,6 +177,11 @@ class MainWindow(QMainWindow):
         log_action.triggered.connect(self._show_log_files_window)
         settings_menu.addAction(log_action)
 
+        analysis_menu = menubar.addMenu("Analysis")
+        bell_action = QAction("Bell Inequality Analysis...", self)
+        bell_action.triggered.connect(self._show_bell_analysis)
+        analysis_menu.addAction(bell_action)
+
     def _create_docks(self) -> None:
         """Create and populate the control panel dock widgets."""
         dock = QDockWidget("Control Panel", self)
@@ -509,6 +514,16 @@ class MainWindow(QMainWindow):
 
             self.log_files_window = LogFilesWindow(self)
         self.log_files_window.show()
+
+    def _show_bell_analysis(self) -> None:
+        """Run Bell analysis and display the results."""
+        if not hasattr(self, "bell_window"):
+            from .bell_window import BellAnalysisWindow
+
+            self.bell_window = BellAnalysisWindow(self)
+        else:
+            self.bell_window._run_analysis()  # refresh on repeat
+        self.bell_window.show()
 
     def _load_into_main(self) -> None:
         """Apply the edited graph to the main simulation view and disk."""

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Observers can enable a *Detector Mode* that records a binary outcome whenever a
 tick from an entangled bridge is detected.
 These detector events are additionally written to `entangled_log.jsonl` for
 Bell inequality analysis.
+The GUI now includes an **Analysis** menu with a *Bell Inequality Analysis...*
+action that opens a window showing CHSH statistics and a histogram of
+expectation values.
 
 Runs produce a set of JSON logs in `output/`. The script `bundle_run.py` can be used after a simulation to archive the results. Full descriptions of each log file and their fields are available in [docs/log_schemas.md](docs/log_schemas.md).
 


### PR DESCRIPTION
## Summary
- implement compute_bell_statistics for entangled log correlation
- show CHSH results in new BellAnalysisWindow
- add Analysis menu to trigger Bell inequality window
- document the new feature in README

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb9b9d96883258f760066d9ec86d5