### PR TITLE
Default v2 engine params and SoA graph

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -94,20 +94,20 @@ class Config:
 
     # Parameters for the experimental strict-local engine (``engine_mode = "v2"``)
     windowing = {
-        "W0": 0.0,
-        "zeta1": 0.0,
-        "zeta2": 0.0,
-        "a": 0.0,
-        "b": 0.0,
-        "T_hold": 0.0,
-        "C_min": 0.0,
+        "W0": 4.0,
+        "zeta1": 0.3,
+        "zeta2": 0.3,
+        "a": 0.7,
+        "b": 0.4,
+        "T_hold": 2.0,
+        "C_min": 0.1,
     }
     rho_delay = {
-        "alpha_d": 0.0,
-        "alpha_leak": 0.0,
-        "eta": 0.0,
-        "gamma": 0.0,
-        "rho0": 0.0,
+        "alpha_d": 0.1,
+        "alpha_leak": 0.01,
+        "eta": 0.2,
+        "gamma": 0.8,
+        "rho0": 1.0,
     }
     epsilon_pairs = {
         "delta_ttl": 0,

--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -78,6 +78,9 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
         "fanin": np.zeros(n_vert, dtype=np.int32),
         "ancestry": np.zeros((n_vert, 4), dtype=np.int32),
         "m": np.zeros((n_vert, 3), dtype=np.float32),
+        "rho_mean": np.asarray(
+            [nodes[nid].get("rho_mean", 0.0) for nid in nodes], dtype=np.float32
+        ),
     }
 
     edges_data = graph_json.get("edges", [])

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ advanced controls for the v2 engine.  Each group is a nested mapping:
 ```json
 {
   "engine_mode": "v2",
-  "windowing": {"W0": 2, "zeta1": 0.0, "zeta2": 0.0, "a": 1.0, "b": 0.5,
-                 "T_hold": 1, "C_min": 0.0},
-  "rho_delay": {"alpha_d": 0.0, "alpha_leak": 0.0, "eta": 0.0,
-                "gamma": 0.0, "rho0": 1.0},
+  "windowing": {"W0": 4, "zeta1": 0.3, "zeta2": 0.3, "a": 0.7, "b": 0.4,
+                 "T_hold": 2, "C_min": 0.1},
+  "rho_delay": {"alpha_d": 0.1, "alpha_leak": 0.01, "eta": 0.2,
+                "gamma": 0.8, "rho0": 1.0},
   "epsilon_pairs": {"delta_ttl": 0, "ancestry_prefix_L": 0,
                      "theta_max": 0.0, "sigma0": 0.0,
                      "lambda_decay": 0.0, "sigma_reinforce": 0.0,

--- a/tests/test_adapter_depth_window.py
+++ b/tests/test_adapter_depth_window.py
@@ -5,13 +5,8 @@ from Causal_Web.engine.engine_v2.state import Packet
 def test_run_until_next_window_or_rolls_window():
     graph = {
         "params": {"W0": 2},
-        "vertices": [
-            {
-                "id": 0,
-                "rho_mean": 0.0,
-                "edges": [{"id": 0, "dst": 0, "d_eff": 1}],
-            }
-        ],
+        "nodes": [{"id": "0", "rho_mean": 0.0}],
+        "edges": [{"from": "0", "to": "0", "delay": 1.0}],
     }
 
     adapter = EngineAdapter()
@@ -30,7 +25,7 @@ def test_run_until_next_window_or_rolls_window():
 def test_run_until_next_window_or_no_events():
     """Adapter reports zero depth and events when scheduler is empty."""
 
-    graph = {"vertices": [{"id": 0, "rho_mean": 0.0, "edges": []}]}
+    graph = {"nodes": [{"id": "0", "rho_mean": 0.0}], "edges": []}
 
     adapter = EngineAdapter()
     adapter.build_graph(graph)
@@ -44,7 +39,7 @@ def test_run_until_next_window_or_no_events():
 def test_run_until_next_window_or_single_event():
     """Processing a single event does not advance the depth."""
 
-    graph = {"vertices": [{"id": 0, "rho_mean": 0.0, "edges": []}]}
+    graph = {"nodes": [{"id": "0", "rho_mean": 0.0}], "edges": []}
 
     adapter = EngineAdapter()
     adapter.build_graph(graph)

--- a/tests/test_engine_adapter_api.py
+++ b/tests/test_engine_adapter_api.py
@@ -10,13 +10,8 @@ from Causal_Web.engine.engine_v2.state import (
 def test_step_returns_telemetry_frame():
     graph = {
         "params": {"W0": 2},
-        "vertices": [
-            {
-                "id": 0,
-                "rho_mean": 0.0,
-                "edges": [{"id": 0, "dst": 0, "d_eff": 1}],
-            }
-        ],
+        "nodes": [{"id": "0", "rho_mean": 0.0}],
+        "edges": [{"from": "0", "to": "0", "delay": 1.0}],
     }
     adapter = EngineAdapter()
     adapter.build_graph(graph)


### PR DESCRIPTION
## Summary
- provide safe defaults for v2 windowing and rho-delay parameters
- switch engine v2 adapter to struct-of-arrays graph ingestion and rho-delay scheduling
- stop headless loop at tick_limit and document new defaults

## Testing
- `python -m pip install numpy networkx pytest pydantic`
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main --no-gui --max_ticks 1` *(fails: JSONDecodeError)*
- `python bundle_run.py`


------
https://chatgpt.com/codex/tasks/task_e_6898307377348325814715c5d1cc7a22