### PR TITLE
Fix bridge activation order and entanglement

### DIFF
--- a/Causal_Web/engine/models/bridge.py
+++ b/Causal_Web/engine/models/bridge.py
@@ -299,8 +299,8 @@ class Bridge(LoggingMixin):
             self._log_dynamics(tick_time, "recovered", {"coherence": coherence})
 
     def apply(self, tick_time: int, graph: "CausalGraph") -> None:
-        """Apply the bridge logic for ``tick_time``."""
-        from .services.sim_services import BridgeApplyService
+        """Activate the bridge for ``tick_time`` using ``BridgeApplyService``."""
+        from ..services.sim_services import BridgeApplyService
 
         BridgeApplyService(self, tick_time, graph).process()
 

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -467,8 +467,14 @@ class BridgeApplyService:
         self.node_b = self.graph.get_node(self.bridge.node_b_id)
         self.phase_a = self.node_a.get_phase_at(self.tick_time)
         self.phase_b = self.node_b.get_phase_at(self.tick_time)
-        self.a_collapsed = self.node_a.collapse_origin.get(self.tick_time) == "self"
-        self.b_collapsed = self.node_b.collapse_origin.get(self.tick_time) == "self"
+        self.a_collapsed = self.node_a.collapse_origin.get(self.tick_time) in {
+            "self",
+            "seed",
+        }
+        self.b_collapsed = self.node_b.collapse_origin.get(self.tick_time) in {
+            "self",
+            "seed",
+        }
 
     # ------------------------------------------------------------------
     def _validate_collapse(self) -> bool:
@@ -552,6 +558,10 @@ class BridgeApplyService:
     def _propagate_braided(self) -> None:
         if self.a_collapsed:
             phase = self.node_a.get_phase_at(self.tick_time)
+            if self.bridge.is_entangled and self.node_a.tick_history:
+                last = self.node_a.tick_history[-1]
+                if last.time == self.tick_time:
+                    last.entangled_id = self.bridge.entangled_id
             self.node_b.apply_tick(
                 self.tick_time,
                 phase + self.bridge.phase_offset,
@@ -565,6 +575,10 @@ class BridgeApplyService:
             self.node_b.entangled_with.add(self.node_a.id)
         elif self.b_collapsed:
             phase = self.node_b.get_phase_at(self.tick_time)
+            if self.bridge.is_entangled and self.node_b.tick_history:
+                last = self.node_b.tick_history[-1]
+                if last.time == self.tick_time:
+                    last.entangled_id = self.bridge.entangled_id
             self.node_a.apply_tick(
                 self.tick_time,
                 phase + self.bridge.phase_offset,
@@ -581,6 +595,10 @@ class BridgeApplyService:
     def _propagate_unidirectional(self) -> None:
         if self.a_collapsed:
             phase = self.node_a.get_phase_at(self.tick_time)
+            if self.bridge.is_entangled and self.node_a.tick_history:
+                last = self.node_a.tick_history[-1]
+                if last.time == self.tick_time:
+                    last.entangled_id = self.bridge.entangled_id
             self.node_b.apply_tick(
                 self.tick_time,
                 phase + self.bridge.phase_offset,

--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -194,8 +194,8 @@ class SimulationRunner:
         self.evaluation.finalize(self.global_tick)
         snapshot_path = self.io.snapshot_state(self.global_tick)
         self.io.update_state(self.global_tick, False, False, snapshot_path)
-        self.io.handle_observers(self.global_tick)
         self.mutation.apply_bridges(self.global_tick)
+        self.io.handle_observers(self.global_tick)
 
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ is tagged with an `entangled_id` used by observers to generate deterministic
 measurement outcomes for Bell-type experiments.
 Observers can enable a *Detector Mode* that records a binary outcome whenever a
 tick from an entangled bridge is detected.
+Bridge propagation now occurs before observers handle a tick so detector events
+reflect entangled activity in the same cycle.
 These detector events are additionally written to `entangled_log.jsonl` for
 Bell inequality analysis.
 The GUI now includes an **Analysis** menu with a *Bell Inequality Analysis...*


### PR DESCRIPTION
## Summary
- apply bridges before observers get updated
- fix Bridge.apply import path
- treat seeded ticks as collapsed in bridges
- propagate entangled IDs to both nodes
- document updated bridge behaviour

## Testing
- `python -m compileall Causal_Web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bd48600dc83259ba649b3e3bc3995