### PR TITLE
Implement depth-aware scheduler with LCCM windowing

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -1,45 +1,75 @@
 """Compatibility layer for the v2 engine prototype.
 
-The :class:`EngineAdapter` exposes a subset of the old tick engine API so
-that existing entry points can drive the new core without modification.
-All methods currently produce synthetic results; the real physics model
-will fill in these hooks later.
+The :class:`EngineAdapter` exposes a subset of the legacy tick engine API but
+drives a new depth-based scheduler and the lightweight :mod:`lccm` model.  The
+adapter processes packets ordered by arrival depth and advances vertex windows
+according to the local causal consistency math.
 """
 
 from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-from .scheduler import Scheduler
-from .state import TelemetryFrame
+from .lccm import LCCM
+from .scheduler import DepthScheduler
+from .state import Packet, TelemetryFrame
 
 
 class EngineAdapter:
     """Bridge between the legacy orchestrator calls and engine v2."""
 
     def __init__(self) -> None:
-        self._scheduler = Scheduler()
+        self._scheduler = DepthScheduler()
         self._running = False
-        self._depth = 0
-        self._graph: Optional[Dict[str, Any]] = None
+        self._vertices: Dict[int, Dict[str, Any]] = {}
 
     # Public API -----------------------------------------------------
     def build_graph(self, graph_json_path: str | Dict[str, Any]) -> None:
-        """Load a graph description.
-
-        Parameters
-        ----------
-        graph_json_path:
-            Path to a JSON graph file or an in-memory dictionary.
-        """
+        """Load a graph description."""
 
         if isinstance(graph_json_path, dict):
-            self._graph = graph_json_path
+            graph = graph_json_path
         else:  # pragma: no cover - simple file IO
             import json
 
             with open(graph_json_path, "r", encoding="utf-8") as fh:
-                self._graph = json.load(fh)
+                graph = json.load(fh)
+
+        params = graph.get("params", {})
+        W0 = params.get("W0", 4)
+        zeta1 = params.get("zeta1", 0.0)
+        zeta2 = params.get("zeta2", 0.0)
+        rho0 = params.get("rho0", 1.0)
+        a = params.get("a", 1.0)
+        b = params.get("b", 0.5)
+        C_min = params.get("C_min", 0.0)
+        f_min = params.get("f_min", 1.0)
+        H_max = params.get("H_max", 0.0)
+        T_hold = params.get("T_hold", 1)
+        T_class = params.get("T_class", 1)
+
+        self._vertices.clear()
+        for v in graph.get("vertices", []):
+            vid = int(v["id"])
+            edges = v.get("edges", [])
+            deg = len(edges)
+            rho_mean = v.get("rho_mean", 0.0)
+            lccm = LCCM(
+                W0,
+                zeta1,
+                zeta2,
+                rho0,
+                a,
+                b,
+                C_min,
+                f_min,
+                H_max,
+                T_hold,
+                T_class,
+                deg=deg,
+                rho_mean=rho_mean,
+            )
+            self._vertices[vid] = {"edges": edges, "lccm": lccm}
 
     def start(self) -> None:
         """Mark the engine as running."""
@@ -55,32 +85,71 @@ class EngineAdapter:
         """Stop execution and reset all state."""
 
         self._running = False
-        self._depth = 0
+        self._vertices.clear()
         self._scheduler.clear()
 
     def step(self, max_events: int | None = None) -> TelemetryFrame:
-        """Advance the simulation by one synthetic step."""
+        """Advance the simulation until a window rolls or ``max_events``."""
 
-        if not self._running:
-            self.start()
-
-        event_count = max_events or 0
-        frame = TelemetryFrame(depth=self._depth, events=event_count)
-        self._depth += 1
-        self._scheduler.clear()
-        return frame
+        return self.run_until_next_window_or(max_events)
 
     def run_until_next_window_or(self, limit: int | None) -> TelemetryFrame:
         """Run until the next window boundary or until ``limit`` events."""
 
-        return self.step(max_events=limit)
+        if not self._running:
+            self.start()
+
+        if limit is None:
+            limit = float("inf")
+
+        start_windows = {
+            vid: data["lccm"].window_idx for vid, data in self._vertices.items()
+        }
+        events = 0
+        packets = []
+
+        while self._scheduler and events < limit:
+            depth_arr, dst, edge_id, pkt = self._scheduler.pop()
+            vertex = self._vertices.get(dst)
+            if vertex is None:
+                continue
+            lccm = vertex["lccm"]
+            lccm.advance_depth(depth_arr)
+            lccm.deliver()
+            packets.append(pkt)
+            for edge in vertex.get("edges", []):
+                depth_next = depth_arr + edge.get("d_eff", 1)
+                new_pkt = Packet(src=dst, dst=edge["dst"], payload=None)
+                self._scheduler.push(depth_next, edge["dst"], edge["id"], new_pkt)
+            events += 1
+
+            if any(
+                data["lccm"].window_idx != start_windows[vid]
+                for vid, data in self._vertices.items()
+            ):
+                break
+
+        max_depth = 0
+        for data in self._vertices.values():
+            max_depth = max(max_depth, data["lccm"].depth)
+
+        return TelemetryFrame(depth=max_depth, events=events, packets=packets)
 
     def snapshot_for_ui(self) -> dict:
         """Return a minimal snapshot for the GUI."""
 
-        return {"depth": self._depth}
+        max_depth = 0
+        for data in self._vertices.values():
+            max_depth = max(max_depth, data["lccm"].depth)
+        return {"depth": max_depth}
 
     def current_depth(self) -> int:
         """Return the current depth of the simulation."""
 
-        return self._depth
+        max_depth = 0
+        for data in self._vertices.values():
+            max_depth = max(max_depth, data["lccm"].depth)
+        return max_depth
+
+
+__all__ = ["EngineAdapter"]

--- a/Causal_Web/engine/engine_v2/lccm.py
+++ b/Causal_Web/engine/engine_v2/lccm.py
@@ -1,35 +1,124 @@
-"""Local causal consistency model helpers.
+"""Local causal consistency helpers for engine v2.
 
-This module exposes placeholder functions for Q accumulation and
-window management used by the experimental engine. The routines are
-simple stubs that will be replaced with full implementations as the
-physics model evolves.
+This module implements the windowing mathematics and layer transition rules
+for the Local Causal Consistency Model (LCCM).  The implementation is a
+lightweight container used by the experimental engine to reason about packet
+delivery counts within rolling windows and to transition between quantum (Q),
+decohered (Θ) and classical (C) layers with simple hysteresis timers.
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 
 @dataclass
 class LCCM:
-    """Accumulate and mix local causal consistency metrics."""
+    """Track window indices and layer transitions for a vertex.
 
-    q: float = 0.0
+    Parameters defining the window function and transition thresholds are
+    provided at construction time.  ``deg`` represents the vertex out-degree
+    while ``rho_mean`` is the mean local density used in ``W(v)``.  The public
+    attributes ``depth``, ``window_idx`` and ``layer`` expose the current state
+    for callers.
+    """
 
-    def accumulate(self, value: float) -> None:
-        """Accumulate ``value`` into ``q``."""
+    W0: int
+    zeta1: float
+    zeta2: float
+    rho0: float
+    a: float
+    b: float
+    C_min: float
+    f_min: float
+    H_max: float
+    T_hold: int
+    T_class: int
+    deg: int = 0
+    rho_mean: float = 0.0
+    depth: int = 0
+    window_idx: int = 0
+    layer: str = "Q"
 
-        self.q += value
+    _lambda: int = 0
+    _eq: float = 0.0
+    _eq_hold: int = 0
+    _bit_fraction: float = 0.0
+    _entropy: float = 0.0
+    _class_timer: int = 0
 
-    def close(self) -> float:
-        """Return the accumulated ``q`` and reset it."""
+    # ------------------------------------------------------------------
+    def _window_size(self) -> int:
+        term = self.zeta1 * math.log(1 + self.deg) + self.zeta2 * math.log(
+            1 + self.rho_mean / self.rho0
+        )
+        return self.W0 + math.floor(term)
 
-        result = self.q
-        self.q = 0.0
-        return result
+    # Public API -------------------------------------------------------
+    def advance_depth(self, new_depth: int) -> None:
+        """Update ``depth`` and recompute ``window_idx``.
 
-    def majority(self, a: float, b: float, c: float) -> float:
-        """Simple majority helper used in windowing math."""
+        ``new_depth`` must be monotonically increasing.  When the window index
+        changes the fan-in counter Λ is reset.
+        """
 
-        return (a + b + c) / 3.0
+        if new_depth < self.depth:
+            raise ValueError("depth must be monotonically increasing")
+        self.depth = new_depth
+        w = self._window_size()
+        idx = new_depth // w
+        if idx != self.window_idx:
+            self.window_idx = idx
+            self._lambda = 0
+
+    def deliver(self) -> None:
+        """Record a packet delivery at the current depth."""
+
+        self._lambda += 1
+        self._check_transitions()
+
+    def update_eq(self, value: float) -> None:
+        """Update the EQ metric used for Θ→Q transitions."""
+
+        self._eq = value
+
+    def update_classical_metrics(self, bit_fraction: float, entropy: float) -> None:
+        """Update metrics used for Θ→C transitions."""
+
+        self._bit_fraction = bit_fraction
+        self._entropy = entropy
+
+    # Internal helpers -------------------------------------------------
+    def _check_transitions(self) -> None:
+        w = self._window_size()
+        if self.layer == "Q":
+            if self._lambda >= self.a * w:
+                self.layer = "Θ"
+                self._eq_hold = 0
+                self._class_timer = 0
+        elif self.layer == "Θ":
+            # Recoherence toward Q
+            if self._lambda <= self.b * w and self._eq >= self.C_min:
+                self._eq_hold += 1
+            else:
+                self._eq_hold = 0
+            if self._eq_hold >= self.T_hold:
+                self.layer = "Q"
+                self._eq_hold = 0
+                self._class_timer = 0
+                self._lambda = 0
+                return
+
+            # Classical dominance toward C
+            if self._bit_fraction >= self.f_min and self._entropy <= self.H_max:
+                self._class_timer += 1
+            else:
+                self._class_timer = 0
+            if self._class_timer >= self.T_class:
+                self.layer = "C"
+                self._class_timer = 0
+                self._eq_hold = 0
+
+
+__all__ = ["LCCM"]

--- a/README.md
+++ b/README.md
@@ -120,8 +120,12 @@ Parameter groups `windowing`, `rho_delay`, `epsilon_pairs`, and `bell` provide
 advanced controls for the v2 engine and currently have placeholder defaults.
 An adapter in ``engine_v2`` mirrors the legacy tick engine API and yields
 synthetic telemetry frames so the GUI can tick while the new physics is under
-development.
-A lightweight loader converts graph JSON into struct-of-arrays via ``engine_v2.loader.load_graph_arrays`` to prime this core.
+development.  A depth-based scheduler orders packets by their arrival depth and
+advances vertex windows using the Local Causal Consistency Model (LCCM).  The
+LCCM computes a window size ``W(v)`` from vertex degree and local density and
+transitions between quantum ``Q``, decohered ``Θ`` and classical ``C`` layers
+with simple hysteresis timers.  A lightweight loader converts graph JSON into
+struct-of-arrays via ``engine_v2.loader.load_graph_arrays`` to prime this core.
 
 The `density_calc` option controls how edge density is computed. Set one of:
 

--- a/tests/test_adapter_depth_window.py
+++ b/tests/test_adapter_depth_window.py
@@ -1,0 +1,27 @@
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+from Causal_Web.engine.engine_v2.state import Packet
+
+
+def test_run_until_next_window_or_rolls_window():
+    graph = {
+        "params": {"W0": 2},
+        "vertices": [
+            {
+                "id": 0,
+                "rho_mean": 0.0,
+                "edges": [{"id": 0, "dst": 0, "d_eff": 1}],
+            }
+        ],
+    }
+
+    adapter = EngineAdapter()
+    adapter.build_graph(graph)
+
+    adapter._scheduler.push(0, 0, 0, Packet(0, 0))
+    frame = adapter.run_until_next_window_or(limit=10)
+
+    # Window index should have rolled once and depth advanced to W0
+    lccm = adapter._vertices[0]["lccm"]
+    assert lccm.window_idx == 1
+    assert frame.depth == 2
+    assert frame.events == 3

--- a/tests/test_depth_scheduler.py
+++ b/tests/test_depth_scheduler.py
@@ -1,0 +1,31 @@
+from Causal_Web.engine.engine_v2.scheduler import DepthScheduler
+from Causal_Web.engine.engine_v2.state import Packet
+
+
+def test_scheduler_deterministic_order_and_peek():
+    sched = DepthScheduler()
+    # push out-of-order depths
+    sched.push(3, 0, 0, Packet(0, 0))
+    sched.push(1, 1, 0, Packet(0, 1))
+    sched.push(2, 2, 0, Packet(0, 2))
+
+    assert sched.peek_depth() == 1
+    depths = []
+    while sched:
+        depth, dst, edge, pkt = sched.pop()
+        depths.append(depth)
+    assert depths == [1, 2, 3]
+
+
+def test_scheduler_tie_breaking():
+    sched = DepthScheduler()
+    sched.push(5, 2, 1, Packet(0, 2))
+    sched.push(5, 1, 2, Packet(0, 1))
+    sched.push(5, 1, 1, Packet(0, 1))
+
+    results = []
+    while sched:
+        depth, dst, edge, pkt = sched.pop()
+        results.append((depth, dst, edge))
+
+    assert results == [(5, 1, 1), (5, 1, 2), (5, 2, 1)]

--- a/tests/test_lccm.py
+++ b/tests/test_lccm.py
@@ -1,0 +1,51 @@
+from Causal_Web.engine.engine_v2.lccm import LCCM
+
+
+def test_lccm_layer_transitions_with_hysteresis():
+    lccm = LCCM(
+        W0=2,
+        zeta1=0.0,
+        zeta2=0.0,
+        rho0=1.0,
+        a=1.0,
+        b=0.5,
+        C_min=1.0,
+        f_min=0.9,
+        H_max=0.5,
+        T_hold=2,
+        T_class=2,
+        deg=0,
+        rho_mean=0.0,
+    )
+
+    # Q -> Θ when λ >= a*W
+    lccm.advance_depth(0)
+    lccm.deliver()
+    assert lccm.layer == "Q"
+    lccm.deliver()
+    assert lccm.layer == "Θ"
+
+    # Θ -> Q requires λ <= b*W and EQ above threshold for T_hold
+    lccm.advance_depth(2)
+    lccm.update_eq(1.0)
+    lccm.deliver()
+    assert lccm.layer == "Θ"
+    lccm.advance_depth(4)
+    lccm.update_eq(1.0)
+    lccm.deliver()
+    assert lccm.layer == "Q"
+
+    # Decoherence again for Θ -> C test
+    lccm.advance_depth(5)
+    lccm.deliver()
+    lccm.deliver()
+    assert lccm.layer == "Θ"
+
+    # Θ -> C when classical dominance sustained for T_class
+    lccm.update_classical_metrics(1.0, 0.0)
+    lccm.deliver()
+    assert lccm.layer == "Θ"
+    lccm.advance_depth(6)
+    lccm.update_classical_metrics(1.0, 0.0)
+    lccm.deliver()
+    assert lccm.layer == "C"


### PR DESCRIPTION
## Summary
- Replace prototype scheduler with `DepthScheduler` including deterministic tie-breaks and depth peek
- Add LCCM helper modelling window size and Q/Θ/C layer transitions with hysteresis
- Expand engine v2 adapter to process packets by arrival depth and advance windows accordingly
- Document depth-based scheduling and LCCM in README and add unit tests

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest tests/test_depth_scheduler.py tests/test_lccm.py tests/test_adapter_depth_window.py -q`
- `python -m Causal_Web.main` *(fails: config JSON load error)*
- `python bundle_run.py` *(fails: interpretation_log.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897c717e76c8325b0113d0e35f2e5ec