### PR TITLE
Add epsilon-edge entanglement support

### DIFF
--- a/Causal_Web/engine/services/__init__.py
+++ b/Causal_Web/engine/services/__init__.py
@@ -17,6 +17,7 @@ from .serialization_service import (
     GraphSerializationService,
     NarrativeGeneratorService,
 )
+from .entanglement_service import EntanglementService
 
 __all__ = [
     "NodeInitializationService",
@@ -30,4 +31,5 @@ __all__ = [
     "GlobalDiagnosticsService",
     "GraphSerializationService",
     "NarrativeGeneratorService",
+    "EntanglementService",
 ]

--- a/Causal_Web/engine/services/entanglement_service.py
+++ b/Causal_Web/engine/services/entanglement_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ..models.node import Node
+
+
+class EntanglementService:
+    """Utilities for managing entanglement effects."""
+
+    @staticmethod
+    def collapse_epsilon(graph, node: Node, tick_time: int) -> None:
+        """Collapse epsilon-linked partners to the opposite eigenstate.
+
+        Parameters
+        ----------
+        graph:
+            The :class:`~Causal_Web.engine.models.graph.CausalGraph` containing
+            the nodes.
+        node:
+            Node that has just collapsed.
+        tick_time:
+            Global tick index of the collapse event.
+        """
+
+        for edge in graph.get_edges_from(node.id):
+            if not getattr(edge, "epsilon", False):
+                continue
+            partner = graph.get_node(edge.target)
+            if partner is None:
+                continue
+            if partner.collapse_origin.get(tick_time) is not None:
+                continue
+            partner.psi = np.array([node.psi[1], node.psi[0]], np.complex128)
+            partner.collapse_origin[tick_time] = "epsilon"
+            partner.incoming_tick_counts[tick_time] = 0

--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -379,6 +379,7 @@ class EdgePropagationService:
             tick_id=new_tick.trace_id,
             cumulative_delay=new_delay,
             entangled_id=new_tick.entangled_id,
+            graph=self.graph,
         )
         GLOBAL_TICK_POOL.release(new_tick)
 
@@ -423,6 +424,7 @@ class EdgePropagationService:
             origin=self.node.id,
             created_tick=self.tick_time,
             entangled_id=self.tick.entangled_id,
+            graph=self.graph,
         )
         target.node_type = NodeType.REFRACTIVE
         log_json(

--- a/Causal_Web/engine/services/serialization_service.py
+++ b/Causal_Web/engine/services/serialization_service.py
@@ -95,6 +95,8 @@ class GraphSerializationService:
                 "attenuation": e.attenuation,
                 "density": e.density,
                 "phase_shift": e.phase_shift,
+                "epsilon": getattr(e, "epsilon", False),
+                "partner_id": getattr(e, "partner_id", None),
             }
             for e in self.graph.edges
         ]

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -306,6 +306,7 @@ class GraphLoadService:
         g.tick_sources = []
         g.spatial_index.clear()
         g.meta_nodes.clear()
+        g._epsilon_pair_map.clear()
 
     # ------------------------------------------------------------------
     def _load_nodes(self, nodes_data: list | dict) -> None:
@@ -382,6 +383,8 @@ class GraphLoadService:
                 delay=edge.get("delay", 1),
                 phase_shift=edge.get("phase_shift", 0.0),
                 weight=edge.get("weight"),
+                epsilon=edge.get("epsilon", False),
+                partner_id=edge.get("partner_id"),
             )
 
     # ------------------------------------------------------------------

--- a/Causal_Web/engine/tick_engine/tick_router.py
+++ b/Causal_Web/engine/tick_engine/tick_router.py
@@ -30,8 +30,12 @@ class TickRouter:
         return cls.LAYERS[-1]
 
     @classmethod
-    def record_fanin(cls, node: Node, tick_time: int) -> None:
-        """Increment fan-in counts and collapse via Born rule."""
+    def record_fanin(cls, node: Node, tick_time: int, graph=None) -> None:
+        """Increment fan-in counts and collapse via Born rule.
+
+        ``graph`` is optionally supplied so that entanglement constraints can
+        propagate collapses across ``\u03b5`` edges.
+        """
         count = node.incoming_tick_counts[tick_time]
         if count == getattr(Config, "N_DECOH", 0):
             probs = np.abs(node.psi) ** 2
@@ -42,6 +46,13 @@ class TickRouter:
                 node.psi = np.array([1 + 0j, 0 + 0j], np.complex128)
             else:
                 node.psi = np.array([0 + 0j, 1 + 0j], np.complex128)
+            node.collapse_origin[tick_time] = node.collapse_origin.get(
+                tick_time, "self"
+            )
+            if graph is not None:
+                from ..services.entanglement_service import EntanglementService
+
+                EntanglementService.collapse_epsilon(graph, node, tick_time)
             node.incoming_tick_counts[tick_time] = 0
 
     @classmethod

--- a/Causal_Web/graph/types.py
+++ b/Causal_Web/graph/types.py
@@ -36,6 +36,8 @@ EdgeData = TypedDict(
         "phase_shift": float,
         "weight": float,
         "u_id": int,
+        "epsilon": bool,
+        "partner_id": str,
     },
     total=False,
 )

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Bridge propagation now occurs before observers handle a tick so detector events
 reflect entangled activity in the same cycle.
 These detector events are additionally written to `entangled_log.jsonl` for
 Bell inequality analysis.
+Graphs may also define ``epsilon`` edges linking two nodes in a singlet state.
+When one node collapses, its ``epsilon`` partner is projected onto the opposite
+eigenvector, enabling Bell-test correlations without a bridge.
 The GUI now includes an **Analysis** menu with a *Bell Inequality Analysis...*
 action that opens a window showing CHSH statistics and a histogram of
 expectation values.


### PR DESCRIPTION
## Summary
- support ε-edges by linking partner edges and serializing `epsilon`/`partner_id`
- route collapse events through new `EntanglementService` to enforce singlet-state correlations
- document ε-edge usage for Bell-type analysis

## Testing
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main --no-gui --max_ticks 1`
- `python - <<'PY'
from Causal_Web.analysis.bell import compute_bell_statistics
print(compute_bell_statistics())
PY`
- `python bundle_run.py` *(fails: ModuleNotFoundError: No module named 'Causal_Web.engine.logging.services')*

------
https://chatgpt.com/codex/tasks/task_e_6893705bcc748325a3858b7cc1be64c8