### PR TITLE
Add Monte-Carlo path sampling for lensing analysis

### DIFF
--- a/Causal_Web/analysis/lensing.py
+++ b/Causal_Web/analysis/lensing.py
@@ -1,0 +1,42 @@
+"""Gravitational lensing analysis utilities."""
+
+from __future__ import annotations
+
+import random
+from typing import Hashable
+
+import networkx as nx
+
+from ..engine.analysis.mc_paths import monte_carlo_path_integral
+
+__all__ = ["lensing_wedge_amplitude"]
+
+
+def lensing_wedge_amplitude(
+    graph: nx.DiGraph,
+    source: Hashable,
+    target: Hashable,
+    *,
+    k: int = 100,
+    samples: int = 1000,
+    weight: str = "delay",
+    rng: random.Random | None = None,
+) -> complex:
+    """Estimate the lensing wedge amplitude between two nodes.
+
+    This function is a thin wrapper over
+    :func:`~Causal_Web.engine.analysis.mc_paths.monte_carlo_path_integral`
+    used in performance-sensitive analyses. It enumerates the ``k`` shortest
+    paths between ``source`` and ``target`` and returns a Monte-Carlo estimate
+    of their aggregate complex amplitude.
+    """
+
+    return monte_carlo_path_integral(
+        graph,
+        source,
+        target,
+        k=k,
+        samples=samples,
+        weight=weight,
+        rng=rng,
+    )

--- a/Causal_Web/engine/analysis/__init__.py
+++ b/Causal_Web/engine/analysis/__init__.py
@@ -1,0 +1,3 @@
+"""Analysis utilities for the simulation engine."""
+
+__all__ = ["mc_paths"]

--- a/Causal_Web/engine/analysis/mc_paths.py
+++ b/Causal_Web/engine/analysis/mc_paths.py
@@ -1,0 +1,162 @@
+"""Monte-Carlo estimation of path integrals on causal graphs."""
+
+from __future__ import annotations
+
+import cmath
+import random
+from dataclasses import dataclass
+from typing import Hashable, Iterable, List, Sequence
+
+import networkx as nx
+
+__all__ = [
+    "PathInfo",
+    "yen_k_shortest_paths",
+    "accumulate_path",
+    "monte_carlo_path_integral",
+    "enumerate_path_integral",
+]
+
+
+@dataclass(frozen=True)
+class PathInfo:
+    """Container for path properties.
+
+    Attributes
+    ----------
+    nodes:
+        Sequence of node identifiers along the path.
+    delay:
+        Sum of edge ``delay`` attributes.
+    phase:
+        Sum of edge ``phase`` attributes.
+    attenuation:
+        Product of edge ``atten`` attributes.
+    """
+
+    nodes: Sequence[Hashable]
+    delay: float
+    phase: float
+    attenuation: float
+
+    @property
+    def amplitude(self) -> complex:
+        """Complex amplitude contributed by this path."""
+
+        return self.attenuation * cmath.exp(1j * self.phase)
+
+
+def yen_k_shortest_paths(
+    graph: nx.DiGraph,
+    source: Hashable,
+    target: Hashable,
+    k: int,
+    weight: str = "delay",
+) -> List[Sequence[Hashable]]:
+    """Return up to ``k`` shortest simple paths from ``source`` to ``target``.
+
+    The implementation delegates to :func:`networkx.shortest_simple_paths`,
+    which internally uses Yen's algorithm to generate simple paths in
+    nondecreasing order of total ``weight``.
+    """
+
+    paths: List[Sequence[Hashable]] = []
+    generator = nx.shortest_simple_paths(graph, source, target, weight=weight)
+    for _ in range(k):
+        try:
+            paths.append(next(generator))
+        except StopIteration:
+            break
+    return paths
+
+
+def accumulate_path(graph: nx.DiGraph, path: Sequence[Hashable]) -> PathInfo:
+    """Accumulate delay, phase and attenuation for ``path``.
+
+    Parameters
+    ----------
+    graph:
+        Graph containing edges of ``path``.
+    path:
+        Sequence of node identifiers representing a simple path.
+    """
+
+    delay = 0.0
+    phase = 0.0
+    attenuation = 1.0
+
+    for u, v in nx.utils.pairwise(path):
+        data = graph[u][v]
+        delay += float(data.get("delay", 0.0))
+        phase += float(data.get("phase", 0.0))
+        attenuation *= float(data.get("atten", 1.0))
+
+    return PathInfo(list(path), delay, phase, attenuation)
+
+
+def monte_carlo_path_integral(
+    graph: nx.DiGraph,
+    source: Hashable,
+    target: Hashable,
+    *,
+    k: int = 100,
+    samples: int = 1000,
+    weight: str = "delay",
+    rng: random.Random | None = None,
+) -> complex:
+    """Estimate the sum of complex amplitudes over paths from source to target.
+
+    Paths are first truncated to the ``k`` shortest simple paths according to
+    ``weight``. The returned value approximates the sum of amplitudes for this
+    truncated set using Monte-Carlo sampling with ``samples`` draws.
+
+    Edge attributes ``phase`` and ``atten`` control the complex contribution of
+    each edge. Missing attributes default to ``0`` phase and ``1`` attenuation.
+
+    Parameters
+    ----------
+    graph:
+        Directed graph to sample.
+    source, target:
+        Nodes between which paths are considered.
+    k:
+        Maximum number of shortest paths to enumerate.
+    samples:
+        Number of Monte-Carlo samples to draw.
+    weight:
+        Edge attribute used as length for Yen's algorithm.
+    rng:
+        Optional :class:`random.Random` instance for reproducibility.
+
+    Returns
+    -------
+    complex
+        Estimated complex amplitude of the truncated path set.
+    """
+
+    rng = rng or random.Random()
+    raw_paths = yen_k_shortest_paths(graph, source, target, k, weight=weight)
+    infos = [accumulate_path(graph, p) for p in raw_paths]
+    if not infos:
+        return 0j
+
+    amplitudes = [info.amplitude for info in infos]
+    picks = rng.choices(amplitudes, k=samples)
+    return sum(picks) / samples * len(amplitudes)
+
+
+def enumerate_path_integral(
+    graph: nx.DiGraph, source: Hashable, target: Hashable
+) -> complex:
+    """Compute the exact path integral by enumerating all simple paths.
+
+    This helper is intended for small graphs and testing. The calculation uses
+    :func:`networkx.all_simple_paths` and therefore may be extremely expensive
+    for dense graphs.
+    """
+
+    total = 0j
+    for path in nx.all_simple_paths(graph, source, target):
+        info = accumulate_path(graph, path)
+        total += info.amplitude
+    return total

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ percent numerical error.
 Each node also accumulates a proper-time `tau` that accounts for local velocity
 and density effects. Run `analysis/twin.py` for a simple twin-paradox
 demonstration showcasing this time dilation.
+Run `analysis/lensing.py` to approximate lensing wedge amplitudes via a
+Monte-Carlo path sampler over the graph's causal structure.
 
 ## Table of Contents
 - [Quick Start](#quick-start)

--- a/tests/test_mc_paths.py
+++ b/tests/test_mc_paths.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import random
+
+import networkx as nx
+
+from Causal_Web.engine.analysis.mc_paths import (
+    enumerate_path_integral,
+    monte_carlo_path_integral,
+)
+
+
+def build_test_graph() -> nx.DiGraph:
+    g = nx.DiGraph()
+    edges = [
+        ("s", "a", {"delay": 1, "phase": 0.1, "atten": 0.9}),
+        ("a", "t", {"delay": 1, "phase": 0.2, "atten": 0.8}),
+        ("s", "b", {"delay": 2, "phase": 0.0, "atten": 0.7}),
+        ("b", "t", {"delay": 1, "phase": 0.3, "atten": 0.6}),
+        ("a", "b", {"delay": 1, "phase": 0.5, "atten": 0.5}),
+        ("b", "a", {"delay": 1, "phase": 0.4, "atten": 0.5}),
+    ]
+    g.add_edges_from(edges)
+    return g
+
+
+def test_mc_estimator_matches_full_enumeration():
+    g = build_test_graph()
+    exact = enumerate_path_integral(g, "s", "t")
+    n_paths = sum(1 for _ in nx.all_simple_paths(g, "s", "t"))
+    estimate = monte_carlo_path_integral(
+        g,
+        "s",
+        "t",
+        k=n_paths,
+        samples=5000,
+        rng=random.Random(1),
+    )
+    rel_err = abs(estimate - exact) / abs(exact)
+    assert rel_err < 0.02


### PR DESCRIPTION
## Summary
- add `engine.analysis.mc_paths` implementing Yen-K shortest paths with Monte Carlo averaging
- expose `analysis.lensing.lensing_wedge_amplitude` wrapper
- document new lensing analysis feature and test accuracy against full enumeration

## Testing
- `black Causal_Web tests/test_mc_paths.py`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893c18e4b9083259647c8a3e507e725