### PR TITLE
Add ancestry-aware Bell helpers with measurement dependence toggle

### DIFF
--- a/Causal_Web/engine/engine_v2/bell.py
+++ b/Causal_Web/engine/engine_v2/bell.py
@@ -1,40 +1,153 @@
 """Bell experiment helpers for the v2 engine.
 
-This module contains placeholders for ancestry tracking and contextual
-readouts used in Bell-type experiments. The implementations are
-non-functional and serve only to define the expected interface.
+This module implements a minimal Bell experiment simulator with
+ancestry-aware hidden variables and measurement setting draws that can
+be either strictly independent or weakly conditioned on the shared
+``lambda``.  The implementation is intentionally lightweight but
+captures the interfaces required by the engine.
 """
 
 from __future__ import annotations
 
-import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+import numpy as np
 
 
 @dataclass
 class Ancestry:
-    """Track simple ancestry information for a packet."""
+    """Track ancestry information for a packet.
 
-    parent_id: int | None = None
+    Parameters
+    ----------
+    h:
+        Rolling 256-bit hash stored as four ``uint64`` values.
+    m:
+        Three dimensional phase-moment vector.
+    """
+
+    h: np.ndarray = field(default_factory=lambda: np.zeros(4, dtype=np.uint64))
+    m: np.ndarray = field(default_factory=lambda: np.zeros(3, dtype=float))
 
 
 class BellHelpers:
     """Utility methods for Bell experiment simulations."""
 
     def __init__(self, seed: int | None = None) -> None:
-        self._rand = random.Random(seed)
+        self._rng = np.random.default_rng(seed)
 
-    def lambda_at_source(self) -> float:
-        """Return a random ``lambda`` value."""
+    # ------------------------------------------------------------------
+    # Helpers
+    def _unit_vector(self, vec: np.ndarray) -> np.ndarray:
+        norm = np.linalg.norm(vec)
+        if norm == 0:
+            vec = self._rng.normal(size=3)
+            norm = np.linalg.norm(vec)
+        return vec / norm
 
-        return self._rand.random()
+    def _random_unit(self) -> np.ndarray:
+        return self._unit_vector(self._rng.normal(size=3))
 
-    def setting_draw(self) -> int:
-        """Draw a binary measurement setting."""
+    def _sample_vmf(self, mu: np.ndarray, kappa: float) -> np.ndarray:
+        """Sample from an approximate 3D von Mises–Fisher distribution.
 
-        return self._rand.randint(0, 1)
+        This uses a simple normal perturbation which is sufficient for the
+        simulation goals of this project and avoids heavy dependencies.
+        """
 
-    def contextual_readout(self, setting: int, lam: float) -> int:
-        """Produce a contextual readout given ``setting`` and ``lambda``."""
+        if kappa <= 0:
+            return self._random_unit()
+        sample = self._rng.normal(size=3) + kappa * mu
+        return self._unit_vector(sample)
 
-        return 1 if lam > 0.5 else -1
+    def _rotate(self, u: np.ndarray, zeta: int) -> np.ndarray:
+        """Rotate ``u`` using a simple component roll keyed by ``zeta``."""
+
+        return np.roll(u, int(zeta % 3))
+
+    def _ancestry_overlap(self, a: Ancestry, b: Ancestry) -> float:
+        """Return fraction of matching ``h`` segments between ancestries."""
+
+        return float(np.sum(a.h == b.h)) / 4.0
+
+    # ------------------------------------------------------------------
+    # Public API
+    def lambda_at_source(
+        self, ancestry: Ancestry, beta_m: float, beta_h: float
+    ) -> Tuple[np.ndarray, int]:
+        """Create the shared hidden variable ``lambda`` for a new pair.
+
+        Parameters
+        ----------
+        ancestry:
+            Source ancestry values ``(h_S, m_S)``.
+        beta_m:
+            Blend factor for phase moments.
+        beta_h:
+            Blend factor for hash contribution to ``zeta``.
+        """
+
+        u_rand = self._random_unit()
+        u = beta_m * ancestry.m + (1.0 - beta_m) * u_rand
+        u = self._unit_vector(u)
+
+        h_int = int.from_bytes(ancestry.h.tobytes(), "little")
+        zeta_rand = int(self._rng.integers(0, 2**32))
+        zeta = int(beta_h * h_int) ^ zeta_rand
+        return u, zeta
+
+    def setting_draw(
+        self,
+        mode: str,
+        ancestry: Ancestry,
+        lam_u: np.ndarray,
+        kappa_a: float,
+    ) -> np.ndarray:
+        """Draw a measurement setting vector ``a_D``.
+
+        Parameters
+        ----------
+        mode:
+            Either ``"strict"`` for measurement independence or
+            ``"conditioned"`` to bias settings toward the shared ancestry.
+        ancestry:
+            Detector ancestry values ``(h_D, m_D)``.
+        lam_u:
+            Shared hidden direction from :func:`lambda_at_source`.
+        kappa_a:
+            Concentration parameter for ``MI_conditioned`` draws.
+        """
+
+        if mode == "strict":
+            return self._random_unit()
+
+        mu = self._unit_vector(ancestry.m + lam_u)
+        return self._sample_vmf(mu, kappa_a)
+
+    def contextual_readout(
+        self,
+        mode: str,
+        a_D: np.ndarray,
+        detector_ancestry: Ancestry,
+        lam_u: np.ndarray,
+        zeta: int,
+        kappa_xi: float,
+        source_ancestry: Ancestry,
+        kappa_a: float,
+        batch: int,
+    ) -> Tuple[int, Dict[str, float]]:
+        """Compute the detector readout and associated log values."""
+
+        rotated = self._rotate(lam_u, zeta)
+        noise = self._rng.normal(scale=1.0 / max(kappa_xi, 1e-9))
+        outcome = 1 if float(np.dot(a_D, rotated) + noise) > 0 else -1
+
+        log = {
+            "mode": mode,
+            "kappa_a": kappa_a,
+            "kappa_xi": kappa_xi,
+            "L": self._ancestry_overlap(detector_ancestry, source_ancestry),
+            "batch": batch,
+        }
+        return outcome, log

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Bridge propagation now occurs before observers handle a tick so detector events
 reflect entangled activity in the same cycle.
 These detector events are additionally written to `entangled_log.jsonl` for
 Bell inequality analysis.
+The underlying Bell helpers now track 256-bit ancestry fields and allow
+detector settings to be drawn either strictly independently or from a
+von Mises–Fisher distribution conditioned on shared ancestry.  This
+toggle enables controlled measurement dependence studies.
 Graphs may also define ``epsilon`` edges linking two nodes in a singlet state.
 When one node collapses, its ``epsilon`` partner is projected onto the opposite
 eigenvector, enabling Bell-test correlations without a bridge. Collapse now

--- a/tests/test_bell_helpers.py
+++ b/tests/test_bell_helpers.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from Causal_Web.engine.engine_v2.bell import Ancestry, BellHelpers
+
+
+def test_setting_draw_modes() -> None:
+    bell = BellHelpers(seed=123)
+    anc = Ancestry()
+    u, zeta = bell.lambda_at_source(anc, 0.5, 0.5)
+    strict = bell.setting_draw("strict", anc, u, kappa_a=0)
+    conditioned = bell.setting_draw("conditioned", anc, u, kappa_a=10.0)
+    assert strict.shape == (3,)
+    assert conditioned.shape == (3,)
+    assert np.isclose(np.linalg.norm(strict), 1.0)
+    assert np.isclose(np.linalg.norm(conditioned), 1.0)
+
+
+def test_contextual_readout_logging() -> None:
+    bell = BellHelpers(seed=0)
+    source = Ancestry()
+    detector = Ancestry()
+    u, zeta = bell.lambda_at_source(source, 0.5, 0.5)
+    a_D = bell.setting_draw("strict", detector, u, kappa_a=0)
+    outcome, log = bell.contextual_readout(
+        "strict",
+        a_D,
+        detector,
+        u,
+        zeta,
+        kappa_xi=1.0,
+        source_ancestry=source,
+        kappa_a=0.0,
+        batch=1,
+    )
+    assert outcome in (-1, 1)
+    assert log["mode"] == "strict"
+    assert log["batch"] == 1
+    assert 0.0 <= log["L"] <= 1.0


### PR DESCRIPTION
## Summary
- implement ancestry-tracking Bell helper with lambda generation, measurement-independent and conditioned setting draws, and contextual readouts
- document ancestry-aware measurement dependence in README
- add unit tests for Bell helper settings and logging

## Testing
- `pip install numpy networkx pytest pydantic`
- `black Causal_Web tests/test_bell_helpers.py`
- `python -m compileall Causal_Web`
- `python -m Causal_Web.main --max_ticks 0 --no-gui` *(fails: JSONDecodeError)*
- `python bundle_run.py` *(fails: FileNotFoundError: interpretation_log.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d21650cc8325bd3197c0f62f20a5