### PR TITLE
Add experimental engine v2 adapter

### DIFF
--- a/Causal_Web/engine/engine_v2/__init__.py
+++ b/Causal_Web/engine/engine_v2/__init__.py
@@ -1,0 +1,6 @@
+"""Experimental v2 engine package.
+
+This package hosts a strict-local engine prototype. Modules expose simple
+placeholders so the GUI can drive the engine before the physics core is
+implemented.
+"""

--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -1,0 +1,86 @@
+"""Compatibility layer for the v2 engine prototype.
+
+The :class:`EngineAdapter` exposes a subset of the old tick engine API so
+that existing entry points can drive the new core without modification.
+All methods currently produce synthetic results; the real physics model
+will fill in these hooks later.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .scheduler import Scheduler
+from .state import TelemetryFrame
+
+
+class EngineAdapter:
+    """Bridge between the legacy orchestrator calls and engine v2."""
+
+    def __init__(self) -> None:
+        self._scheduler = Scheduler()
+        self._running = False
+        self._depth = 0
+        self._graph: Optional[Dict[str, Any]] = None
+
+    # Public API -----------------------------------------------------
+    def build_graph(self, graph_json_path: str | Dict[str, Any]) -> None:
+        """Load a graph description.
+
+        Parameters
+        ----------
+        graph_json_path:
+            Path to a JSON graph file or an in-memory dictionary.
+        """
+
+        if isinstance(graph_json_path, dict):
+            self._graph = graph_json_path
+        else:  # pragma: no cover - simple file IO
+            import json
+
+            with open(graph_json_path, "r", encoding="utf-8") as fh:
+                self._graph = json.load(fh)
+
+    def start(self) -> None:
+        """Mark the engine as running."""
+
+        self._running = True
+
+    def pause(self) -> None:
+        """Pause execution."""
+
+        self._running = False
+
+    def stop(self) -> None:
+        """Stop execution and reset all state."""
+
+        self._running = False
+        self._depth = 0
+        self._scheduler.clear()
+
+    def step(self, max_events: int | None = None) -> TelemetryFrame:
+        """Advance the simulation by one synthetic step."""
+
+        if not self._running:
+            self.start()
+
+        event_count = max_events or 0
+        frame = TelemetryFrame(depth=self._depth, events=event_count)
+        self._depth += 1
+        self._scheduler.clear()
+        return frame
+
+    def run_until_next_window_or(self, limit: int | None) -> TelemetryFrame:
+        """Run until the next window boundary or until ``limit`` events."""
+
+        return self.step(max_events=limit)
+
+    def snapshot_for_ui(self) -> dict:
+        """Return a minimal snapshot for the GUI."""
+
+        return {"depth": self._depth}
+
+    def current_depth(self) -> int:
+        """Return the current depth of the simulation."""
+
+        return self._depth

--- a/Causal_Web/engine/engine_v2/bell.py
+++ b/Causal_Web/engine/engine_v2/bell.py
@@ -1,0 +1,40 @@
+"""Bell experiment helpers for the v2 engine.
+
+This module contains placeholders for ancestry tracking and contextual
+readouts used in Bell-type experiments. The implementations are
+non-functional and serve only to define the expected interface.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+
+@dataclass
+class Ancestry:
+    """Track simple ancestry information for a packet."""
+
+    parent_id: int | None = None
+
+
+class BellHelpers:
+    """Utility methods for Bell experiment simulations."""
+
+    def __init__(self, seed: int | None = None) -> None:
+        self._rand = random.Random(seed)
+
+    def lambda_at_source(self) -> float:
+        """Return a random ``lambda`` value."""
+
+        return self._rand.random()
+
+    def setting_draw(self) -> int:
+        """Draw a binary measurement setting."""
+
+        return self._rand.randint(0, 1)
+
+    def contextual_readout(self, setting: int, lam: float) -> int:
+        """Produce a contextual readout given ``setting`` and ``lambda``."""
+
+        return 1 if lam > 0.5 else -1

--- a/Causal_Web/engine/engine_v2/epairs.py
+++ b/Causal_Web/engine/engine_v2/epairs.py
@@ -1,0 +1,43 @@
+"""Epsilon-pair management for the v2 engine.
+
+The routines below track time-to-live (TTL) seeds and provide a simple
+reinforcement/decay mechanism for bridge ``sigma`` values. They are
+non-physical placeholders that allow higher layers to exercise the API
+without requiring a completed physics model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class TTLSeeds:
+    """Track TTL values for epsilon pair seeds."""
+
+    seeds: Dict[int, int] = field(default_factory=dict)
+
+    def seed(self, pair_id: int, ttl: int) -> None:
+        self.seeds[pair_id] = ttl
+
+    def tick(self) -> None:
+        expired = [k for k, v in self.seeds.items() if v <= 1]
+        for k in expired:
+            del self.seeds[k]
+        for k in self.seeds:
+            self.seeds[k] -= 1
+
+
+@dataclass
+class BridgeSigma:
+    """Reinforce or decay a bridge's sigma value."""
+
+    sigma: float = 0.0
+    decay: float = 0.1
+
+    def reinforce(self, amount: float) -> None:
+        self.sigma += amount
+
+    def tick(self) -> None:
+        self.sigma *= 1.0 - self.decay

--- a/Causal_Web/engine/engine_v2/lccm.py
+++ b/Causal_Web/engine/engine_v2/lccm.py
@@ -1,0 +1,35 @@
+"""Local causal consistency model helpers.
+
+This module exposes placeholder functions for Q accumulation and
+window management used by the experimental engine. The routines are
+simple stubs that will be replaced with full implementations as the
+physics model evolves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class LCCM:
+    """Accumulate and mix local causal consistency metrics."""
+
+    q: float = 0.0
+
+    def accumulate(self, value: float) -> None:
+        """Accumulate ``value`` into ``q``."""
+
+        self.q += value
+
+    def close(self) -> float:
+        """Return the accumulated ``q`` and reset it."""
+
+        result = self.q
+        self.q = 0.0
+        return result
+
+    def majority(self, a: float, b: float, c: float) -> float:
+        """Simple majority helper used in windowing math."""
+
+        return (a + b + c) / 3.0

--- a/Causal_Web/engine/engine_v2/rho_delay.py
+++ b/Causal_Web/engine/engine_v2/rho_delay.py
@@ -1,0 +1,33 @@
+"""Density-dependent delay helpers.
+
+Functions here provide a toy diffusion model and a saturating mapping
+from density to an effective delay. They are intentionally simple and
+serve as placeholders until the full model is implemented.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+
+def diffuse(rho: List[float], weight: float) -> List[float]:
+    """Diffuse density values across neighbours.
+
+    Parameters
+    ----------
+    rho:
+        List of density values.
+    weight:
+        Diffusion weight in ``[0, 1]``.
+    """
+
+    if not rho:
+        return []
+    avg = sum(rho) / len(rho)
+    return [r + weight * (avg - r) for r in rho]
+
+
+def effective_delay(rho: float, cap: float = 1.0) -> float:
+    """Map density to an effective delay using a simple saturation."""
+
+    return min(rho, cap)

--- a/Causal_Web/engine/engine_v2/scheduler.py
+++ b/Causal_Web/engine/engine_v2/scheduler.py
@@ -1,0 +1,47 @@
+"""Event scheduler for the v2 engine prototype.
+
+Events are ordered by a four-tuple key ``(depth_arr, dst_id, edge_id, seq)``
+which allows deterministic processing of packets arriving at the same
+depth. This module only provides a minimal priority queue wrapper
+sufficient for early experimentation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import heapq
+from typing import Any, List, Tuple
+
+
+@dataclass(order=True)
+class _ScheduledItem:
+    key: Tuple[int, int, int, int]
+    payload: Any
+
+
+class Scheduler:
+    """Arrival-depth priority queue."""
+
+    def __init__(self) -> None:
+        self._queue: List[_ScheduledItem] = []
+        self._seq = 0
+
+    def push(self, depth_arr: int, dst_id: int, edge_id: int, payload: Any) -> None:
+        """Insert a payload into the queue."""
+
+        key = (depth_arr, dst_id, edge_id, self._seq)
+        heapq.heappush(self._queue, _ScheduledItem(key, payload))
+        self._seq += 1
+
+    def pop(self) -> Any:
+        """Remove and return the next payload."""
+
+        return heapq.heappop(self._queue).payload
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._queue)
+
+    def clear(self) -> None:
+        """Drop all scheduled items."""
+
+        self._queue.clear()

--- a/Causal_Web/engine/engine_v2/state.py
+++ b/Causal_Web/engine/engine_v2/state.py
@@ -1,0 +1,44 @@
+"""Lightweight data structures for the experimental engine.
+
+The module defines Struct-of-Arrays containers used by the
+prototype scheduler along with simple packet and telemetry frame
+representations. The structures are intentionally minimal and
+will expand as the engine matures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List
+
+
+@dataclass
+class VertexArray:
+    """Struct-of-arrays representation of vertex data."""
+
+    ids: List[int] = field(default_factory=list)
+
+
+@dataclass
+class EdgeArray:
+    """Struct-of-arrays representation of edge data."""
+
+    ids: List[int] = field(default_factory=list)
+
+
+@dataclass
+class Packet:
+    """A scheduled message between two vertices."""
+
+    src: int
+    dst: int
+    payload: Any = None
+
+
+@dataclass
+class TelemetryFrame:
+    """Snapshot returned to the GUI after each step."""
+
+    depth: int
+    events: int
+    packets: List[Packet] = field(default_factory=list)

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -36,7 +36,12 @@ from ..gui.state import (
 from .canvas_widget import CanvasWidget
 from .toolbar_builder import build_toolbar
 from ..gui.command_stack import AddNodeCommand, AddObserverCommand
-from ..engine import tick_engine
+from ..config import Config
+
+if getattr(Config, "engine_mode", "tick") == "v2":
+    from ..engine.engine_v2 import adapter as tick_engine
+else:
+    from ..engine import tick_engine
 from .shared import TooltipCheckBox, TOOLTIPS
 
 

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -258,7 +258,12 @@ class MainService:
     # ------------------------------------------------------------------
     def _run_headless(self) -> None:
         """Run the simulation without launching the GUI."""
-        from .engine import tick_engine
+        from .config import Config
+
+        if getattr(Config, "engine_mode", "tick") == "v2":
+            from .engine.engine_v2 import adapter as tick_engine
+        else:
+            from .engine import tick_engine
 
         tick_engine.build_graph()
         with Config.state_lock:

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ The `engine_mode` flag selects the simulation core. The default `tick` value
 uses the existing engine while `v2` enables an experimental strict-local core.
 Parameter groups `windowing`, `rho_delay`, `epsilon_pairs`, and `bell` provide
 advanced controls for the v2 engine and currently have placeholder defaults.
+An adapter in ``engine_v2`` mirrors the legacy tick engine API and yields
+synthetic telemetry frames so the GUI can tick while the new physics is under
+development.
 
 The `density_calc` option controls how edge density is computed. Set one of:
 


### PR DESCRIPTION
## Summary
- scaffold `engine_v2` package with placeholder state, scheduler and physics modules
- implement `EngineAdapter` that emits synthetic telemetry frames and mirrors the old tick engine API
- conditionally import adapter when `Config.engine_mode` is set to `v2`
- document the experimental engine in the README

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c3cf01608325b00616f75268fd19