### PR TITLE
feat: add GPU kernels and Ray sharding utilities

### DIFF
--- a/Causal_Web/engine/backend/__init__.py
+++ b/Causal_Web/engine/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend utilities for GPU and distributed processing."""

--- a/Causal_Web/engine/backend/cupy_kernels.py
+++ b/Causal_Web/engine/backend/cupy_kernels.py
@@ -1,0 +1,58 @@
+"""CUDA kernels for heavy per-edge operations.
+
+The functions in this module offload dense complex-number operations to the
+GPU using `cupy`.  If `cupy` is not installed or a CUDA device is not
+available, the implementations transparently fall back to NumPy.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import cupy as cp
+except Exception:  # pragma: no cover - gracefully handle missing CUDA
+    cp = None
+
+
+def _to_device(array: np.ndarray | Iterable[float]) -> "cp.ndarray" | np.ndarray:
+    """Return an array on the GPU if `cupy` is available."""
+    if cp is None:
+        return np.asarray(array)
+    return cp.asarray(array)
+
+
+def complex_weighted_sum(phases: np.ndarray, weights: np.ndarray) -> np.ndarray:
+    """Return ``phases * weights`` using the GPU when possible.
+
+    Parameters
+    ----------
+    phases:
+        Complex phase factors for each edge.
+    weights:
+        Edge weights with the same shape as ``phases``.
+
+    Returns
+    -------
+    np.ndarray
+        Weighted phases as a NumPy array regardless of backend.
+    """
+
+    if phases.shape != weights.shape:
+        raise ValueError("phase and weight arrays must share a shape")
+
+    if cp is None:
+        return phases * weights
+
+    c_phases = _to_device(phases)
+    c_weights = _to_device(weights)
+    result = c_phases * c_weights
+    return cp.asnumpy(result)
+
+
+def is_available() -> bool:
+    """Return ``True`` if a CUDA backend is ready."""
+
+    return cp is not None

--- a/Causal_Web/engine/backend/ray_cluster.py
+++ b/Causal_Web/engine/backend/ray_cluster.py
@@ -1,0 +1,63 @@
+"""Minimal Ray helpers for sharding classical zones.
+
+This module provides a tiny wrapper around :mod:`ray` to spread work across
+multiple CPU or GPU workers.  Functions fall back to local execution when Ray
+is not installed or a cluster is unavailable.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Any, List
+
+try:  # pragma: no cover - optional dependency
+    import ray
+except Exception:  # pragma: no cover - gracefully handle missing Ray
+    ray = None
+
+
+def init_cluster(**kwargs: Any) -> None:
+    """Initialise a Ray cluster if possible."""
+    if ray is None:
+        return
+    if not ray.is_initialized():
+        ray.init(**kwargs)
+
+
+if ray is not None:  # pragma: no cover - decorator requires Ray
+
+    @ray.remote
+    def _apply(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+else:  # pragma: no cover - local fallback
+
+    def _apply(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+
+def map_zones(func: Callable[[Any], Any], zones: Iterable[Any]) -> List[Any]:
+    """Execute ``func`` for each item in ``zones`` using Ray when available.
+
+    Parameters
+    ----------
+    func:
+        Callable applied to each zone.
+    zones:
+        Iterable of zone descriptors.
+
+    Returns
+    -------
+    list
+        Results for each zone.
+    """
+    zone_list = list(zones)
+    if ray is None or not ray.is_initialized():
+        return [func(z) for z in zone_list]
+    futures = [_apply.remote(func, z) for z in zone_list]
+    return list(ray.get(futures))
+
+
+def shutdown() -> None:
+    """Shut down the Ray cluster if it is running."""
+    if ray is not None and ray.is_initialized():
+        ray.shutdown()

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ The scheduler also supports a quantum micro layer via
 steps before each classical update and calls a user-provided ``flush`` callback
 to synchronise state between layers.
 
+## GPU and Distributed Acceleration
+The engine optionally accelerates per-edge calculations on the GPU when [Cupy](https://cupy.dev) is installed and can shard classical zones across a [Ray](https://www.ray.io) cluster.
+
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `log_interval` option controls how often metrics and graph snapshots are written, while `logging_mode` selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.


### PR DESCRIPTION
## Summary
- add optional CuPy-based GPU kernels for per-edge complex math
- provide Ray helpers to shard classical zones
- document optional GPU and distributed acceleration in README

## Testing
- `pip install numpy networkx pytest pydantic`
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893f92b091083259ab31e14acd33e44