### PR TITLE
Allow fractional delays and deduplicate density neighbours

### DIFF
--- a/Causal_Web/engine/fields/density.py
+++ b/Causal_Web/engine/fields/density.py
@@ -33,6 +33,13 @@ class DensityField:
             Edge receiving the energy contribution.
         amplitude:
             Complex amplitude whose squared magnitude represents energy.
+
+        Note
+        ----
+        Access to the internal density map is protected by the GIL in
+        CPython but is not inherently thread-safe. Alternative interpreters
+        or accelerator backends may require atomic updates or per-thread
+        accumulation.
         """
 
         energy = float(np.sum(np.abs(amplitude) ** 2))
@@ -61,10 +68,10 @@ class DensityField:
         new_rho: Dict[Tuple[str, str], float] = defaultdict(float, self._rho)
         for edge in graph.edges:
             key = (edge.source, edge.target)
-            neighbours = []
+            neighbours: set[Edge] = set()
             for nid in (edge.source, edge.target):
-                neighbours.extend(graph.get_edges_from(nid))
-                neighbours.extend(graph.get_edges_to(nid))
+                neighbours.update(graph.get_edges_from(nid))
+                neighbours.update(graph.get_edges_to(nid))
             if not neighbours:
                 continue
             mean = sum(

--- a/Causal_Web/engine/services/node_services.py
+++ b/Causal_Web/engine/services/node_services.py
@@ -360,7 +360,7 @@ class EdgePropagationService:
         from ..fields.density import get_field
 
         rho = get_field().get(edge)
-        delay = max(1, int(round(delay * (1 + kappa * rho))))
+        delay = max(1.0, delay * (1 + kappa * rho))
         if self.node.node_type == NodeType.DECOHERENT:
             shifted = (
                 (self.node.locked_phase if self.node.locked_phase is not None else 0.0)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Causal Web
 
-Causal Web is a simulation engine and GUI for experimenting with causal graphs. Nodes emit ticks that propagate through edges with delay and attenuation while observers infer hidden state from the resulting activity. The project is written in Python and uses [PySide6](https://doc.qt.io/qtforpython/) for the graphical interface.
+Causal Web is a simulation engine and GUI for experimenting with causal graphs. Nodes emit ticks that propagate through edges with delay and attenuation while observers infer hidden state from the resulting activity. Delays now retain sub-tick precision and are quantised only when scheduled, enabling finer-grained simulations. The project is written in Python and uses [PySide6](https://doc.qt.io/qtforpython/) for the graphical interface.
 
 Ticks carry both phase and amplitude. Their influence on interference and coherence is weighted by amplitude and each tick records the local `generation_tick` at which it was emitted.
 

--- a/tests/test_dynamic_density.py
+++ b/tests/test_dynamic_density.py
@@ -23,4 +23,4 @@ def test_dynamic_delay_uses_computed_density():
     g.precompute_local_densities(radius=1)
     edge = g.get_edges_from("A")[0]
     delay = edge.adjusted_delay(1.0, 1.0, kappa=1.0, graph=g)
-    assert delay == int(2 * (1 + 2))
+    assert delay == 2 * (1 + 2)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -37,7 +37,7 @@ def test_detect_clusters():
 def test_edge_adjusted_delay():
     edge = Edge("A", "B", attenuation=1.0, density=0.5, delay=2)
     delay = edge.adjusted_delay(1.0, 1.0, kappa=1.0)
-    assert delay == int(2 * (1 + 0.5))
+    assert delay == 2 * (1 + 0.5)
 
 
 def test_remove_node_cleans_references():

--- a/tests/test_stress_energy_density.py
+++ b/tests/test_stress_energy_density.py
@@ -16,7 +16,7 @@ def test_density_increases_delay():
     kappa = 1.0
     base = edge.adjusted_delay(1.0, 1.0, kappa, graph=g)
     rho = field.get(edge)
-    delay = int(round(base * (1 + kappa * rho)))
+    delay = base * (1 + kappa * rho)
     assert delay == 2
 
 


### PR DESCRIPTION
## Summary
- retain sub-tick precision for edge delays and defer quantisation to scheduler
- deduplicate neighbour collection in `DensityField.diffuse`
- document density-field thread-safety concerns

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d01ad3fc832596a9f2317cb5a16c