### PR TITLE
Ensure graph snapshots respect log interval

### DIFF
--- a/Causal_Web/engine/tick_engine/core.py
+++ b/Causal_Web/engine/tick_engine/core.py
@@ -163,7 +163,7 @@ class SimulationRunner:
                 if limit and limit != -1 and self.global_tick >= limit:
                     with Config.state_lock:
                         Config.is_running = False
-                    snapshot = log_utils.snapshot_graph(self.global_tick)
+                    snapshot = self.io.snapshot_state(self.global_tick)
                     _update_simulation_state(False, True, self.global_tick, snapshot)
                     log_utils.write_output()
                     break
@@ -208,11 +208,7 @@ class SimulationRunner:
             self.io.log_cluster_info(self.global_tick)
 
         self.evaluation.finalize(self.global_tick)
-        interval = getattr(Config, "log_interval", 1)
-        if interval and self.global_tick % interval == 0:
-            snapshot_path = self.io.snapshot_state(self.global_tick)
-        else:
-            snapshot_path = None
+        snapshot_path = self.io.snapshot_state(self.global_tick)
         self.io.update_state(self.global_tick, False, False, snapshot_path)
         self.mutation.apply_bridges(self.global_tick)
         self.io.handle_observers(self.global_tick)

--- a/Causal_Web/engine/tick_engine/orchestrators.py
+++ b/Causal_Web/engine/tick_engine/orchestrators.py
@@ -95,9 +95,6 @@ class IOOrchestrator:
         """Return a graph snapshot path when logging is due."""
         if Config.headless:
             return None
-        interval = getattr(Config, "log_interval", 1)
-        if interval and tick % interval != 0:
-            return None
         return log_utils.snapshot_graph(tick)
 
     def update_state(


### PR DESCRIPTION
## Summary
- Delegate all snapshot creation to IOOrchestrator so graph snapshots are only generated at the configured `log_interval`.
- Simplify snapshot orchestration by removing redundant interval checks and using the logging utility everywhere snapshots are requested.

## Testing
- `python -m black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main --no-gui --max_ticks 6`
- `python bundle_run.py` *(fails: No module named 'Causal_Web.engine.logging.services')*


------
https://chatgpt.com/codex/tasks/task_e_68927b2c3d5483258cb9d9aa11d091c6