### PR TITLE
feat: add struct-of-arrays graph loader

### DIFF
--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -1,0 +1,131 @@
+"""Graph loader for struct-of-arrays representation.
+
+The :func:`load_graph_arrays` helper converts a graph JSON dictionary
+into arrays suitable for the experimental engine. Missing fields are
+filled from :mod:`Causal_Web.config.Config` defaults.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from ...config import Config
+
+
+@dataclass
+class GraphArrays:
+    """Struct-of-arrays container returned by :func:`load_graph_arrays`."""
+
+    id_map: Dict[str, int]
+    vertices: Dict[str, Any]
+    edges: Dict[str, Any]
+    adjacency: Dict[str, List[int]]
+
+
+def _identity_matrix(dim: int) -> List[List[float]]:
+    """Return a ``dim`` x ``dim`` identity matrix."""
+
+    return [[1.0 if i == j else 0.0 for j in range(dim)] for i in range(dim)]
+
+
+def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
+    """Convert ``graph_json`` into struct-of-arrays collections.
+
+    Parameters
+    ----------
+    graph_json:
+        Graph description as a dictionary following the JSON schema.
+
+    Returns
+    -------
+    GraphArrays
+        Struct-of-arrays representation of ``graph_json``.
+    """
+
+    nodes = graph_json.get("nodes", {})
+    if isinstance(nodes, list):
+        nodes = {n.get("id", str(i)): n for i, n in enumerate(nodes)}
+
+    id_map = {nid: i for i, nid in enumerate(nodes)}
+    n_vert = len(id_map)
+
+    W0 = Config.windowing.get("W0", 0.0)
+    Q = Config.windowing.get("Q", 0)
+    Dq = int(Config.windowing.get("Dq", 1))
+    Dp = int(Config.windowing.get("Dp", 1))
+
+    vertices = {
+        "depth": [0 for _ in range(n_vert)],
+        "window_len": [nodes[nid].get("window_len", W0) for nid in nodes],
+        "window_idx": [0 for _ in range(n_vert)],
+        "layer": [nodes[nid].get("layer", Q) for nid in nodes],
+        "psi": [[1.0 if j == 0 else 0.0 for j in range(Dq)] for _ in range(n_vert)],
+        "psi_acc": [[0.0 for _ in range(Dq)] for _ in range(n_vert)],
+        "EQ": [0.0 for _ in range(n_vert)],
+        "p": [[1.0 / Dp for _ in range(Dp)] for _ in range(n_vert)],
+        "bit": [0 for _ in range(n_vert)],
+        "conf": [0 for _ in range(n_vert)],
+        "fanin": [0 for _ in range(n_vert)],
+        "ancestry": [[0, 0, 0, 0] for _ in range(n_vert)],
+        "m": [[0, 0, 0] for _ in range(n_vert)],
+    }
+
+    edges_data = graph_json.get("edges", [])
+
+    edges = {
+        "src": [],
+        "dst": [],
+        "d0": [],
+        "rho": [],
+        "alpha": [],
+        "phi": [],
+        "A": [],
+        "U": [],
+        "sigma": [],
+    }
+
+    default_u = _identity_matrix(Dq)
+    unitary_map = getattr(Config, "unitaries", {})
+
+    for edge in edges_data:
+        src_idx = id_map.get(edge.get("from"))
+        dst_idx = id_map.get(edge.get("to"))
+        if src_idx is None or dst_idx is None:
+            continue
+        edges["src"].append(src_idx)
+        edges["dst"].append(dst_idx)
+        edges["d0"].append(edge.get("delay", 0.0))
+        edges["rho"].append(edge.get("density", 0.0))
+        edges["alpha"].append(edge.get("weight", 1.0))
+        edges["phi"].append(edge.get("phase_shift", 0.0))
+        edges["A"].append(edge.get("A_phase", 0.0))
+        u_id = edge.get("u_id")
+        if u_id is not None and isinstance(unitary_map, dict) and u_id in unitary_map:
+            edges["U"].append(unitary_map[u_id])
+        else:
+            edges["U"].append([row[:] for row in default_u])
+        edges["sigma"].append(0.0)
+
+    # Build edge-neighbor adjacency CSR
+    vertex_edges: Dict[int, List[int]] = {i: [] for i in range(n_vert)}
+    for idx, (s, d) in enumerate(zip(edges["src"], edges["dst"])):
+        vertex_edges[s].append(idx)
+        vertex_edges[d].append(idx)
+
+    n_edge = len(edges["src"])
+    nbr_ptr: List[int] = [0]
+    nbr_idx: List[int] = []
+    for idx in range(n_edge):
+        s = edges["src"][idx]
+        d = edges["dst"][idx]
+        neighbors = set(vertex_edges[s] + vertex_edges[d])
+        neighbors.discard(idx)
+        nbr_idx.extend(sorted(neighbors))
+        nbr_ptr.append(len(nbr_idx))
+
+    adjacency = {"nbr_ptr": nbr_ptr, "nbr_idx": nbr_idx}
+
+    return GraphArrays(
+        id_map=id_map, vertices=vertices, edges=edges, adjacency=adjacency
+    )

--- a/Causal_Web/engine/engine_v2/test_loader.py
+++ b/Causal_Web/engine/engine_v2/test_loader.py
@@ -1,0 +1,90 @@
+import pytest
+
+from Causal_Web.engine.engine_v2.loader import load_graph_arrays
+from Causal_Web.config import Config
+
+
+@pytest.fixture
+def patch_config(monkeypatch):
+    monkeypatch.setattr(
+        Config,
+        "windowing",
+        {"W0": 3.0, "Q": 5, "Dq": 2, "Dp": 3},
+    )
+    monkeypatch.setattr(
+        Config,
+        "unitaries",
+        {"u1": [[0.0, 1.0], [1.0, 0.0]]},
+        raising=False,
+    )
+
+    yield
+
+
+def test_load_graph_arrays_struct_and_defaults(patch_config):
+    graph_json = {
+        "nodes": [
+            {"id": "A", "window_len": 10.0, "layer": 2},
+            {"id": "B"},
+            {"id": "C", "extra": 123},
+        ],
+        "edges": [
+            {
+                "from": "A",
+                "to": "B",
+                "weight": 2,
+                "delay": 1,
+                "density": 0.3,
+                "phase_shift": 0.1,
+                "A_phase": 0.2,
+                "u_id": "u1",
+            },
+            {"from": "B", "to": "A", "density": 0.5},
+            {"from": "B", "to": "B", "weight": 3, "delay": 2},
+            {"from": "C", "to": "D"},
+        ],
+    }
+
+    arrays = load_graph_arrays(graph_json)
+
+    assert arrays.id_map == {"A": 0, "B": 1, "C": 2}
+
+    v = arrays.vertices
+    assert v["window_len"] == [10.0, 3.0, 3.0]
+    assert v["layer"] == [2, 5, 5]
+    assert all(len(row) == 2 for row in v["psi"])
+    assert v["p"][0] == [1 / 3, 1 / 3, 1 / 3]
+
+    e = arrays.edges
+    assert e["src"] == [0, 1, 1]
+    assert e["dst"] == [1, 0, 1]
+    assert e["d0"] == [1, 0.0, 2]
+    assert e["alpha"] == [2, 1.0, 3]
+    assert e["rho"] == [0.3, 0.5, 0.0]
+    assert e["U"][0] == [[0.0, 1.0], [1.0, 0.0]]
+    assert e["U"][1] == [[1.0, 0.0], [0.0, 1.0]]
+    assert e["sigma"] == [0.0, 0.0, 0.0]
+
+    adj = arrays.adjacency
+    assert adj["nbr_ptr"] == [0, 2, 4, 6]
+    assert adj["nbr_idx"] == [1, 2, 0, 2, 0, 1]
+
+
+def test_load_graph_arrays_numeric_types(patch_config):
+    graph_json = {
+        "nodes": [{"id": "A"}],
+        "edges": [{"from": "A", "to": "A"}],
+    }
+    arrays = load_graph_arrays(graph_json)
+
+    v = arrays.vertices
+    assert all(isinstance(x, int) for x in v["depth"])
+    assert all(isinstance(x, float) for x in v["window_len"])
+    assert all(isinstance(x, int) for x in v["layer"])
+    assert all(isinstance(x, int) for x in v["bit"])
+    assert all(isinstance(x, float) for x in v["EQ"])
+
+    e = arrays.edges
+    numeric_fields = ["d0", "rho", "alpha", "phi", "A", "sigma"]
+    for field in numeric_fields:
+        assert all(isinstance(x, (int, float)) for x in e[field])

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ advanced controls for the v2 engine and currently have placeholder defaults.
 An adapter in ``engine_v2`` mirrors the legacy tick engine API and yields
 synthetic telemetry frames so the GUI can tick while the new physics is under
 development.
+A lightweight loader converts graph JSON into struct-of-arrays via ``engine_v2.loader.load_graph_arrays`` to prime this core.
 
 The `density_calc` option controls how edge density is computed. Set one of:
 


### PR DESCRIPTION
## Summary
- add `load_graph_arrays` to convert graph JSON into struct-of-arrays for engine v2
- document new loader in README
- cover loader with tests and fix adjacency CSR when skipping invalid edges

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c55d57408325a6ff424da19ad65b