### PR TITLE
Expose Hawking delta energy and inject RNG

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -63,6 +63,7 @@ class Config:
     N_DECOH = 3  # Fan-in threshold for thermodynamic behaviour
     N_CLASS = 6  # Fan-in threshold for classical fallback
     chi_max = 16  # Max MPS bond dimension
+    hawking_delta_e = 1.0  # Energy quantum for horizon emissions
 
     # Mapping of ``category`` -> {``label``: bool} controlling which logs are
     # written. Categories correspond to consolidated output files and the labels

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Amplitude energy now feeds a stress–energy field that scales edge delay by
 Scheduler steps also integrate a toy horizon thermodynamics model. Interior
 nodes may emit Hawking pairs with probability ``exp(-ΔE/T_H)``, and the
 resulting radiation entropy follows a simple Page-curve: growing then
-declining as the horizon evaporates.
+declining as the horizon evaporates. The energy quantum ``ΔE`` can be tuned at
+runtime via ``Config.hawking_delta_e``.
 
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `log_interval` option controls how often metrics and graph snapshots are written, while `logging_mode` selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.

--- a/tests/test_horizon_entropy.py
+++ b/tests/test_horizon_entropy.py
@@ -5,8 +5,8 @@ from Causal_Web.engine.models.node import Node
 
 
 def test_page_curve_behavior():
-    random.seed(0)
-    horizon = HorizonThermodynamics(temperature=2.0)
+    rng = random.Random(0)
+    horizon = HorizonThermodynamics(temperature=2.0, rng=rng)
     nodes = [Node(str(i)) for i in range(3)]
     for n in nodes:
         horizon.register(n, energy=2.0)


### PR DESCRIPTION
## Summary
- allow tuning Hawking quantum energy via `Config.hawking_delta_e`
- seedable random generator in `HorizonThermodynamics` and global helper
- document configuration option and adapt entropy test

## Testing
- `python -m Causal_Web.main --no-gui --max_ticks 1`
- `python bundle_run.py` *(fails: ModuleNotFoundError: No module named 'Causal_Web.engine.logging.services')*
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893f4ceb1348325bf3b0d4067191003