### PR TITLE
Add horizon thermodynamics and Page-curve entropy tracking

### DIFF
--- a/Causal_Web/engine/horizon.py
+++ b/Causal_Web/engine/horizon.py
@@ -1,0 +1,138 @@
+"""Toy horizon thermodynamics model for Hawking radiation.
+
+This module contains a lightweight model that probabilistically emits entangled
+Hawking pairs from nodes designated as *interior* to a horizon.  The emitted
+quanta are tracked to build a crude Page curve for the exterior radiation's
+entropy.  The entropy rises until roughly half of the interior quanta have been
+emitted and then falls back to zero as the horizon evaporates.
+
+The public API exposes a singleton horizon model and a few helpers for
+integration with the scheduler:
+
+``get_horizon()``
+    Access the global :class:`HorizonThermodynamics` instance.
+``register_interior(node, energy)``
+    Mark a node as inside the horizon with an energy budget.
+``step(nodes)``
+    Perform Hawking emission for a collection of nodes for one tick.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Dict, Iterable, List
+
+from ..config import Config
+from .models.node import Node
+
+
+class HorizonThermodynamics:
+    """Simulate Hawking-pair emission and track exterior entropy.
+
+    Parameters
+    ----------
+    temperature:
+        Hawking temperature :math:`T_H` controlling the emission probability.
+    delta_e:
+        Energy carried by a single quantum; defaults to ``1.0``.
+    """
+
+    def __init__(self, temperature: float, delta_e: float = 1.0) -> None:
+        self.temperature = temperature
+        self.delta_e = delta_e
+        self.interior_energy: Dict[str, float] = {}
+        self.emitted_quanta = 0
+        self.total_quanta = 0.0
+        self.outside_entropy: List[float] = []
+
+    def register(self, node: Node, energy: float) -> None:
+        """Mark ``node`` as inside the horizon with available ``energy``.
+
+        Parameters
+        ----------
+        node:
+            Interior node eligible to emit Hawking quanta.
+        energy:
+            Energy budget that can be converted into emitted quanta.
+        """
+
+        self.interior_energy[node.id] = energy
+        self.total_quanta += energy / self.delta_e
+
+    def step(self, nodes: Iterable[Node]) -> None:
+        """Attempt Hawking emission for ``nodes`` and update entropy.
+
+        Parameters
+        ----------
+        nodes:
+            Nodes to process this tick. Only nodes previously registered as
+            interior contribute energy.
+        """
+
+        prob = math.exp(-self.delta_e / self.temperature)
+        for node in nodes:
+            energy = self.interior_energy.get(node.id, 0.0)
+            if energy <= 0.0:
+                continue
+            if random.random() < prob:
+                energy -= self.delta_e
+                self.emitted_quanta += 1
+            self.interior_energy[node.id] = max(0.0, energy)
+        self._update_entropy()
+
+    def _update_entropy(self) -> None:
+        out = self.emitted_quanta
+        ent = min(out, self.total_quanta - out)
+        self.outside_entropy.append(ent)
+
+    @property
+    def entropy(self) -> float:
+        """Return the most recent outside entropy value."""
+
+        if not self.outside_entropy:
+            return 0.0
+        return self.outside_entropy[-1]
+
+
+_horizon: HorizonThermodynamics | None = None
+
+
+def get_horizon() -> HorizonThermodynamics:
+    """Return the global :class:`HorizonThermodynamics` instance.
+
+    The instance is created lazily using ``Config.hawking_temperature`` for its
+    temperature.
+    """
+
+    global _horizon
+    if _horizon is None:
+        temp = getattr(Config, "hawking_temperature", 1.0)
+        _horizon = HorizonThermodynamics(temp)
+    return _horizon
+
+
+def register_interior(node: Node, energy: float) -> None:
+    """Register ``node`` as interior using the global horizon model.
+
+    Parameters
+    ----------
+    node:
+        Node to register as interior.
+    energy:
+        Energy available for Hawking emission.
+    """
+
+    get_horizon().register(node, energy)
+
+
+def step(nodes: Iterable[Node]) -> None:
+    """Advance the global horizon model for ``nodes``.
+
+    Parameters
+    ----------
+    nodes:
+        Nodes to process for potential Hawking emission during this tick.
+    """
+
+    get_horizon().step(nodes)

--- a/Causal_Web/engine/scheduler.py
+++ b/Causal_Web/engine/scheduler.py
@@ -6,6 +6,7 @@ from typing import Iterable, Mapping
 from ..config import Config
 from .models.node import Node
 from .fields.density import get_field
+from .horizon import step as horizon_step
 
 
 def update_proper_time(node: Node, dt: float, rho: float, kappa: float) -> float:
@@ -72,3 +73,4 @@ def step(
     for node in nodes:
         rho = rho_map.get(node.id, 0.0)
         update_proper_time(node, dt, rho, kappa)
+    horizon_step(nodes)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ Amplitude energy now feeds a stress–energy field that scales edge delay by
 ``1 + κρ``. This density diffuses each scheduler step with weight
 ``Config.density_diffusion_weight`` (``α``).
 
+Scheduler steps also integrate a toy horizon thermodynamics model. Interior
+nodes may emit Hawking pairs with probability ``exp(-ΔE/T_H)``, and the
+resulting radiation entropy follows a simple Page-curve: growing then
+declining as the horizon evaporates.
+
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `log_interval` option controls how often metrics and graph snapshots are written, while `logging_mode` selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.

--- a/tests/test_horizon_entropy.py
+++ b/tests/test_horizon_entropy.py
@@ -1,0 +1,26 @@
+import random
+
+from Causal_Web.engine.horizon import HorizonThermodynamics
+from Causal_Web.engine.models.node import Node
+
+
+def test_page_curve_behavior():
+    random.seed(0)
+    horizon = HorizonThermodynamics(temperature=2.0)
+    nodes = [Node(str(i)) for i in range(3)]
+    for n in nodes:
+        horizon.register(n, energy=2.0)
+
+    for _ in range(1000):
+        horizon.step(nodes)
+        if horizon.emitted_quanta >= horizon.total_quanta:
+            break
+
+    entropy = horizon.outside_entropy
+    peak = max(entropy)
+    peak_idx = entropy.index(peak)
+    assert peak_idx < len(entropy) - 1
+    # Final entropy should return to zero but allow for floating point tolerance
+    assert abs(entropy[-1]) < 1e-10
+    assert all(entropy[i] <= entropy[i + 1] for i in range(peak_idx))
+    assert all(entropy[i] >= entropy[i + 1] for i in range(peak_idx, len(entropy) - 1))


### PR DESCRIPTION
## Summary
- Model Hawking-pair emission and entropy bookkeeping in new `HorizonThermodynamics`
- Schedule horizon step each tick to integrate emission into node updates
- Document horizon thermodynamics in README
- Relax horizon entropy test to allow a small tolerance for floating point rounding
- Document Horizon Thermodynamics API and helper functions

## Testing
- `pip install numpy networkx pytest pydantic`
- `python -m compileall Causal_Web`
- `pytest`
- `python bundle_run.py` *(fails: ModuleNotFoundError: No module named 'Causal_Web.engine.logging.services')*

------
https://chatgpt.com/codex/tasks/task_e_6893d1a868548325a9114ea3abdd6267