### PR TITLE
fix: respect log interval for graph snapshots

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -14,7 +14,7 @@ class Config:
         Dictionary containing ``enable_sip`` and ``enable_csp`` flags used to
         toggle the two propagation mechanisms.
     log_interval:
-        Number of ticks between metric log writes.
+        Number of ticks between metric log writes and graph snapshots.
     headless:
         When ``True`` disables observers and intermediate logging.
     graph_file:
@@ -273,8 +273,6 @@ class Config:
     coherence_wave = {"amplitude": 0.0, "period": 30}  # threshold modulation
     # ticks over which to ramp up global forcing effects
     forcing_ramp_ticks = 20
-    # interval for saving runtime snapshots of the graph
-    snapshot_interval = 10
     # interval for expensive clustering operations
     cluster_interval = 10
     # interval for dynamic bridge management

--- a/Causal_Web/engine/logging/log_utils.py
+++ b/Causal_Web/engine/logging/log_utils.py
@@ -94,8 +94,21 @@ def log_meta_node_ticks(global_tick: int) -> None:
 
 
 def snapshot_graph(global_tick: int) -> Optional[str]:
+    """Serialize the graph to disk at the configured interval.
+
+    Parameters
+    ----------
+    global_tick:
+        Current simulation tick.
+
+    Returns
+    -------
+    Optional[str]
+        Path to the snapshot file if one was written, otherwise ``None``.
+    """
+
     assert _graph is not None
-    interval = getattr(Config, "snapshot_interval", 0)
+    interval = getattr(Config, "log_interval", 1)
     if interval and global_tick % interval == 0:
         path_dir = os.path.join(Config.output_dir, "runtime_graph_snapshots")
         os.makedirs(path_dir, exist_ok=True)

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -14,7 +14,7 @@
     "strategy": "probabilistic",
     "probability": 0.2
   },
-  "snapshot_interval": 5,
+  "log_interval": 5,
   "random_seed": 42,
   "thread_count": 4,
   "log_verbosity": "info",

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `density_calc` option controls how edge density is computed. Set one of:
 `density_calc` can also be specified via `--density-calc` on the command line.
 
 ## Output Logs
-Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `logging_mode` option selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
+Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `log_interval` option controls how often metrics and graph snapshots are written, while `logging_mode` selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.
 Individual files can still be toggled via `log_files` for advanced filtering.
 Entangled tick metadata and detector outcomes are stored separately in


### PR DESCRIPTION
## Summary
- serialize runtime graph snapshots based on `Config.log_interval`
- remove unused `snapshot_interval` setting and document `log_interval`

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926d0dfb88832598d551586bdefea1