### PR TITLE
feat: add layer cut-offs

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -58,7 +58,8 @@ class Config:
     current_tick = 0  # Counter to display progress
     # Preallocated ticks for object pool
     TICK_POOL_SIZE = 10000
-    N_DECOH = 3  # Fan-in threshold for Born-rule collapse
+    N_DECOH = 3  # Fan-in threshold for thermodynamic behaviour
+    N_CLASS = 6  # Fan-in threshold for classical fallback
 
     # Mapping of ``category`` -> {``label``: bool} controlling which logs are
     # written. Categories correspond to consolidated output files and the labels

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Ticks carry both phase and amplitude. Their influence on interference and cohere
 
 The engine now includes a lightweight quantum upgrade. Each node maintains a
 two-component complex state vector `psi` instead of a single phase, edges can
-optionally apply a Hadamard transform (`u_id=1`), and a global
-`Config.N_DECOH` controls when accumulated fan-in triggers Born-rule collapse.
+optionally apply a Hadamard transform (`u_id=1`), and fan-in thresholds
+`Config.N_DECOH` and `Config.N_CLASS` switch nodes between quantum,
+thermodynamic, and classical behaviour.
 
 Each node also accumulates a proper-time `tau` that accounts for local velocity
 and density effects. Run `analysis/twin.py` for a simple twin-paradox


### PR DESCRIPTION
## Summary
- add `N_CLASS` config threshold for classical fan-in cut-off
- route ticks based on fan-in to thermodynamic or classical layers
- document new layer cut-off configuration in README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main --no-gui --max_ticks 1`
- `python bundle_run.py` *(fails: No module named 'Causal_Web.engine.logging.services')*

------
https://chatgpt.com/codex/tasks/task_e_689382024dac83258055c1ac9a3a09d6