### PR TITLE
Align state snapshots with logging interval

### DIFF
--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -208,7 +208,11 @@ class SimulationRunner:
             self.io.log_cluster_info(self.global_tick)
 
         self.evaluation.finalize(self.global_tick)
-        snapshot_path = self.io.snapshot_state(self.global_tick)
+        interval = getattr(Config, "log_interval", 1)
+        if interval and self.global_tick % interval == 0:
+            snapshot_path = self.io.snapshot_state(self.global_tick)
+        else:
+            snapshot_path = None
         self.io.update_state(self.global_tick, False, False, snapshot_path)
         self.mutation.apply_bridges(self.global_tick)
         self.io.handle_observers(self.global_tick)


### PR DESCRIPTION
## Summary
- snapshot graph state only when current tick aligns with configured logging interval

## Testing
- `python -m black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689276c1fc9c83258792961c5a1c4b62