### PR TITLE
feat: vectorize edge propagation with cupy

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ to synchronise state between layers.
 ## GPU and Distributed Acceleration
 The engine optionally accelerates per-edge calculations on the GPU when [Cupy](https://cupy.dev) is installed and can shard classical zones across a [Ray](https://www.ray.io) cluster. Select the backend with `Config.backend` or `--backend` (`cpu` by default, `cupy` for CUDA).
 
+Edge propagation now batches phase factors and attenuations before offloading the
+complex multiply to CuPy, falling back to vectorised NumPy when CUDA is
+unavailable. A micro-benchmark under `tests/perf_edge_kernel.py` asserts the
+kernel processes one million edges in under 100 ms on compatible hardware.
+
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `log_interval` option controls how often metrics and graph snapshots are written, while `logging_mode` selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.

--- a/tests/perf_edge_kernel.py
+++ b/tests/perf_edge_kernel.py
@@ -1,0 +1,18 @@
+import time
+
+import numpy as np
+import pytest
+
+from Causal_Web.engine.backend import cupy_kernels
+
+
+@pytest.mark.skipif(not cupy_kernels.is_available(), reason="cupy not available")
+def test_complex_weighted_sum_performance():
+    n = 1_000_000
+    rng = np.random.default_rng(1)
+    phases = np.exp(1j * rng.random(n))
+    weights = rng.random(n)
+    start = time.perf_counter()
+    cupy_kernels.complex_weighted_sum(phases, weights)
+    duration_ms = (time.perf_counter() - start) * 1000
+    assert duration_ms < 100

--- a/tests/test_edge_kernel.py
+++ b/tests/test_edge_kernel.py
@@ -1,0 +1,12 @@
+import numpy as np
+from Causal_Web.engine.backend.cupy_kernels import complex_weighted_sum
+
+
+def test_complex_weighted_sum_matches_scalar():
+    n = 100_000
+    rng = np.random.default_rng(0)
+    phases = np.exp(1j * rng.random(n))
+    weights = rng.random(n)
+    expected = phases * weights
+    result = complex_weighted_sum(phases, weights)
+    np.testing.assert_allclose(result, expected, rtol=0.0, atol=1e-12)


### PR DESCRIPTION
## Summary
- batch outgoing edge phases and attenuations and offload multiply to `cupy` when available
- add micro-benchmark and correctness tests for complex edge kernel
- document GPU batching and performance test in README

## Testing
- `python -m compileall Causal_Web`
- `python -m Causal_Web.main --max_ticks 0 --no-gui`
- `python bundle_run.py`
- `pytest`
- `pytest tests/perf_edge_kernel.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6893fcd086fc8325b560e7452e33bd82