### PR TITLE
feat(gui): integrate step engine and bell metadata

### DIFF
--- a/Causal_Web/analysis/bell.py
+++ b/Causal_Web/analysis/bell.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Tuple, List
+from typing import Any, Dict, Tuple, List
 
 from ..config import Config
 
 
 def compute_bell_statistics(
     log_file: str | None = None,
-) -> Tuple[float, Dict[Tuple[str, str], float]]:
+) -> Tuple[float, Dict[Tuple[str, str], float], Dict[str, Any]]:
     """Return CHSH ``S`` value from ``entangled_log.jsonl``.
 
     Parameters
@@ -27,13 +27,16 @@ def compute_bell_statistics(
         The calculated ``S`` value.
     Dict[Tuple[str, str], float]
         Mapping of setting pair to expectation value ``E(A_i,B_j)``.
+    Dict[str, Any]
+        Optional metadata fields captured from the log.
     """
 
     log_path = Path(log_file or Config.output_path("entangled_log.jsonl"))
     if not log_path.exists():
-        return 0.0, {}
+        return 0.0, {}, {}
 
     events: List[dict] = []
+    metadata: Dict[str, Any] = {}
     with log_path.open() as fh:
         for line in fh:
             if not line.strip():
@@ -44,6 +47,17 @@ def compute_bell_statistics(
                 or obj.get("label") == "measurement"
             ):
                 payload = obj.get("payload") or obj.get("value") or {}
+                if not metadata:
+                    for key in [
+                        "mode",
+                        "kappa_a",
+                        "kappa_xi",
+                        "h_prefix_len",
+                        "delta_ttl",
+                        "batch_id",
+                    ]:
+                        if key in payload:
+                            metadata[key] = payload[key]
                 events.append(
                     {
                         "tick": obj.get("tick"),
@@ -55,12 +69,12 @@ def compute_bell_statistics(
                 )
 
     if not events:
-        return 0.0, {}
+        return 0.0, {}, metadata
 
     # Determine observers and setting labels
     observer_ids = sorted({e["observer_id"] for e in events})[:2]
     if len(observer_ids) < 2:
-        return 0.0, {}
+        return 0.0, {}, metadata
     obs_map = {observer_ids[0]: "A", observer_ids[1]: "B"}
     setting_names: Dict[str, Dict[float, str]] = defaultdict(dict)
 
@@ -112,4 +126,4 @@ def compute_bell_statistics(
     e_a2_b2 = expectations.get(("A2", "B2"), 0.0)
     s_value = e_a1_b1 - e_a1_b2 + e_a2_b1 + e_a2_b2
 
-    return s_value, expectations
+    return s_value, expectations, metadata

--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -174,7 +174,9 @@ class EngineAdapter:
             max_depth = max(max_depth, lccm.depth)
             max_window = max(max_window, lccm.window_idx)
 
-        frame = TelemetryFrame(depth=max_depth, events=events, packets=packets)
+        frame = TelemetryFrame(
+            depth=max_depth, events=events, packets=packets, window=max_window
+        )
 
         depth_bucket = max_depth // 10
         self._frame += 1
@@ -225,6 +227,11 @@ class EngineAdapter:
         for data in self._vertices.values():
             max_depth = max(max_depth, data["lccm"].depth)
         return max_depth
+
+    def current_frame(self) -> int:
+        """Return the number of steps executed so far."""
+
+        return self._frame
 
 
 __all__ = ["EngineAdapter"]

--- a/Causal_Web/engine/engine_v2/state.py
+++ b/Causal_Web/engine/engine_v2/state.py
@@ -42,3 +42,4 @@ class TelemetryFrame:
     depth: int
     events: int
     packets: List[Packet] = field(default_factory=list)
+    window: int = 0

--- a/Causal_Web/gui_pyside/bell_window.py
+++ b/Causal_Web/gui_pyside/bell_window.py
@@ -45,8 +45,9 @@ class BellAnalysisWindow(QMainWindow):
     # ------------------------------------------------------------------
     def _run_analysis(self) -> None:
         """Compute statistics and update the display."""
-        s_value, expectations = compute_bell_statistics()
-        self.result_label.setText(f"S = {s_value:.3f}")
+        s_value, expectations, meta = compute_bell_statistics()
+        extra = "" if not meta else " " + ", ".join(f"{k}={v}" for k, v in meta.items())
+        self.result_label.setText(f"S = {s_value:.3f}{extra}")
         if QChartView is object:
             return
 

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -36,10 +36,11 @@ from ..gui.state import (
 from .canvas_widget import CanvasWidget
 from .toolbar_builder import build_toolbar
 from ..gui.command_stack import AddNodeCommand, AddObserverCommand
-from ..config import Config
 
 if getattr(Config, "engine_mode", "tick") == "v2":
-    from ..engine.engine_v2 import adapter as tick_engine
+    from ..engine.engine_v2.adapter import EngineAdapter
+
+    tick_engine = EngineAdapter()
 else:
     from ..engine import tick_engine
 from .shared import TooltipCheckBox, TOOLTIPS
@@ -214,6 +215,12 @@ class MainWindow(QMainWindow):
         self.tick_label = QLabel("0")
         layout.addRow("Current Tick", self.tick_label)
 
+        if getattr(Config, "engine_mode", "tick") == "v2":
+            self.depth_label = QLabel("0")
+            layout.addRow("Depth", self.depth_label)
+            self.window_label = QLabel("0")
+            layout.addRow("Window", self.window_label)
+
         self.limit_spin = QSpinBox()
         self.limit_spin.setMinimum(1)
         self.limit_spin.setMaximum(100000)
@@ -302,8 +309,21 @@ class MainWindow(QMainWindow):
         with Config.state_lock:
             running = Config.is_running
             tick = Config.current_tick
-        model_dict = tick_engine.graph.to_dict() if running else get_graph().to_dict()
-        self.tick_label.setText(str(tick))
+        if getattr(Config, "engine_mode", "tick") == "v2" and running:
+            frame = tick_engine.step()
+            tick = tick_engine.current_frame()
+            Config.current_tick = tick
+            self.tick_label.setText(str(tick))
+            if hasattr(self, "depth_label"):
+                self.depth_label.setText(str(frame.depth))
+            if hasattr(self, "window_label"):
+                self.window_label.setText(str(frame.window))
+            model_dict = get_graph().to_dict()
+        else:
+            model_dict = (
+                tick_engine.graph.to_dict() if running else get_graph().to_dict()
+            )
+            self.tick_label.setText(str(tick))
         self.sim_canvas.load_model(GraphModel.from_dict(model_dict))
         if not running:
             self.start_button.setEnabled(get_active_file() is not None)
@@ -361,32 +381,61 @@ class MainWindow(QMainWindow):
             strategy = f"modular-{self.modular_combo.currentText()}"
         Config.density_calc = strategy
         Config.max_ticks = self.limit_spin.value()
-        tick_engine.build_graph()
-        with Config.state_lock:
-            if Config.is_running:
-                return
-            Config.is_running = True
-            tick = Config.current_tick
-        tick_engine.simulation_loop()
-        self.start_button.setEnabled(False)
-        self.pause_button.setEnabled(True)
-        self.stop_button.setEnabled(True)
-        tick_engine._update_simulation_state(False, False, tick, None)
+        if getattr(Config, "engine_mode", "tick") == "v2":
+            tick_engine.build_graph(Config.graph_file)
+            with Config.state_lock:
+                if Config.is_running:
+                    return
+                Config.is_running = True
+                Config.current_tick = 0
+            tick_engine.start()
+            self.start_button.setEnabled(False)
+            self.pause_button.setEnabled(True)
+            self.stop_button.setEnabled(True)
+        else:
+            tick_engine.build_graph()
+            with Config.state_lock:
+                if Config.is_running:
+                    return
+                Config.is_running = True
+                tick = Config.current_tick
+            tick_engine.simulation_loop()
+            self.start_button.setEnabled(False)
+            self.pause_button.setEnabled(True)
+            self.stop_button.setEnabled(True)
+            tick_engine._update_simulation_state(False, False, tick, None)
 
     def pause_or_resume(self) -> None:
         """Toggle between pausing and resuming the simulation."""
         with Config.state_lock:
             running = Config.is_running
-        if running:
-            tick_engine.pause_simulation()
-            self.pause_button.setText("Resume")
+        if getattr(Config, "engine_mode", "tick") == "v2":
+            if running:
+                tick_engine.pause()
+                with Config.state_lock:
+                    Config.is_running = False
+                self.pause_button.setText("Resume")
+            else:
+                tick_engine.start()
+                with Config.state_lock:
+                    Config.is_running = True
+                self.pause_button.setText("Pause")
         else:
-            tick_engine.resume_simulation()
-            self.pause_button.setText("Pause")
+            if running:
+                tick_engine.pause_simulation()
+                self.pause_button.setText("Resume")
+            else:
+                tick_engine.resume_simulation()
+                self.pause_button.setText("Pause")
 
     def stop_simulation(self) -> None:
         """Stop the simulation immediately."""
-        tick_engine.stop_simulation()
+        if getattr(Config, "engine_mode", "tick") == "v2":
+            tick_engine.stop()
+            with Config.state_lock:
+                Config.is_running = False
+        else:
+            tick_engine.stop_simulation()
         self.start_button.setEnabled(get_active_file() is not None)
         self.pause_button.setEnabled(False)
         self.pause_button.setText("Pause")

--- a/Causal_Web/gui_pyside/toolbar_builder.py
+++ b/Causal_Web/gui_pyside/toolbar_builder.py
@@ -44,6 +44,10 @@ EVENT_TYPES = [
     "coherence",
     "phase",
     "region",
+    "EQ",
+    "ρ",
+    "d_eff",
+    "σ",
 ]
 
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ preserve ``cnot_source`` flags and their resulting ``epsilon`` pairings on
 reload.
 The GUI now includes an **Analysis** menu with a *Bell Inequality Analysis...*
 action that opens a window showing CHSH statistics and a histogram of
-expectation values.
+expectation values. Any metadata fields found in `entangled_log.jsonl`, such as
+`mode` or `kappa` parameters, are displayed alongside the CHSH score.
 
 Runs produce a set of JSON logs in `output/`. The script `bundle_run.py` can be used after a simulation to archive the results. Full descriptions of each log file and their fields are available in [docs/log_schemas.md](docs/log_schemas.md).
 

--- a/docs/graph_format.md
+++ b/docs/graph_format.md
@@ -56,7 +56,7 @@ Nodes can optionally set ``allow_self_connection`` to ``true`` to permit self-co
   "observers": [
     {
       "id": "OBS",
-      "monitors": ["collapse", "law_wave", "region"],
+      "monitors": ["collapse", "law_wave", "region", "EQ", "ρ", "d_eff", "σ"],
       "frequency": 1
     }
   ],

--- a/tests/test_chsh_epsilon.py
+++ b/tests/test_chsh_epsilon.py
@@ -71,6 +71,6 @@ def test_chsh_epsilon(tmp_path, monkeypatch):
         )
 
     logger.flush()
-    s, _ = compute_bell_statistics(tmp_path / "entangled_log.jsonl")
+    s, _, _ = compute_bell_statistics(tmp_path / "entangled_log.jsonl")
     assert s > 2.6
 

--- a/tests/test_engine_adapter_api.py
+++ b/tests/test_engine_adapter_api.py
@@ -28,14 +28,17 @@ def test_step_returns_telemetry_frame():
     assert frame.packets and isinstance(frame.packets[0], Packet)
     assert adapter.snapshot_for_ui()["depth"] == frame.depth
     assert adapter.current_depth() == frame.depth
+    assert isinstance(frame.window, int)
+    assert adapter.current_frame() == 1
 
 
 def test_state_data_structures_defaults():
     vertices = VertexArray()
     edges = EdgeArray()
     pkt = Packet(src=1, dst=2, payload={"x": 1})
-    frame = TelemetryFrame(depth=3, events=1, packets=[pkt])
+    frame = TelemetryFrame(depth=3, events=1, packets=[pkt], window=2)
 
     assert vertices.ids == []
     assert edges.ids == []
     assert frame.packets[0].payload == {"x": 1}
+    assert frame.window == 2

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -105,7 +105,7 @@ def bell_score(epsilon: bool, runs: int = 200, seed: int | None = None) -> float
             for i in range(2, runs + 2):
                 emit(i, rng.choice(settings_a), rng.choice(settings_b))
             logger.flush()
-            s_val, _ = compute_bell_statistics(Path(tmp) / "entangled_log.jsonl")
+            s_val, _, _ = compute_bell_statistics(Path(tmp) / "entangled_log.jsonl")
             return s_val
         finally:
             Config.output_dir = original_dir


### PR DESCRIPTION
## Summary
- support step-driven engine v2 in GUI with depth/window display and pause controls
- expose optional Bell metadata in CHSH analysis view
- allow observers to monitor new meters (EQ, ρ, d_eff, σ)

## Testing
- `python -m compileall Causal_Web`
- `pytest`
- `QT_QPA_PLATFORM=offscreen python -m Causal_Web.main` *(fails: JSONDecodeError)*

------
https://chatgpt.com/codex/tasks/task_e_689829561b1c832592f04909e7e47d84