### PR TITLE
feat: add diagnostics sweep utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,30 @@ Per-tick law-wave frequencies are still written under the `law_wave_log` label i
 The interpreter provides `records_for_tick()` and `assemble_timeline()` helpers to query these consolidated logs.
 The ingestion service also consumes these unified files, routing records to database tables based on their `label` or `event_type`.
 
+## Diagnostics Sweep
+Parameter sweeps can be scripted in YAML and executed via `tools/sweep.py`. Each
+experiment logs metrics to a CSV file and produces a Matplotlib heat-map.
+
+Example configuration:
+
+```yaml
+bell:
+  epsilon: [true, false]
+interference:
+  fan_in: [0, 3]
+twin:
+  velocity: [0.2, 0.4, 0.6]
+```
+
+Run the sweep with:
+
+```bash
+python tools/sweep.py sweep.yml
+```
+
+The resulting `*_sweep.csv` and `*_heatmap.png` files summarise Bell scores,
+interference visibility and proper-time ratios.
+
 ### Phase smoothing
 
 The `smooth_phase` option applies exponential decay to each node's internal oscillator phase. Enable it from the GUI control panel or set `"smooth_phase": true` in `input/config.json`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-numpy
+matplotlib
 networkx
-pytest
+numpy
+pandas
 pydantic
+pytest
+pyyaml

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+"""Diagnostic metrics for common simulations."""
+
+from dataclasses import dataclass
+import math
+import random
+import uuid
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from Causal_Web.engine.models.graph import CausalGraph
+from Causal_Web.engine.services.entanglement_service import EntanglementService
+from Causal_Web.engine.logging.logger import log_json, logger
+from Causal_Web.analysis.bell import compute_bell_statistics
+from Causal_Web.config import Config
+from Causal_Web.engine.services.node_services import EdgePropagationService
+from Causal_Web.engine.models.tick import GLOBAL_TICK_POOL
+from Causal_Web.engine.tick_engine.tick_router import TickRouter
+
+
+@dataclass
+class TwinResult:
+    """Results of a twin-paradox simulation."""
+
+    tau_home: float
+    tau_traveller: float
+    ratio: float
+    analytic: float
+
+
+def bell_score(epsilon: bool, runs: int = 200, seed: int | None = None) -> float:
+    """Estimate the CHSH ``S`` value using ``\u03b5`` edges.
+
+    Parameters
+    ----------
+    epsilon:
+        When ``True`` the two nodes are linked by ``\u03b5`` edges enabling
+        super-classical correlations.
+    runs:
+        Number of measurement pairs to generate.
+    seed:
+        Optional seed for the random number generator.
+
+    Returns
+    -------
+    float
+        The calculated CHSH ``S`` value.
+    """
+
+    rng = random.Random(seed)
+    with tempfile.TemporaryDirectory() as tmp:
+        original_dir = Config.output_dir
+        try:
+            Config.output_dir = tmp
+            g = CausalGraph()
+            g.add_node("A")
+            g.add_node("B")
+            g.add_edge("A", "B", epsilon=epsilon, partner_id="pair")
+            g.add_edge("B", "A", epsilon=epsilon, partner_id="pair")
+            ent_id = "E"
+            settings_a = [0.0, math.pi / 2]
+            settings_b = [math.pi / 4, 3 * math.pi / 4]
+
+            def emit(tick: int, a_setting: float, b_setting: float) -> None:
+                node_a = g.get_node("A")
+                outcome_a = rng.choice([1, -1])
+                node_a.psi = (
+                    np.array([1, 0], np.complex128)
+                    if outcome_a == 1
+                    else np.array([0, 1], np.complex128)
+                )
+                EntanglementService.collapse_epsilon(g, node_a, tick)
+                p_same = 0.5 * (1 + math.cos(a_setting - b_setting))
+                outcome_b = outcome_a if rng.random() < p_same else -outcome_a
+                log_json(
+                    "entangled",
+                    "measurement",
+                    {
+                        "tick_id": str(uuid.uuid4()),
+                        "observer_id": "A",
+                        "entangled_id": ent_id,
+                        "measurement_setting": a_setting,
+                        "binary_outcome": outcome_a,
+                    },
+                    tick=tick,
+                )
+                log_json(
+                    "entangled",
+                    "measurement",
+                    {
+                        "tick_id": str(uuid.uuid4()),
+                        "observer_id": "B",
+                        "entangled_id": ent_id,
+                        "measurement_setting": b_setting,
+                        "binary_outcome": outcome_b,
+                    },
+                    tick=tick,
+                )
+
+            emit(0, 0.0, math.pi / 4)
+            emit(1, math.pi / 2, 3 * math.pi / 4)
+            for i in range(2, runs + 2):
+                emit(i, rng.choice(settings_a), rng.choice(settings_b))
+            logger.flush()
+            s_val, _ = compute_bell_statistics(Path(tmp) / "entangled_log.jsonl")
+            return s_val
+        finally:
+            Config.output_dir = original_dir
+
+
+def interference_visibility(
+    fan_in: int, runs: int = 200, seed: int | None = None
+) -> float:
+    """Return interference visibility for a double-slit style graph.
+
+    Parameters
+    ----------
+    fan_in:
+        Threshold for decoherence. ``0`` keeps coherent phases.
+    runs:
+        Number of simulation runs to average.
+    seed:
+        Optional random seed.
+
+    Returns
+    -------
+    float
+        Visibility defined as ``(I_max - I_min) / (I_max + I_min)``.
+    """
+
+    Config.N_DECOH = fan_in
+    rng = random.Random(seed)
+    np.random.seed(seed or 0)
+
+    def _build_graph() -> CausalGraph:
+        g = CausalGraph()
+        for nid in ["S", "A", "B", "D1", "D2"]:
+            g.add_node(nid)
+        g.add_edge("S", "A", attenuation=0.5)
+        g.add_edge("S", "B", attenuation=0.5)
+        g.add_edge("A", "D1")
+        g.add_edge("A", "D2")
+        g.add_edge("B", "D1")
+        g.add_edge("B", "D2", phase_shift=np.pi)
+        return g
+
+    g = _build_graph()
+    counts = np.zeros(2)
+    for _ in range(runs):
+        for node_id, node in g.nodes.items():
+            node.psi = (
+                np.array([1 + 0j, 0 + 0j])
+                if node_id == "S"
+                else np.zeros(2, dtype=np.complex128)
+            )
+            node.incoming_tick_counts.clear()
+        tick = GLOBAL_TICK_POOL.acquire()
+        tick.origin = "self"
+        tick.time = 0
+        tick.phase = 0
+        tick.amplitude = 1
+        EdgePropagationService(g.get_node("S"), 0, 0, "self", g, tick).propagate()
+        GLOBAL_TICK_POOL.release(tick)
+        if fan_in:
+            for sid in ["A", "B"]:
+                node = g.get_node(sid)
+                node.incoming_tick_counts[0] = fan_in
+                TickRouter.record_fanin(node, 0)
+        for sid in ["A", "B"]:
+            phase = rng.uniform(0, 2 * np.pi) if fan_in else 0.0
+            tick2 = GLOBAL_TICK_POOL.acquire()
+            tick2.origin = sid
+            tick2.time = 0
+            tick2.phase = phase
+            tick2.amplitude = 1
+            EdgePropagationService(g.get_node(sid), 0, phase, sid, g, tick2).propagate()
+            GLOBAL_TICK_POOL.release(tick2)
+        counts[0] += abs(g.get_node("D1").psi[0]) ** 2
+        counts[1] += abs(g.get_node("D2").psi[0]) ** 2
+        for nid in ["A", "B", "D1", "D2"]:
+            g.get_node(nid).psi[:] = 0
+    probs = counts / runs
+    i_max, i_min = probs.max(), probs.min()
+    return float((i_max - i_min) / (i_max + i_min) if (i_max + i_min) else 0.0)
+
+
+def tau_ratio(velocity: float, total_time: float = 10.0, dt: float = 1.0) -> TwinResult:
+    """Compute proper time ratio for travelling and stationary twins.
+
+    Parameters
+    ----------
+    velocity:
+        Constant speed of the travelling twin.
+    total_time:
+        Total coordinate time of the round trip.
+    dt:
+        Scheduler time step.
+
+    Returns
+    -------
+    TwinResult
+        Proper times for each twin along with the measured and analytic ratios.
+    """
+
+    from Causal_Web.analysis.twin import run_demo
+
+    tau_home, tau_traveller = run_demo(total_time=total_time, dt=dt, velocity=velocity)
+    ratio = tau_traveller / tau_home if tau_home else 0.0
+    analytic = math.sqrt(1 - velocity**2)
+    return TwinResult(tau_home, tau_traveller, ratio, analytic)

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Parameter sweep utilities producing CSV summaries and heat-maps."""
+
+import argparse
+import itertools
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import yaml
+
+from . import metrics
+
+
+def _run_experiment(name: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Dispatch to the metric associated with ``name``."""
+
+    if name == "bell":
+        return {"bell": metrics.bell_score(**params)}
+    if name == "interference":
+        return {"visibility": metrics.interference_visibility(**params)}
+    if name == "twin":
+        res = metrics.tau_ratio(**params)
+        return {"tau_ratio": res.ratio, "tau_expected": res.analytic}
+    raise ValueError(f"unknown experiment {name}")
+
+
+def _iter_grid(grid: Dict[str, Iterable[Any]]):
+    keys = list(grid)
+    for values in itertools.product(*(grid[k] for k in keys)):
+        yield dict(zip(keys, values))
+
+
+def _save_heatmap(df: pd.DataFrame, metric: str, out: Path) -> None:
+    """Persist a heat-map for one or two parameter columns."""
+
+    params = [c for c in df.columns if c not in {metric}]
+    if len(params) == 1:
+        p = params[0]
+        plt.figure()
+        plt.plot(df[p], df[metric], marker="o")
+        plt.xlabel(p)
+        plt.ylabel(metric)
+        plt.savefig(out)
+        plt.close()
+        return
+    if len(params) >= 2:
+        x, y = params[:2]
+        pivot = df.pivot(index=y, columns=x, values=metric)
+        plt.figure()
+        plt.imshow(pivot.values, origin="lower", aspect="auto")
+        plt.xticks(range(len(pivot.columns)), pivot.columns)
+        plt.yticks(range(len(pivot.index)), pivot.index)
+        plt.xlabel(x)
+        plt.ylabel(y)
+        plt.colorbar(label=metric)
+        plt.savefig(out)
+        plt.close()
+
+
+def sweep(config: Dict[str, Any]) -> None:
+    """Execute sweeps defined in ``config``."""
+
+    for name, spec in config.items():
+        grid = {k: v for k, v in spec.items() if isinstance(v, list)}
+        fixed = {k: v for k, v in spec.items() if not isinstance(v, list)}
+        rows = []
+        for combo in _iter_grid(grid):
+            params = {**fixed, **combo}
+            metrics_res = _run_experiment(name, params)
+            rows.append({**combo, **metrics_res})
+        df = pd.DataFrame(rows)
+        csv_path = Path(f"{name}_sweep.csv")
+        df.to_csv(csv_path, index=False)
+        metric_col = next(iter(metrics_res))
+        _save_heatmap(df, metric_col, Path(f"{name}_heatmap.png"))
+
+
+def main(path: str) -> None:
+    with open(path) as fh:
+        config = yaml.safe_load(fh)
+    sweep(config)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run parameter sweeps")
+    parser.add_argument("config", type=str, help="YAML configuration file")
+    args = parser.parse_args()
+    main(args.config)


### PR DESCRIPTION
## Summary
- add `tools/metrics` module with helpers for Bell score, interference visibility and twin paradox tau ratios
- introduce YAML-driven `tools/sweep` to collect metrics across parameter grids and emit CSV/heatmap outputs
- document diagnostics sweep usage and add plotting dependencies

## Testing
- `black tools/metrics.py tools/sweep.py`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894321d1d4c83259a65f4bb05732675