### PR TITLE
Test scheduler edge cases and clarify depth semantics

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -94,7 +94,12 @@ class EngineAdapter:
         return self.run_until_next_window_or(max_events)
 
     def run_until_next_window_or(self, limit: int | None) -> TelemetryFrame:
-        """Run until the next window boundary or until ``limit`` events."""
+        """Run until the next window boundary or until ``limit`` events.
+
+        The returned frame's ``depth`` mirrors the greatest arrival depth
+        encountered during processing. If no events are handled or only events
+        at the current depth are processed, the depth will remain unchanged.
+        """
 
         if not self._running:
             self.start()

--- a/Causal_Web/engine/engine_v2/scheduler.py
+++ b/Causal_Web/engine/engine_v2/scheduler.py
@@ -26,7 +26,9 @@ class DepthScheduler:
     deterministic pop order even when multiple packets arrive at the same
     depth.  ``peek_depth`` exposes the depth of the next scheduled event
     without removing it from the queue, which is useful for detecting window
-    boundaries in the adapter loop.
+    boundaries in the adapter loop. The scheduler itself does not maintain or
+    increment a global depth counter; it merely stores the depth associated
+    with each scheduled item.
     """
 
     def __init__(self) -> None:

--- a/tests/test_adapter_depth_window.py
+++ b/tests/test_adapter_depth_window.py
@@ -25,3 +25,34 @@ def test_run_until_next_window_or_rolls_window():
     assert lccm.window_idx == 1
     assert frame.depth == 2
     assert frame.events == 3
+
+
+def test_run_until_next_window_or_no_events():
+    """Adapter reports zero depth and events when scheduler is empty."""
+
+    graph = {"vertices": [{"id": 0, "rho_mean": 0.0, "edges": []}]}
+
+    adapter = EngineAdapter()
+    adapter.build_graph(graph)
+
+    frame = adapter.run_until_next_window_or(limit=10)
+
+    assert frame.depth == 0
+    assert frame.events == 0
+
+
+def test_run_until_next_window_or_single_event():
+    """Processing a single event does not advance the depth."""
+
+    graph = {"vertices": [{"id": 0, "rho_mean": 0.0, "edges": []}]}
+
+    adapter = EngineAdapter()
+    adapter.build_graph(graph)
+
+    adapter._scheduler.push(0, 0, 0, Packet(0, 0))
+    frame = adapter.run_until_next_window_or(limit=10)
+
+    assert frame.events == 1
+    assert frame.depth == 0
+    lccm = adapter._vertices[0]["lccm"]
+    assert lccm.window_idx == 0


### PR DESCRIPTION
## Summary
- Document that engine depth only advances when events increase arrival depth in both adapter and scheduler docs
- Add tests for `run_until_next_window_or` handling zero and single events

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ce851ca4832582f83a8857cff31e