### PR TITLE
feat: extend telemetry and bell logging

### DIFF
--- a/Causal_Web/engine/models/node.py
+++ b/Causal_Web/engine/models/node.py
@@ -475,6 +475,12 @@ class Node(LoggingMixin):
         cumulative_delay: float = 0.0,
         entangled_id: str | None = None,
         graph: "CausalGraph | None" = None,
+        rho_before: float | None = None,
+        rho_after: float | None = None,
+        d_eff: float | None = None,
+        leak_contrib: float | None = None,
+        is_bridge: bool | None = None,
+        sigma: float | None = None,
     ) -> None:
         """Store an incoming phase for future evaluation.
 
@@ -489,6 +495,8 @@ class Node(LoggingMixin):
             Phase value being delivered.
         origin : str, optional
             ID of the node that emitted the phase.
+        rho_before, rho_after, d_eff, leak_contrib, is_bridge, sigma:
+            Optional telemetry fields describing edge delivery characteristics.
         """
 
         if created_tick is None:
@@ -516,15 +524,25 @@ class Node(LoggingMixin):
             f"[{self.id}] Received tick at {tick_time} with phase {incoming_phase:.2f}"
         )
         if origin is not None:
-            self._log(
-                "tick_delivery_log.json",
-                {
-                    "tick": tick_time,
-                    "source": origin,
-                    "node_id": self.id,
-                    "stored_phase": incoming_phase,
-                },
-            )
+            record = {
+                "tick": tick_time,
+                "source": origin,
+                "node_id": self.id,
+                "stored_phase": incoming_phase,
+            }
+            if rho_before is not None:
+                record["rho_before"] = rho_before
+            if rho_after is not None:
+                record["rho_after"] = rho_after
+            if d_eff is not None:
+                record["d_eff"] = d_eff
+            if leak_contrib is not None:
+                record["leak_contrib"] = leak_contrib
+            if is_bridge is not None:
+                record["is_bridge"] = is_bridge
+            if sigma is not None:
+                record["sigma"] = sigma
+            self._log("tick_delivery_log.json", record)
         from .. import tick_engine as te
 
         te.mark_for_update(self.id)

--- a/Causal_Web/engine/models/observer.py
+++ b/Causal_Web/engine/models/observer.py
@@ -3,6 +3,7 @@ import random
 import math
 
 from ..logging.logger import log_json
+from ...config import Config
 
 
 class Observer:
@@ -86,28 +87,31 @@ class Observer:
                 setting = rng.choice(self.measurement_settings)
                 adjusted = ev["phase"] - setting
                 outcome = 1 if math.cos(adjusted) > 0 else -1
+                payload = {
+                    "tick_id": ev["tick_id"],
+                    "observer_id": self.id,
+                    "entangled_id": ent_id,
+                    "measurement_setting": setting,
+                    "binary_outcome": outcome,
+                    "mode": getattr(Config, "bell_mode", None),
+                    "kappa_a": getattr(Config, "kappa_a", None),
+                    "kappa_xi": getattr(Config, "kappa_xi", None),
+                    "h_prefix_len": getattr(Config, "h_prefix_len", None),
+                    "delta_ttl": getattr(Config, "delta_ttl", None),
+                    "batch_id": getattr(Config, "batch_id", None),
+                    "setting": setting,
+                    "outcome": outcome,
+                }
                 log_json(
                     "event",
                     "entangled_measurement",
-                    {
-                        "tick_id": ev["tick_id"],
-                        "observer_id": self.id,
-                        "entangled_id": ent_id,
-                        "measurement_setting": setting,
-                        "binary_outcome": outcome,
-                    },
+                    payload,
                     tick=tick_time,
                 )
                 log_json(
                     "entangled",
                     "measurement",
-                    {
-                        "tick_id": ev["tick_id"],
-                        "observer_id": self.id,
-                        "entangled_id": ent_id,
-                        "measurement_setting": setting,
-                        "binary_outcome": outcome,
-                    },
+                    payload,
                     tick=tick_time,
                 )
         self.memory.append({"tick": tick_time, "events": events})

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ physics is under development.  A telemetry frame is a simple structure:
 {"depth": 3, "events": 5, "packets": [{"src": 1, "dst": 2, "payload": null}]}
 ```
 
+Each frame is also logged to `ticks_log.jsonl` with its sequential frame number,
+coarse ``depth_bucket`` and the highest ``window_idx`` encountered. Additional
+edge and vertex telemetry fields are appended without renaming existing keys so
+existing ingestion remains compatible.
+
 The adapter exposes methods like `build_graph`, `step`, `pause` and
 `snapshot_for_ui` to remain drop-in compatible.  Internally a depth-based
 scheduler orders packets by their arrival depth and advances vertex windows

--- a/docs/log_schemas.md
+++ b/docs/log_schemas.md
@@ -241,6 +241,8 @@ The following lists describe the JSON keys recorded in each output file.
 #### `entangled_measurement.json`
 - event-driven record with `tick_id`, `observer_id`, `entangled_id`,
   `measurement_setting` and `binary_outcome` for each detected entangled tick.
+- optional fields: `mode`, `kappa_a`, `kappa_xi`, `h_prefix_len`,
+  `delta_ttl`, `batch_id`, `setting`, `outcome`.
 
 #### `entangled_log.jsonl`
 - JSON lines file capturing entangled tick activity. `label` values include
@@ -274,6 +276,8 @@ The following lists describe the JSON keys recorded in each output file.
 
 #### `tick_delivery_log.json`
 - `source`, `node_id` and `stored_phase` for incoming ticks.
+- optional fields: `rho_before`, `rho_after`, `d_eff`, `leak_contrib`,
+  `is_bridge`, `sigma`.
 
 
 #### `tick_drop_log.json`


### PR DESCRIPTION
## Summary
- log adapter frames with frame index, depth buckets and window indices
- capture vertex window metrics and edge delivery details
- enrich entangled measurement logs with Bell experiment metadata

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68982745e83c8325a19c39236df5651f