### PR TITLE
Preserve cnot_source flags and epsilon pairs

### DIFF
--- a/Causal_Web/engine/services/entanglement_service.py
+++ b/Causal_Web/engine/services/entanglement_service.py
@@ -13,7 +13,8 @@ class EntanglementService:
         """Collapse epsilon-linked partners to the opposite eigenstate.
 
         Both incoming and outgoing ``\u03b5`` edges are inspected so collapse
-        propagates even when only a single directed edge exists.
+        propagates even when only a single directed edge exists. The partner's
+        classical probabilities are mirrored to maintain coherent statistics.
 
         Parameters
         ----------
@@ -38,6 +39,7 @@ class EntanglementService:
             if partner is None or partner.collapse_origin.get(tick_time) is not None:
                 continue
             partner.psi = np.array([node.psi[1], node.psi[0]], np.complex128)
+            partner.probabilities = node.probabilities[::-1]
             partner.collapse_origin[tick_time] = "epsilon"
             partner.incoming_tick_counts[tick_time] = 0
             visited.add(partner_id)

--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -291,8 +291,11 @@ class NodeTickService:
                 ):
                     e1.epsilon = True
                     e2.epsilon = True
+                    pair_id = str(uuid.uuid4())
                     e1.partner = e2
                     e2.partner = e1
+                    e1.partner_id = pair_id
+                    e2.partner_id = pair_id
         EdgePropagationService(
             node=self.node,
             tick_time=self.tick_time,

--- a/Causal_Web/engine/services/serialization_service.py
+++ b/Causal_Web/engine/services/serialization_service.py
@@ -67,6 +67,7 @@ class GraphSerializationService:
                     "decoherence_debt": n.decoherence_debt,
                     "phase_lock": n.phase_lock,
                     "locked_phase": n.locked_phase,
+                    "cnot_source": n.cnot_source,
                 }
             )
         return nodes

--- a/Causal_Web/engine/services/sim_services.py
+++ b/Causal_Web/engine/services/sim_services.py
@@ -333,6 +333,7 @@ class GraphLoadService:
                 origin_type=node_data.get("origin_type", "seed"),
                 generation_tick=node_data.get("generation_tick", 0),
                 parent_ids=node_data.get("parent_ids"),
+                cnot_source=node_data.get("cnot_source", False),
             )
             goals = node_data.get("goals")
             if goals is not None:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ edge enforces the pairing.
 Nodes flagged with ``cnot_source`` dynamically convert their first two outgoing
 edges into such an ``epsilon`` pair whenever they fire. Each edge additionally
 supports an ``A_phase`` parameter representing a U(1) gauge potential; ticks
-traversing the edge accumulate this phase shift.
+traversing the edge accumulate this phase shift. Serialized graphs now
+preserve ``cnot_source`` flags and their resulting ``epsilon`` pairings on
+reload.
 The GUI now includes an **Analysis** menu with a *Bell Inequality Analysis...*
 action that opens a window showing CHSH statistics and a histogram of
 expectation values.

--- a/tests/test_dynamic_entanglement.py
+++ b/tests/test_dynamic_entanglement.py
@@ -1,6 +1,13 @@
+import json
 import math
 
+import numpy as np
+
 from Causal_Web.engine.models.graph import CausalGraph
+from Causal_Web.engine.services import (
+    EntanglementService,
+    GraphLoadService,
+)
 
 
 def test_cnot_source_creates_epsilon_edges():
@@ -17,6 +24,22 @@ def test_cnot_source_creates_epsilon_edges():
     assert edges[0].partner is edges[1]
 
 
+def test_epsilon_collapse_copies_probabilities():
+    g = CausalGraph()
+    g.add_node("A")
+    g.add_node("B")
+    g.add_edge("A", "B", epsilon=True, partner_id="p")
+    g.add_edge("B", "A", epsilon=True, partner_id="p")
+    a = g.get_node("A")
+    b = g.get_node("B")
+    a.psi = np.array([1, 0], np.complex128)
+    a.probabilities = np.array([0.2, 0.8])
+    b.psi = np.array([0, 1], np.complex128)
+    b.probabilities = np.array([0.5, 0.5])
+    EntanglementService.collapse_epsilon(g, a, 0)
+    assert np.allclose(b.probabilities, [0.8, 0.2])
+
+
 def test_gauge_phase_shift():
     g = CausalGraph()
     g.add_node("A")
@@ -27,3 +50,23 @@ def test_gauge_phase_shift():
     b = g.get_node("B")
     incoming = b.incoming_phase_queue[min(b.incoming_phase_queue.keys())][0][0]
     assert math.isclose(incoming, math.pi / 2, rel_tol=1e-5)
+
+
+def test_cnot_source_round_trip(tmp_path):
+    g = CausalGraph()
+    g.add_node("J", cnot_source=True)
+    g.add_node("A")
+    g.add_node("B")
+    g.add_edge("J", "A")
+    g.add_edge("J", "B")
+    j = g.get_node("J")
+    j.apply_tick(0, 0.0, g)
+    data = g.to_dict()
+    path = tmp_path / "graph.json"
+    path.write_text(json.dumps(data))
+    g2 = CausalGraph()
+    GraphLoadService(g2, str(path)).load()
+    j2 = g2.get_node("J")
+    assert j2.cnot_source
+    edges = g2.get_edges_from("J")
+    assert edges[0].partner is edges[1]


### PR DESCRIPTION
## Summary
- forward `cnot_source` through JSON load/save and document persistence
- mirror probabilities when epsilon partners collapse
- give dynamically created epsilon edges persistent `partner_id`

## Testing
- `black Causal_Web tests/test_dynamic_entanglement.py`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c99f5bb48325abb2ae22c3d4cb1e