### PR TITLE
Reset decoherence and warn on excessive sweep params

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,19 @@ twin:
 Run the sweep with:
 
 ```bash
+cw-sweep sweep.yml
+```
+
+or directly via the module:
+
+```bash
 python tools/sweep.py sweep.yml
 ```
 
 The resulting `*_sweep.csv` and `*_heatmap.png` files summarise Bell scores,
-interference visibility and proper-time ratios.
+interference visibility and proper-time ratios. Sweeps seed module-level random
+generators, so parallel sweeps should run in separate processes to avoid
+contention.
 
 ### Phase smoothing
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = causal-web
+version = 0.0.0
+
+[options]
+packages = find:
+
+[options.entry_points]
+console_scripts =
+    cw-sweep = Causal_Web.tools.sweep:main
+

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -130,61 +130,67 @@ def interference_visibility(
     float
         Visibility defined as ``(I_max - I_min) / (I_max + I_min)``.
     """
-
+    original_decoh = Config.N_DECOH
     Config.N_DECOH = fan_in
     rng = random.Random(seed)
     np.random.seed(seed or 0)
 
-    def _build_graph() -> CausalGraph:
-        g = CausalGraph()
-        for nid in ["S", "A", "B", "D1", "D2"]:
-            g.add_node(nid)
-        g.add_edge("S", "A", attenuation=0.5)
-        g.add_edge("S", "B", attenuation=0.5)
-        g.add_edge("A", "D1")
-        g.add_edge("A", "D2")
-        g.add_edge("B", "D1")
-        g.add_edge("B", "D2", phase_shift=np.pi)
-        return g
+    try:
 
-    g = _build_graph()
-    counts = np.zeros(2)
-    for _ in range(runs):
-        for node_id, node in g.nodes.items():
-            node.psi = (
-                np.array([1 + 0j, 0 + 0j])
-                if node_id == "S"
-                else np.zeros(2, dtype=np.complex128)
-            )
-            node.incoming_tick_counts.clear()
-        tick = GLOBAL_TICK_POOL.acquire()
-        tick.origin = "self"
-        tick.time = 0
-        tick.phase = 0
-        tick.amplitude = 1
-        EdgePropagationService(g.get_node("S"), 0, 0, "self", g, tick).propagate()
-        GLOBAL_TICK_POOL.release(tick)
-        if fan_in:
+        def _build_graph() -> CausalGraph:
+            g = CausalGraph()
+            for nid in ["S", "A", "B", "D1", "D2"]:
+                g.add_node(nid)
+            g.add_edge("S", "A", attenuation=0.5)
+            g.add_edge("S", "B", attenuation=0.5)
+            g.add_edge("A", "D1")
+            g.add_edge("A", "D2")
+            g.add_edge("B", "D1")
+            g.add_edge("B", "D2", phase_shift=np.pi)
+            return g
+
+        g = _build_graph()
+        counts = np.zeros(2)
+        for _ in range(runs):
+            for node_id, node in g.nodes.items():
+                node.psi = (
+                    np.array([1 + 0j, 0 + 0j])
+                    if node_id == "S"
+                    else np.zeros(2, dtype=np.complex128)
+                )
+                node.incoming_tick_counts.clear()
+            tick = GLOBAL_TICK_POOL.acquire()
+            tick.origin = "self"
+            tick.time = 0
+            tick.phase = 0
+            tick.amplitude = 1
+            EdgePropagationService(g.get_node("S"), 0, 0, "self", g, tick).propagate()
+            GLOBAL_TICK_POOL.release(tick)
+            if fan_in:
+                for sid in ["A", "B"]:
+                    node = g.get_node(sid)
+                    node.incoming_tick_counts[0] = fan_in
+                    TickRouter.record_fanin(node, 0)
             for sid in ["A", "B"]:
-                node = g.get_node(sid)
-                node.incoming_tick_counts[0] = fan_in
-                TickRouter.record_fanin(node, 0)
-        for sid in ["A", "B"]:
-            phase = rng.uniform(0, 2 * np.pi) if fan_in else 0.0
-            tick2 = GLOBAL_TICK_POOL.acquire()
-            tick2.origin = sid
-            tick2.time = 0
-            tick2.phase = phase
-            tick2.amplitude = 1
-            EdgePropagationService(g.get_node(sid), 0, phase, sid, g, tick2).propagate()
-            GLOBAL_TICK_POOL.release(tick2)
-        counts[0] += abs(g.get_node("D1").psi[0]) ** 2
-        counts[1] += abs(g.get_node("D2").psi[0]) ** 2
-        for nid in ["A", "B", "D1", "D2"]:
-            g.get_node(nid).psi[:] = 0
-    probs = counts / runs
-    i_max, i_min = probs.max(), probs.min()
-    return float((i_max - i_min) / (i_max + i_min) if (i_max + i_min) else 0.0)
+                phase = rng.uniform(0, 2 * np.pi) if fan_in else 0.0
+                tick2 = GLOBAL_TICK_POOL.acquire()
+                tick2.origin = sid
+                tick2.time = 0
+                tick2.phase = phase
+                tick2.amplitude = 1
+                EdgePropagationService(
+                    g.get_node(sid), 0, phase, sid, g, tick2
+                ).propagate()
+                GLOBAL_TICK_POOL.release(tick2)
+            counts[0] += abs(g.get_node("D1").psi[0]) ** 2
+            counts[1] += abs(g.get_node("D2").psi[0]) ** 2
+            for nid in ["A", "B", "D1", "D2"]:
+                g.get_node(nid).psi[:] = 0
+        probs = counts / runs
+        i_max, i_min = probs.max(), probs.min()
+        return float((i_max - i_min) / (i_max + i_min) if (i_max + i_min) else 0.0)
+    finally:
+        Config.N_DECOH = original_decoh
 
 
 def tau_ratio(velocity: float, total_time: float = 10.0, dt: float = 1.0) -> TwinResult:

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import argparse
 import itertools
+import logging
 from pathlib import Path
 from typing import Any, Dict, Iterable
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import yaml
+
+plt.switch_backend("Agg")
 
 from . import metrics
 
@@ -34,9 +37,13 @@ def _iter_grid(grid: Dict[str, Iterable[Any]]):
 
 
 def _save_heatmap(df: pd.DataFrame, metric: str, out: Path) -> None:
-    """Persist a heat-map for one or two parameter columns."""
+    """Persist a heat-map for up to two parameter columns."""
 
     params = [c for c in df.columns if c not in {metric}]
+    if len(params) > 2:
+        logging.warning(
+            "Heat-map supports only two parameters; ignoring %s", params[2:]
+        )
     if len(params) == 1:
         p = params[0]
         plt.figure()
@@ -45,8 +52,7 @@ def _save_heatmap(df: pd.DataFrame, metric: str, out: Path) -> None:
         plt.ylabel(metric)
         plt.savefig(out)
         plt.close()
-        return
-    if len(params) >= 2:
+    elif len(params) >= 2:
         x, y = params[:2]
         pivot = df.pivot(index=y, columns=x, values=metric)
         plt.figure()


### PR DESCRIPTION
## Summary
- ensure `interference_visibility` restores `Config.N_DECOH` after runs
- add headless-safe matplotlib backend and warn when sweep heatmaps ignore extra params
- provide `cw-sweep` console entry point and document usage and random seeding caveat

## Testing
- `python -m compileall Causal_Web tools`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689434c362fc8325bf408a146081c64c