### PR TITLE
feat: support dynamic entanglement and gauge phases

### DIFF
--- a/Causal_Web/engine/models/graph.py
+++ b/Causal_Web/engine/models/graph.py
@@ -62,6 +62,7 @@ class CausalGraph:
         origin_type: str = "seed",
         generation_tick: int = 0,
         parent_ids: list[str] | None = None,
+        cnot_source: bool = False,
     ) -> None:
         x, y = self._non_overlapping_position(x, y)
         if refractory_period is None:
@@ -77,6 +78,7 @@ class CausalGraph:
             origin_type=origin_type,
             generation_tick=generation_tick,
             parent_ids=parent_ids,
+            cnot_source=cnot_source,
         )
         node = self.nodes[node_id]
         self.spatial_index[(node.grid_x, node.grid_y)].add(node_id)
@@ -123,6 +125,7 @@ class CausalGraph:
         weight: float | None = None,
         u_id: int = 0,
         *,
+        A_phase: float = 0.0,
         epsilon: bool = False,
         partner_id: str | None = None,
     ) -> None:
@@ -132,6 +135,8 @@ class CausalGraph:
         ----------
         source_id, target_id:
             Node identifiers for the edge endpoints.
+        A_phase:
+            Gauge phase applied to ticks traversing this link.
         epsilon:
             When ``True`` the edge participates in an ``\u03b5`` pair whose
             partner is identified by ``partner_id``. Collapses of one node
@@ -153,6 +158,7 @@ class CausalGraph:
             density,
             delay,
             phase_shift,
+            A_phase,
             weight,
             density_specified=density_specified,
             u_id=u_id,

--- a/Causal_Web/engine/services/serialization_service.py
+++ b/Causal_Web/engine/services/serialization_service.py
@@ -96,6 +96,7 @@ class GraphSerializationService:
                 "attenuation": e.attenuation,
                 "density": e.density,
                 "phase_shift": e.phase_shift,
+                "A_phase": getattr(e, "A_phase", 0.0),
                 "epsilon": getattr(e, "epsilon", False),
                 "partner_id": getattr(e, "partner_id", None),
             }

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -383,6 +383,7 @@ class GraphLoadService:
                 delay=edge.get("delay", 1),
                 phase_shift=edge.get("phase_shift", 0.0),
                 weight=edge.get("weight"),
+                A_phase=edge.get("A_phase", 0.0),
                 epsilon=edge.get("epsilon", False),
                 partner_id=edge.get("partner_id"),
             )

--- a/Causal_Web/graph/types.py
+++ b/Causal_Web/graph/types.py
@@ -34,6 +34,7 @@ EdgeData = TypedDict(
         "attenuation": float,
         "density": float,
         "phase_shift": float,
+        "A_phase": float,
         "weight": float,
         "u_id": int,
         "epsilon": bool,

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ When one node collapses, its ``epsilon`` partner is projected onto the opposite
 eigenvector, enabling Bell-test correlations without a bridge. Collapse now
 propagates regardless of edge direction so even a single directed ``epsilon``
 edge enforces the pairing.
+Nodes flagged with ``cnot_source`` dynamically convert their first two outgoing
+edges into such an ``epsilon`` pair whenever they fire. Each edge additionally
+supports an ``A_phase`` parameter representing a U(1) gauge potential; ticks
+traversing the edge accumulate this phase shift.
 The GUI now includes an **Analysis** menu with a *Bell Inequality Analysis...*
 action that opens a window showing CHSH statistics and a histogram of
 expectation values.

--- a/tests/test_dynamic_entanglement.py
+++ b/tests/test_dynamic_entanglement.py
@@ -1,0 +1,29 @@
+import math
+
+from Causal_Web.engine.models.graph import CausalGraph
+
+
+def test_cnot_source_creates_epsilon_edges():
+    g = CausalGraph()
+    g.add_node("J", cnot_source=True)
+    g.add_node("A")
+    g.add_node("B")
+    g.add_edge("J", "A")
+    g.add_edge("J", "B")
+    j = g.get_node("J")
+    j.apply_tick(0, 0.0, g)
+    edges = g.get_edges_from("J")
+    assert edges[0].epsilon and edges[1].epsilon
+    assert edges[0].partner is edges[1]
+
+
+def test_gauge_phase_shift():
+    g = CausalGraph()
+    g.add_node("A")
+    g.add_node("B")
+    g.add_edge("A", "B", A_phase=math.pi / 2)
+    a = g.get_node("A")
+    a.apply_tick(0, 0.0, g)
+    b = g.get_node("B")
+    incoming = b.incoming_phase_queue[min(b.incoming_phase_queue.keys())][0][0]
+    assert math.isclose(incoming, math.pi / 2, rel_tol=1e-5)


### PR DESCRIPTION
## Summary
- allow nodes flagged as `cnot_source` to entangle two outgoing edges on firing
- add `A_phase` gauge shift to edges and propagate phase with it
- document dynamic epsilon edges and gauge phases

## Testing
- `black Causal_Web tests/test_dynamic_entanglement.py`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`
- `python bundle_run.py` *(fails: ModuleNotFoundError: No module named 'Causal_Web.engine.logging.services')*


------
https://chatgpt.com/codex/tasks/task_e_6893c56f0e848325996265d909499033