### PR TITLE
Handle legacy edge fields in path accumulation

### DIFF
--- a/Causal_Web/engine/analysis/mc_paths.py
+++ b/Causal_Web/engine/analysis/mc_paths.py
@@ -73,6 +73,10 @@ def yen_k_shortest_paths(
 def accumulate_path(graph: nx.DiGraph, path: Sequence[Hashable]) -> PathInfo:
     """Accumulate delay, phase and attenuation for ``path``.
 
+    Edge attributes may use either the short field names ``phase``/``atten`` or
+    the legacy names ``phase_shift``/``attenuation``. Missing attributes default
+    to ``0`` phase and ``1`` attenuation.
+
     Parameters
     ----------
     graph:
@@ -88,8 +92,8 @@ def accumulate_path(graph: nx.DiGraph, path: Sequence[Hashable]) -> PathInfo:
     for u, v in nx.utils.pairwise(path):
         data = graph[u][v]
         delay += float(data.get("delay", 0.0))
-        phase += float(data.get("phase", 0.0))
-        attenuation *= float(data.get("atten", 1.0))
+        phase += float(data.get("phase", data.get("phase_shift", 0.0)))
+        attenuation *= float(data.get("atten", data.get("attenuation", 1.0)))
 
     return PathInfo(list(path), delay, phase, attenuation)
 

--- a/tests/test_mc_paths.py
+++ b/tests/test_mc_paths.py
@@ -7,6 +7,7 @@ import networkx as nx
 from Causal_Web.engine.analysis.mc_paths import (
     enumerate_path_integral,
     monte_carlo_path_integral,
+    accumulate_path,
 )
 
 
@@ -38,3 +39,14 @@ def test_mc_estimator_matches_full_enumeration():
     )
     rel_err = abs(estimate - exact) / abs(exact)
     assert rel_err < 0.02
+
+
+def test_accumulate_path_aliases_legacy_fields() -> None:
+    """accumulate_path should read legacy phase/attenuation fields."""
+
+    g = nx.DiGraph()
+    g.add_edge("s", "t", delay=1, phase_shift=0.25, attenuation=0.5)
+    info = accumulate_path(g, ["s", "t"])
+    assert info.delay == 1
+    assert info.phase == 0.25
+    assert info.attenuation == 0.5


### PR DESCRIPTION
## Summary
- honor legacy `phase_shift` and `attenuation` edge fields when accumulating path properties
- test that `accumulate_path` reads legacy phase and attenuation fields

## Testing
- `python -m black Causal_Web tests/test_mc_paths.py`
- `pip install numpy networkx pytest pydantic`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c3a041108325876d90e72370be31