### PR TITLE
Store locked phase for decoherent propagation

### DIFF
--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -109,6 +109,7 @@ class NodeInitializationService:
         n.coherence_credit = 0.0
         n.decoherence_debt = 0.0
         n.phase_lock = False
+        n.locked_phase = None
         n.collapse_pressure = 0.0
         n.tick_drop_counts = defaultdict(int)
         n.internal_phase = n.phase
@@ -336,7 +337,9 @@ class EdgePropagationService:
             graph=self.graph,
         )
         if self.node.node_type == NodeType.DECOHERENT:
-            shifted = self.phase
+            shifted = (
+                self.node.locked_phase if self.node.locked_phase is not None else 0.0
+            )
             psi_contrib = self.node.probabilities * edge.attenuation
         else:
             shifted = self._shift_phase(edge)

--- a/Causal_Web/engine/services/serialization_service.py
+++ b/Causal_Web/engine/services/serialization_service.py
@@ -66,6 +66,7 @@ class GraphSerializationService:
                     "coherence_credit": n.coherence_credit,
                     "decoherence_debt": n.decoherence_debt,
                     "phase_lock": n.phase_lock,
+                    "locked_phase": n.locked_phase,
                 }
             )
         return nodes

--- a/Causal_Web/engine/tick_engine/tick_router.py
+++ b/Causal_Web/engine/tick_engine/tick_router.py
@@ -57,6 +57,7 @@ class TickRouter:
                 node.psi = np.array([0 + 0j, 1 + 0j], np.complex128)
                 node.probabilities = np.array([0.0, 1.0])
             node.is_classical = True
+            node.locked_phase = node.compute_phase(tick_time)
             node.phase_lock = True
             node.node_type = NodeType.CLASSICALIZED
             node.collapse_origin[tick_time] = node.collapse_origin.get(
@@ -74,6 +75,7 @@ class TickRouter:
             total = probs.sum()
             if total:
                 node.probabilities = probs / total
+            node.locked_phase = node.compute_phase(tick_time)
             node.phase_lock = True
             node.node_type = NodeType.DECOHERENT
             node.incoming_tick_counts[tick_time] = 0


### PR DESCRIPTION
## Summary
- Remember node phase when phase locking occurs and expose it for serialization
- Use locked phase when propagating from decoherent nodes or during entanglement collapse
- Capture locked phase during fan-in evaluation to avoid stale phase usage

## Testing
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main --help`


------
https://chatgpt.com/codex/tasks/task_e_689389377e808325b8299c2f6365f6cf