### PR TITLE
Document Ray init flag and add performance benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ to synchronise state between layers.
 ## GPU and Distributed Acceleration
 The engine optionally accelerates per-edge calculations on the GPU when [Cupy](https://cupy.dev) is installed and can shard classical zones across a [Ray](https://www.ray.io) cluster. Classical nodes are partitioned into coherent zones and dispatched in parallel to Ray workers; if Ray is unavailable an info-level message is logged and processing continues locally. Select the backend with `Config.backend` or `--backend` (`cpu` by default, `cupy` for CUDA).
 
+Ray cluster initialisation can be customised via the `--ray-init` flag. Pass a JSON string of keyword arguments forwarded to `ray.init`, for example:
+
+```bash
+python -m Causal_Web.main --ray-init '{"num_cpus":4}'
+```
+
+This enables tailoring the local or remote Ray cluster before sharding zones.
+
 Edge propagation now batches phase factors and attenuations before offloading the
 complex multiply to CuPy, falling back to vectorised NumPy when CUDA is
 unavailable. A micro-benchmark under `tests/perf_edge_kernel.py` asserts the

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -16,3 +16,13 @@ This project follows the Single Responsibility Principle and decomposes complex 
 Logging helpers such as `LoggingMixin`, `OutputDirMixin` and `PathLoggingMixin` provide common functionality across the engine. Services reside under `Causal_Web/engine/services/` or within the GUI package.
 
 For coding conventions and testing instructions see [AGENTS.md](../AGENTS.md). Run `pytest` to execute the unit tests and format Python files with `black` before submitting changes.
+
+## Ray Cluster
+
+Distributed execution uses a lightweight wrapper around [Ray](https://www.ray.io). A cluster can be configured programmatically via `ray_cluster.init_cluster()` or from the CLI using `--ray-init`:
+
+```bash
+python -m Causal_Web.main --ray-init '{"num_cpus":4}'
+```
+
+The JSON payload is forwarded directly to `ray.init` allowing resource limits or addresses to be specified.

--- a/tests/perf_ray_zones.py
+++ b/tests/perf_ray_zones.py
@@ -1,0 +1,42 @@
+import time
+import networkx as nx
+import pytest
+
+from Causal_Web.engine.backend import ray_cluster
+from Causal_Web.engine.backend.zone_partitioner import partition_zones
+
+
+@pytest.mark.skipif(ray_cluster.ray is None, reason="ray not available")
+def test_ray_zone_parallel_performance():
+    """Benchmark Ray sharding against sequential CPU processing for 20 zones."""
+    ray_cluster.init_cluster(num_cpus=2, ignore_reinit_error=True)
+    g = nx.Graph()
+    # Build alternating classical/quantum chain producing 20 isolated classical zones
+    for i in range(40):
+        g.add_node(f"N{i}", is_classical=(i % 2 == 0))
+        if i > 0:
+            g.add_edge(f"N{i-1}", f"N{i}")
+
+    zones = partition_zones(g)
+    assert len(zones) == 20
+
+    def work(_):
+        total = 0
+        for i in range(1000):
+            total += i * i
+        return total
+
+    # Warm up
+    [work(z) for z in zones]
+    ray_cluster.map_zones(lambda z: z, [])
+
+    start = time.perf_counter()
+    [work(z) for z in zones]
+    cpu_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    ray_cluster.map_zones(work, zones)
+    ray_time = time.perf_counter() - start
+
+    # Allow generous margin to account for Ray overhead
+    assert ray_time < cpu_time * 4


### PR DESCRIPTION
## Summary
- document `--ray-init` CLI flag in README and developer guide
- add benchmark test comparing Ray sharding to sequential CPU processing

## Testing
- `black Causal_Web tests/perf_ray_zones.py`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689430bd65cc8325bf136a3f8fe034aa