### PR TITLE
Respect backend setting in CuPy availability check

### DIFF
--- a/Causal_Web/engine/backend/cupy_kernels.py
+++ b/Causal_Web/engine/backend/cupy_kernels.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Iterable
 
 import numpy as np
+from ...config import Config
 
 try:  # pragma: no cover - optional dependency
     import cupy as cp
@@ -53,6 +54,6 @@ def complex_weighted_sum(phases: np.ndarray, weights: np.ndarray) -> np.ndarray:
 
 
 def is_available() -> bool:
-    """Return ``True`` if a CUDA backend is ready."""
+    """Return ``True`` when CuPy is selected and available."""
 
-    return cp is not None
+    return cp is not None and Config.backend == "cupy"


### PR DESCRIPTION
## Summary
- Ensure `cupy_kernels.is_available()` only reports availability when `Config.backend` is set to `"cupy"`
- Confirm edge propagation uses a single `ThreadPoolExecutor.map` call

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `python -m Causal_Web.main` *(fails: No module named 'PySide6')*
- `python bundle_run.py` *(fails: [Errno 2] No such file or directory: '/workspace/Causal_Web/Causal_Web/output/interpretation_log.json')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68942f4cc9208325a65da7d9e128dce6