### PR TITLE
Implement dynamic ε-pair bridging algorithm

### DIFF
--- a/Causal_Web/engine/engine_v2/epairs.py
+++ b/Causal_Web/engine/engine_v2/epairs.py
@@ -1,43 +1,151 @@
-"""Epsilon-pair management for the v2 engine.
+"""Dynamic ε-pair management for the v2 engine.
 
-The routines below track time-to-live (TTL) seeds and provide a simple
-reinforcement/decay mechanism for bridge ``sigma`` values. They are
-non-physical placeholders that allow higher layers to exercise the API
-without requiring a completed physics model.
+This module implements a toy model for *ε*-pair formation.  Each
+"seed" carries a time-to-live (TTL), a hash prefix identifying the
+originating site and a local ``theta`` value.  Seeds are emitted along
+outgoing edges during Q-delivery and, when two compatible seeds meet,
+their sources are connected by a temporary "bridge" edge.  Bridges
+decay unless periodically reinforced.
+
+The implementation is intentionally lightweight – it exists to provide a
+concrete API for higher level components while the physical model is
+still under development.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Dict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
 
 
 @dataclass
-class TTLSeeds:
-    """Track TTL values for epsilon pair seeds."""
+class Seed:
+    """A propagating ε-pair seed.
 
-    seeds: Dict[int, int] = field(default_factory=dict)
+    Parameters
+    ----------
+    origin:
+        Identifier of the node that emitted the seed.
+    ttl:
+        Remaining hop budget for the seed.
+    h_prefix:
+        ``L``-bit prefix derived from the origin's hash.
+    theta:
+        Local phase value associated with the seed.
+    """
 
-    def seed(self, pair_id: int, ttl: int) -> None:
-        self.seeds[pair_id] = ttl
-
-    def tick(self) -> None:
-        expired = [k for k, v in self.seeds.items() if v <= 1]
-        for k in expired:
-            del self.seeds[k]
-        for k in self.seeds:
-            self.seeds[k] -= 1
+    origin: int
+    ttl: int
+    h_prefix: int
+    theta: float
 
 
 @dataclass
-class BridgeSigma:
-    """Reinforce or decay a bridge's sigma value."""
+class Bridge:
+    """State associated with a dynamic bridge."""
 
-    sigma: float = 0.0
-    decay: float = 0.1
+    sigma: float
 
-    def reinforce(self, amount: float) -> None:
-        self.sigma += amount
 
-    def tick(self) -> None:
-        self.sigma *= 1.0 - self.decay
+class EPairs:
+    """Manage ε-pair seeds and bridges.
+
+    The class exposes three core operations:
+
+    ``emit``
+        Emit seeds from a node to a set of neighbours.
+    ``reinforce``
+        Update the ``sigma`` value for an existing bridge when a tick is
+        delivered across it, removing the bridge if it decays below
+        ``sigma_min``.
+    ``bridges``
+        Mapping of ``(a, b)`` node id pairs to :class:`Bridge` objects.
+
+    Parameters are supplied on construction to avoid global state and to
+    make the component easy to test.
+    """
+
+    def __init__(
+        self,
+        delta_ttl: int,
+        ancestry_prefix_L: int,
+        theta_max: float,
+        sigma0: float,
+        lambda_decay: float,
+        sigma_reinforce: float,
+        sigma_min: float,
+    ) -> None:
+        self.delta_ttl = delta_ttl
+        self.L = ancestry_prefix_L
+        self.theta_max = theta_max
+        self.sigma0 = sigma0
+        self.lambda_decay = lambda_decay
+        self.sigma_reinforce = sigma_reinforce
+        self.sigma_min = sigma_min
+        self.seeds: Dict[int, List[Seed]] = {}
+        self.bridges: Dict[Tuple[int, int], Bridge] = {}
+
+    # ------------------------------------------------------------------
+    # seed handling
+
+    def emit(
+        self, origin: int, h_value: int, theta: float, neighbours: Iterable[int]
+    ) -> None:
+        """Emit seeds from ``origin`` to each neighbour.
+
+        Each seed consumes one unit of TTL during the hop.  Seeds with a
+        remaining TTL of zero are discarded.  When a seed arrives at a
+        site it is compared against existing seeds to determine whether a
+        bridge should be formed.
+        """
+
+        prefix = self._prefix(h_value)
+        for n in neighbours:
+            seed = Seed(
+                origin=origin, ttl=self.delta_ttl - 1, h_prefix=prefix, theta=theta
+            )
+            if seed.ttl > 0:
+                self._place_seed(n, seed)
+
+    # Internal helpers -------------------------------------------------
+
+    def _prefix(self, h_value: int) -> int:
+        if self.L <= 0:
+            return 0
+        shift = max(0, h_value.bit_length() - self.L)
+        return h_value >> shift
+
+    def _place_seed(self, site: int, seed: Seed) -> None:
+        seeds = self.seeds.setdefault(site, [])
+        for other in list(seeds):
+            if (
+                seed.h_prefix == other.h_prefix
+                and abs(seed.theta - other.theta) <= self.theta_max
+                and other.ttl > 0
+            ):
+                self._create_bridge(seed.origin, other.origin)
+                seeds.remove(other)
+                return
+        seeds.append(seed)
+
+    def _create_bridge(self, a: int, b: int) -> None:
+        key = self._bridge_key(a, b)
+        if key not in self.bridges:
+            self.bridges[key] = Bridge(self.sigma0)
+
+    def _bridge_key(self, a: int, b: int) -> Tuple[int, int]:
+        return (a, b) if a <= b else (b, a)
+
+    # ------------------------------------------------------------------
+    # bridge handling
+
+    def reinforce(self, a: int, b: int) -> None:
+        """Reinforce or decay the bridge between ``a`` and ``b``."""
+
+        key = self._bridge_key(a, b)
+        bridge = self.bridges.get(key)
+        if bridge is None:
+            return
+        bridge.sigma = (1.0 - self.lambda_decay) * bridge.sigma + self.sigma_reinforce
+        if bridge.sigma < self.sigma_min:
+            del self.bridges[key]

--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ advanced controls for the v2 engine.  Each group is a nested mapping:
 ```
 
 The `windowing` values control vertex window advancement. `rho_delay` affects
-how edge density relaxes toward a baseline. `epsilon_pairs` governs ε-pair
-reinforcement and decay while `bell` sets mutual information gates for Bell
-pair matching.
+how edge density relaxes toward a baseline. `epsilon_pairs` governs dynamic
+ε-pair behaviour – seeds with a limited TTL can bind to form temporary bridge
+edges whose `sigma` values decay unless reinforced – while `bell` sets mutual
+information gates for Bell pair matching.
 
 An adapter in ``engine_v2`` mirrors a subset of the legacy tick engine API and
 generates *synthetic telemetry frames* so the GUI can tick while the new

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -1,0 +1,38 @@
+"""Tests for the dynamic ε-pair utilities."""
+
+from Causal_Web.engine.engine_v2.epairs import Bridge, EPairs
+
+
+def _make_manager():
+    return EPairs(
+        delta_ttl=2,
+        ancestry_prefix_L=4,
+        theta_max=0.1,
+        sigma0=1.0,
+        lambda_decay=0.5,
+        sigma_reinforce=0.2,
+        sigma_min=0.1,
+    )
+
+
+def test_seed_binding_creates_bridge():
+    mgr = _make_manager()
+    # Seeds share a 4 bit prefix and close theta values
+    mgr.emit(origin=1, h_value=0b1101_1110, theta=0.10, neighbours=[3])
+    mgr.emit(origin=2, h_value=0b1101_0001, theta=0.15, neighbours=[3])
+    assert (1, 2) in mgr.bridges
+    assert mgr.bridges[(1, 2)].sigma == 1.0
+
+
+def test_bridge_reinforcement_and_decay():
+    mgr = _make_manager()
+    mgr.bridges[(1, 2)] = Bridge(0.05)
+    mgr.reinforce(1, 2)
+    # sigma: (1-0.5)*0.05 + 0.2 = 0.225 > sigma_min -> bridge persists
+    assert mgr.bridges[(1, 2)].sigma == (1 - 0.5) * 0.05 + 0.2
+    # decay below minimum removes the bridge
+    mgr.lambda_decay = 0.8
+    mgr.sigma_reinforce = 0.0
+    mgr.reinforce(1, 2)
+    assert (1, 2) not in mgr.bridges
+


### PR DESCRIPTION
## Summary
- implement dynamic epsilon pair seed emission and bridge reinforcement/decay
- document epsilon pair behaviour in README
- add tests for seed binding and bridge decay

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897d0434fdc8325a61cfecf7a9e6658