### PR TITLE
Respect logging interval for snapshots and logs

### DIFF
--- a/Causal_Web/engine/logging/logger.py
+++ b/Causal_Web/engine/logging/logger.py
@@ -96,6 +96,8 @@ def log_record(
         Identifier linking this record to another event.
     metadata:
         Additional metadata to merge with default values.
+    Records are skipped when ``tick`` is provided and not a multiple of
+    :attr:`Config.log_interval`.
     """
 
     meta = {"category": category}
@@ -105,6 +107,10 @@ def log_record(
         meta.update(metadata)
 
     if not Config.is_log_enabled(category, label):
+        return
+
+    interval = getattr(Config, "log_interval", 1)
+    if tick is not None and interval and tick % interval != 0:
         return
 
     path_map = {

--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -144,14 +144,14 @@ class SimulationRunner:
         while True:
             running, stop, rate, limit = self._read_state()
             if stop:
-                snapshot = log_utils.snapshot_graph(self.global_tick)
+                snapshot = self.io.snapshot_state(self.global_tick)
                 _update_simulation_state(False, True, self.global_tick, snapshot)
                 log_utils.write_output()
                 break
             if limit and limit != -1 and self.global_tick >= limit:
                 with Config.state_lock:
                     Config.is_running = False
-                snapshot = log_utils.snapshot_graph(self.global_tick)
+                snapshot = self.io.snapshot_state(self.global_tick)
                 _update_simulation_state(False, True, self.global_tick, snapshot)
                 log_utils.write_output()
                 break

--- a/Causal_Web/engine/tick_engine/orchestrators.py
+++ b/Causal_Web/engine/tick_engine/orchestrators.py
@@ -92,7 +92,11 @@ class IOOrchestrator:
         log_utils.log_curvature_per_tick(tick)
 
     def snapshot_state(self, tick: int) -> Optional[str]:
+        """Return a graph snapshot path when logging is due."""
         if Config.headless:
+            return None
+        interval = getattr(Config, "log_interval", 1)
+        if interval and tick % interval != 0:
             return None
         return log_utils.snapshot_graph(tick)
 
@@ -102,7 +106,11 @@ class IOOrchestrator:
         self._update_state(paused, stopped, tick, snapshot)
 
     def handle_observers(self, tick: int) -> None:
+        """Invoke observers and log disagreements at the configured interval."""
         if Config.headless:
+            return
+        interval = getattr(Config, "log_interval", 1)
+        if interval and tick % interval != 0:
             return
         for obs in self.observers:
             obs.observe(self.graph, tick)


### PR DESCRIPTION
## Summary
- honor `Config.log_interval` in `log_record` so logs skip non-interval ticks
- gate snapshot creation and observer logging on the configured interval
- use interval-aware `snapshot_state` when the simulation ends

## Testing
- `black Causal_Web/engine/tick_engine/orchestrators.py Causal_Web/engine/logging/logger.py Causal_Web/engine/tick_engine/core.py`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892714e4f508325941ece939db5e1ef