### PR TITLE
docs: refresh usage and format guides

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -2,6 +2,7 @@
 
 This project follows the Single Responsibility Principle and decomposes complex tasks into small service classes. Key services include:
 
+- **NodeInitializationService** – sets up node instances with runtime state and metadata.
 - **NodeTickService** – manages the tick emission lifecycle.
 - **GraphLoadService** – loads graphs from JSON files.
 - **NodeMetricsService** – collects metrics per tick.
@@ -12,6 +13,7 @@ This project follows the Single Responsibility Principle and decomposes complex 
 - **ConnectionDisplayService** – visualises existing links in the GUI.
 - **GlobalDiagnosticsService** – exports run metrics.
 - **SIPRecombinationService** – manages recombination-based spawning.
+- **EntanglementService** – collapses ε-linked partners and manages entangled pairs.
 
 Logging helpers such as `LoggingMixin`, `OutputDirMixin` and `PathLoggingMixin` provide common functionality across the engine. Services reside under `Causal_Web/engine/services/` or within the GUI package.
 

--- a/docs/graph_format.md
+++ b/docs/graph_format.md
@@ -1,7 +1,7 @@
 # Graph Format
 
-Graphs are described using JSON files with top level keys for nodes, edges, optional bridges, tick_sources, observers and meta_nodes. Each node defines its position and simulation parameters. Edges specify delays and attenuation. Tick sources seed periodic activity while observers record metrics. Meta nodes group related nodes under additional constraints such as phase locking.
-Nodes can optionally set ``allow_self_connection`` to ``true`` to permit self-connected edges.
+Graphs are described using JSON files with top level keys for nodes, edges, optional bridges, tick_sources, observers and meta_nodes. Each node defines its position and simulation parameters. Edges specify delays, attenuation and optional unitary or gauge terms. Tick sources seed periodic activity while observers record metrics. Meta nodes group related nodes under additional constraints such as phase locking.
+Nodes can optionally set ``allow_self_connection`` to ``true`` to permit self-connected edges and ``cnot_source`` to spawn dynamic ε-pairs when they fire.
 
 ## Example
 ```json
@@ -18,7 +18,8 @@ Nodes can optionally set ``allow_self_connection`` to ``true`` to permit self-co
       "generation_tick": 0,
       "parent_ids": [],
       "goals": {},
-      "allow_self_connection": false
+      "allow_self_connection": false,
+      "cnot_source": false
     },
     "B": {
       "x": 100,
@@ -39,7 +40,9 @@ Nodes can optionally set ``allow_self_connection`` to ``true`` to permit self-co
       "attenuation": 1.0,
       "density": 0.0,
       "delay": 1,
-      "phase_shift": 0.0
+      "phase_shift": 0.0,
+      "A_phase": 0.0,
+      "u_id": 0
     }
   ],
   "bridges": [],
@@ -68,6 +71,15 @@ Nodes can optionally set ``allow_self_connection`` to ``true`` to permit self-co
     }
   }
 }
+```
+
+To define an ε-pair directly, mark both directions with matching ``epsilon`` and ``partner_id`` values:
+
+```json
+"edges": [
+  {"from": "A", "to": "B", "epsilon": true, "partner_id": "pair1"},
+  {"from": "B", "to": "A", "epsilon": true, "partner_id": "pair1"}
+]
 ```
 
 Observers may include optional `x` and `y` fields storing their position on the canvas. Set `detector_mode` to `true` to perform binary measurements on ticks that arrive via entangled bridges. Measurement angles can be overridden with `measurement_settings`, a list of float values. Emergent meta nodes discovered at runtime are logged for analysis but do not affect behaviour unless declared in the file.

--- a/docs/gui_usage.md
+++ b/docs/gui_usage.md
@@ -13,6 +13,8 @@ New nodes include a *Self Connect* checkbox. When enabled, dragging from a node 
 
 The **Control Panel** window lets you start, pause or stop the simulation and set the tick limit and rate. A tick counter shows the current tick. Window resizing keeps the graph responsive and rendering updates only when the graph changes to reduce idle CPU usage.
 
+Bridge and observer panels expose additional quantum controls. Bridges can enable entanglement, assigning an ``entangled_id`` that observers use to produce deterministic measurements. Observers offer a *Detector Mode* toggle for logging binary outcomes from such bridges. The **Analysis** menu provides a *Bell Inequality Analysis...* action which displays CHSH statistics and expectation histograms for active entangled pairs.
+
 Saved graphs are copied into each run directory when the simulation starts so the exact input is preserved. The GUI also exposes a **Log Files** window to enable or disable specific logs.
 
 Changes made in the Graph View are applied back to the main window using the **Apply Changes** button. This action also writes the current graph to disk when a file is loaded.


### PR DESCRIPTION
## Summary
- document NodeInitializationService and EntanglementService in developer guide
- expand graph format doc with cnot_source, gauge A_phase and epsilon pair examples
- describe entanglement controls and Bell analysis UI in GUI usage guide

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894388b391c8325a084c7cb6a654701