### PR TITLE
Refine decoherence handling and stochastic collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ The engine now includes a lightweight quantum upgrade. Each node maintains a
 two-component complex state vector `psi` instead of a single phase, edges can
 optionally apply a Hadamard transform (`u_id=1`), and fan-in thresholds
 `Config.N_DECOH` and `Config.N_CLASS` switch nodes between quantum,
-thermodynamic, and classical behaviour.
+thermodynamic, and classical behaviour. Hitting the classical threshold now
+collapses a node to an eigenstate using the Born rule, while the decoherence
+threshold preserves ``psi`` but freezes unitary evolution and records only the
+resulting probability distribution.
 
 Each node also accumulates a proper-time `tau` that accounts for local velocity
 and density effects. Run `analysis/twin.py` for a simple twin-paradox


### PR DESCRIPTION
## Summary
- Collapse now samples eigenstates via Born rule at the classical fan-in threshold and resets fan-in counts.
- Decoherence preserves the state vector, records a probability distribution, halts unitary updates, and also resets fan-in counts.
- Edge propagation bypasses unitary transforms for decoherent sources, and nodes initialize with a default probability vector.

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893854457188325a9f46dc7b653d8fc