### PR TITLE
Implement Q/Θ/C packet updates and density-delay model

### DIFF
--- a/Causal_Web/engine/engine_v2/qtheta_c.py
+++ b/Causal_Web/engine/engine_v2/qtheta_c.py
@@ -1,0 +1,94 @@
+"""Q/Θ/C field update helpers.
+
+This module provides minimal routines for the experimental v2 engine to
+update quantum (``psi``), probabilistic (``p``) and classical (``bit``)
+fields when a packet is delivered across an edge.  The functions operate on
+simple ``dict`` structures matching the loader's output and return the
+combined intensity used by the density-delay model.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Iterable, Tuple
+
+import numpy as np
+
+
+def deliver_packet(
+    depth_v: int,
+    psi_acc: np.ndarray,
+    p_v: np.ndarray,
+    bit_deque: Deque[int],
+    packet: dict,
+    edge: dict,
+    max_deque: int = 8,
+) -> Tuple[int, np.ndarray, np.ndarray, Tuple[int, float], float]:
+    """Apply Q/Θ/C delivery rules for a single packet.
+
+    Parameters
+    ----------
+    depth_v:
+        Current depth of the destination vertex.
+    psi_acc:
+        Accumulator for quantum amplitudes.
+    p_v:
+        Classical probability vector for the vertex.
+    bit_deque:
+        Recent bits used for majority voting.
+    packet:
+        Packet carrying ``depth_arr``, ``psi``, ``p`` and ``bit`` fields.
+    edge:
+        Edge parameters ``alpha``, ``phi``, ``A`` and unitary ``U``.
+    max_deque:
+        Maximum length of ``bit_deque``.
+
+    Returns
+    -------
+    tuple
+        Updated ``depth_v``, ``psi_acc``, ``p_v``, ``(bit, conf)`` and the
+        combined intensity in ``[0, 1]``.
+    """
+
+    depth_v = max(depth_v, int(packet.get("depth_arr", 0)))
+
+    U = np.asarray(edge.get("U"), dtype=np.complex128)
+    psi = np.asarray(packet.get("psi"), dtype=np.complex128)
+    coeff = edge.get("alpha", 1.0) * np.exp(
+        1j * (edge.get("phi", 0.0) + edge.get("A", 0.0))
+    )
+    psi_acc = psi_acc + coeff * (U @ psi)
+
+    p_v = p_v + edge.get("alpha", 1.0) * np.asarray(packet.get("p"))
+    total = float(np.sum(p_v))
+    if total > 0:
+        p_v = p_v / total
+
+    bit_deque.append(int(packet.get("bit", 0)))
+    while len(bit_deque) > max_deque:
+        bit_deque.popleft()
+    ones = sum(bit_deque)
+    zeros = len(bit_deque) - ones
+    bit = 1 if ones >= zeros else 0
+    conf = abs(ones - zeros) / len(bit_deque)
+
+    q_intensity = min(1.0, float(np.linalg.norm(U @ psi) ** 2))
+    theta_intensity = min(1.0, float(np.sum(np.abs(packet.get("p", [])))))
+    c_intensity = bit
+    intensity = min(1.0, q_intensity + theta_intensity + c_intensity)
+
+    return depth_v, psi_acc, p_v, (bit, conf), intensity
+
+
+def close_window(psi_acc: np.ndarray) -> Tuple[np.ndarray, float]:
+    """Normalise the accumulated ``psi`` and compute ``EQ``."""
+
+    EQ = float(np.vdot(psi_acc, psi_acc).real)
+    if EQ > 0:
+        psi = psi_acc / np.sqrt(EQ)
+    else:
+        psi = psi_acc.copy()
+    return psi, EQ
+
+
+__all__ = ["deliver_packet", "close_window"]

--- a/Causal_Web/engine/engine_v2/rho_delay.py
+++ b/Causal_Web/engine/engine_v2/rho_delay.py
@@ -1,13 +1,16 @@
 """Density-dependent delay helpers.
 
-Functions here provide a toy diffusion model and a saturating mapping
-from density to an effective delay. They are intentionally simple and
-serve as placeholders until the full model is implemented.
+Functions here provide helpers for evolving a stress--energy density
+associated with edges and mapping that density to an effective delay.
+The ``update_rho_delay`` routine implements a leaky diffusion step with
+external input and a logarithmic delay scaling used by the experimental
+engine.
 """
 
 from __future__ import annotations
 
-from typing import Iterable, List
+import math
+from typing import Iterable, List, Tuple
 
 
 def diffuse(rho: List[float], weight: float) -> List[float]:
@@ -31,3 +34,47 @@ def effective_delay(rho: float, cap: float = 1.0) -> float:
     """Map density to an effective delay using a simple saturation."""
 
     return min(rho, cap)
+
+
+def update_rho_delay(
+    rho: float,
+    neighbours: Iterable[float],
+    intensity: float,
+    *,
+    alpha_d: float,
+    alpha_leak: float,
+    eta: float,
+    d0: float,
+    gamma: float,
+    rho0: float,
+) -> Tuple[float, int]:
+    """Update density and effective delay for a single edge.
+
+    Parameters
+    ----------
+    rho:
+        Current density on the edge.
+    neighbours:
+        Densities of neighbouring edges used for diffusion.
+    intensity:
+        External input contribution ``I``.
+    alpha_d, alpha_leak, eta:
+        Diffusion, leakage and input weights.
+    d0, gamma, rho0:
+        Baseline delay and scaling parameters for ``d_eff``.
+
+    Returns
+    -------
+    tuple
+        Updated ``rho`` and integer ``d_eff``.
+    """
+
+    nbr_list = list(neighbours)
+    mean = sum(nbr_list) / len(nbr_list) if nbr_list else 0.0
+    rho = (1 - alpha_d - alpha_leak) * rho + alpha_d * mean + eta * intensity
+    rho = max(0.0, rho)
+    d_eff = max(1, int(round(d0 + gamma * math.log(1 + rho / rho0))))
+    return rho, d_eff
+
+
+__all__ = ["diffuse", "effective_delay", "update_rho_delay"]

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Amplitude energy now feeds a stress–energy field that scales edge delay by
 ``1 + κρ``. This density diffuses each scheduler step with weight
 ``Config.density_diffusion_weight`` (``α``).
 
+The helper ``engine.engine_v2.rho_delay.update_rho_delay`` applies this rule
+per edge, adding leakage and external intensity and mapping the resulting
+density to a logarithmically scaled effective delay.
+
 Scheduler steps also integrate a toy horizon thermodynamics model. Interior
 nodes may emit Hawking pairs with probability ``exp(-ΔE/T_H)``, and the
 resulting radiation entropy follows a simple Page-curve: growing then

--- a/tests/test_qtheta_c.py
+++ b/tests/test_qtheta_c.py
@@ -1,0 +1,30 @@
+import numpy as np
+from collections import deque
+
+from Causal_Web.engine.engine_v2.qtheta_c import deliver_packet, close_window
+
+
+def test_deliver_packet_updates_fields():
+    depth, psi_acc, p_v = 0, np.zeros(2, dtype=np.complex128), np.array([0.5, 0.5])
+    bits = deque()
+    packet = {"depth_arr": 2, "psi": [1.0, 0.0], "p": [0.2, 0.8], "bit": 1}
+    edge = {
+        "alpha": 0.5,
+        "phi": 0.1,
+        "A": 0.2,
+        "U": [[1.0, 0.0], [0.0, 1.0]],
+    }
+
+    depth, psi_acc, p_v, (bit, conf), intensity = deliver_packet(
+        depth, psi_acc, p_v, bits, packet, edge
+    )
+
+    assert depth == 2
+    assert np.allclose(p_v, np.array([0.4, 0.6]))
+    assert bit == 1 and conf == 1.0
+    assert intensity == 1.0
+
+    psi, EQ = close_window(psi_acc)
+    assert np.isclose(EQ, np.vdot(psi_acc, psi_acc).real)
+    if EQ > 0:
+        assert np.allclose(psi, psi_acc / np.sqrt(EQ))

--- a/tests/test_rho_delay_update.py
+++ b/tests/test_rho_delay_update.py
@@ -1,0 +1,17 @@
+from Causal_Web.engine.engine_v2.rho_delay import update_rho_delay
+
+
+def test_update_rho_delay():
+    rho, d_eff = update_rho_delay(
+        0.5,
+        [0.5, 1.0],
+        1.0,
+        alpha_d=0.1,
+        alpha_leak=0.05,
+        eta=0.2,
+        d0=3,
+        gamma=2.0,
+        rho0=0.1,
+    )
+    assert abs(rho - 0.7) < 1e-9
+    assert d_eff == 7


### PR DESCRIPTION
## Summary
- Add `qtheta_c.deliver_packet` and `close_window` to apply quantum, probabilistic and classical field updates and compute intensity
- Introduce `rho_delay.update_rho_delay` with leaky diffusion and logarithmic effective delay mapping
- Document density-delay helper in README and cover new behaviour with tests

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ca02bde08325a8136f5ce845f69b