### PR TITLE
feat: add multi-layer scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ resulting radiation entropy follows a simple Page-curve: growing then
 declining as the horizon evaporates. The energy quantum ``ΔE`` can be tuned at
 runtime via ``Config.hawking_delta_e``.
 
+The scheduler also supports a quantum micro layer via
+``scheduler.run_multi_layer``. This helper executes ``micro_ticks`` quantum
+steps before each classical update and calls a user-provided ``flush`` callback
+to synchronise state between layers.
+
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `log_interval` option controls how often metrics and graph snapshots are written, while `logging_mode` selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.

--- a/tests/test_multi_layer_scheduler.py
+++ b/tests/test_multi_layer_scheduler.py
@@ -1,0 +1,17 @@
+import Causal_Web.engine.scheduler as scheduler
+
+
+def test_run_multi_layer_order():
+    order = []
+
+    def q_tick():
+        order.append("q")
+
+    def c_tick():
+        order.append("c")
+
+    def flush():
+        order.append("f")
+
+    scheduler.run_multi_layer(q_tick, c_tick, micro_ticks=2, macro_ticks=2, flush=flush)
+    assert order == ["q", "q", "f", "c", "q", "q", "f", "c"]


### PR DESCRIPTION
## Summary
- add `run_multi_layer` to execute quantum micro ticks before classical updates
- document new multi-layer scheduler helper
- cover multi-layer scheduling behaviour with tests

## Testing
- `python -m compileall Causal_Web`
- `pytest`
- `python bundle_run.py` *(fails: ModuleNotFoundError: No module named 'Causal_Web.engine.logging.services')*

------
https://chatgpt.com/codex/tasks/task_e_6893f618a1cc832590aad81fd8e54d4f