### PR TITLE
feat: track proper time for nodes

### DIFF
--- a/Causal_Web/analysis/twin.py
+++ b/Causal_Web/analysis/twin.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..engine.models.node import Node
+from ..engine import scheduler
+
+
+def run_demo(
+    total_time: float = 10.0, dt: float = 1.0, velocity: float = 0.8
+) -> Tuple[float, float]:
+    """Simulate twin-paradox style time dilation.
+
+    Parameters
+    ----------
+    total_time:
+        Duration of the journey in coordinate time.
+    dt:
+        Time step used by the scheduler.
+    velocity:
+        Constant speed of the travelling twin in spatial units per ``dt``.
+
+    Returns
+    -------
+    Tuple[float, float]
+        Proper times ``(tau_home, tau_traveller)`` accumulated by each twin.
+    """
+
+    home = Node("home")
+    traveller = Node("traveller")
+    half_steps = int(total_time / (2 * dt))
+    for _ in range(half_steps):
+        traveller.x += velocity * dt
+        scheduler.step([home, traveller], dt)
+    for _ in range(half_steps):
+        traveller.x -= velocity * dt
+        scheduler.step([home, traveller], dt)
+    return home.tau, traveller.tau
+
+
+if __name__ == "__main__":
+    tau_home, tau_traveller = run_demo()
+    asym = (tau_home - tau_traveller) / tau_home if tau_home else 0.0
+    print(
+        f"home tau: {tau_home:.3f} traveller tau: {tau_traveller:.3f} (asymmetry {asym*100:.1f}%)"
+    )

--- a/Causal_Web/engine/models/node.py
+++ b/Causal_Web/engine/models/node.py
@@ -23,7 +23,11 @@ class NodeType(Enum):
 
 
 class Node(LoggingMixin):
-    """Represents a single oscillator in the causal graph."""
+    """Represents a single oscillator in the causal graph.
+
+    Nodes maintain a ``tau`` attribute representing accumulated proper-time.
+    ``tau`` is advanced externally based on local velocity and density.
+    """
 
     def __init__(
         self,
@@ -55,6 +59,11 @@ class Node(LoggingMixin):
             generation_tick=generation_tick,
             parent_ids=parent_ids,
         )
+
+        # Proper-time and previous position tracking
+        self.tau = 0.0
+        self.prev_x = x
+        self.prev_y = y
 
     def _advance_internal_phase(self, tick_time: float) -> None:
         """Update :attr:`internal_phase` using entrainment from ticks."""

--- a/Causal_Web/engine/scheduler.py
+++ b/Causal_Web/engine/scheduler.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import math
+from typing import Iterable, Mapping
+
+from ..config import Config
+from .models.node import Node
+
+
+def update_proper_time(node: Node, dt: float, rho: float, kappa: float) -> float:
+    """Advance ``node.tau`` using velocity and local density.
+
+    Parameters
+    ----------
+    node:
+        Node being updated.
+    dt:
+        Coordinate time step.
+    rho:
+        Local density associated with ``node``.
+    kappa:
+        Coupling constant that scales density impact.
+
+    Returns
+    -------
+    float
+        The proper-time increment ``d_tau`` applied to ``node``.
+    """
+
+    dx = node.x - getattr(node, "prev_x", node.x)
+    dy = node.y - getattr(node, "prev_y", node.y)
+    v2 = 0.0
+    if dt > 0.0:
+        v2 = (dx * dx + dy * dy) / (dt * dt)
+    d_tau = dt * (1 - kappa * rho) * math.sqrt(max(0.0, 1 - v2))
+    node.tau += d_tau
+    node.prev_x = node.x
+    node.prev_y = node.y
+    return d_tau
+
+
+def step(
+    nodes: Iterable[Node],
+    dt: float,
+    rho_map: Mapping[str, float] | None = None,
+    *,
+    kappa: float | None = None,
+) -> None:
+    """Advance proper-time for ``nodes`` by ``dt``.
+
+    ``rho_map`` may supply pre-computed densities keyed by node identifier. If
+    omitted, zero density is assumed for every node.
+    """
+
+    if rho_map is None:
+        rho_map = {}
+    if kappa is None:
+        kappa = getattr(Config, "kappa", 0.0)
+    for node in nodes:
+        rho = rho_map.get(node.id, 0.0)
+        update_proper_time(node, dt, rho, kappa)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ two-component complex state vector `psi` instead of a single phase, edges can
 optionally apply a Hadamard transform (`u_id=1`), and a global
 `Config.N_DECOH` controls when accumulated fan-in triggers Born-rule collapse.
 
+Each node also accumulates a proper-time `tau` that accounts for local velocity
+and density effects. Run `analysis/twin.py` for a simple twin-paradox
+demonstration showcasing this time dilation.
+
 ## Table of Contents
 - [Quick Start](#quick-start)
 - [Installation](#installation)

--- a/tests/test_proper_time.py
+++ b/tests/test_proper_time.py
@@ -1,0 +1,19 @@
+from Causal_Web.engine.models.node import Node
+from Causal_Web.engine import scheduler
+
+
+def test_proper_time_dilation():
+    stationary = Node("A")
+    traveller = Node("B")
+    dt = 1.0
+    steps = 5
+    v = 0.6
+    for _ in range(steps):
+        traveller.x += v * dt
+        scheduler.step([stationary, traveller], dt)
+    for _ in range(steps):
+        traveller.x -= v * dt
+        scheduler.step([stationary, traveller], dt)
+    assert stationary.tau > traveller.tau
+    asym = (stationary.tau - traveller.tau) / stationary.tau
+    assert asym > 0.05


### PR DESCRIPTION
## Summary
- add per-node proper time `tau` and track previous position
- compute relativistic proper-time updates in new scheduler
- include twin paradox demo illustrating time dilation

## Testing
- `python -m black Causal_Web`
- `python -m compileall Causal_Web`
- `python -m Causal_Web.analysis.twin`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893802e1e048325b1f14d12053a2f53