### PR TITLE
Wire rho density to effective delays and EQ tracking

### DIFF
--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -151,6 +151,7 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
         "A": np.asarray(edges["A"], dtype=np.float32),
         "U": np.asarray(edges["U"], dtype=np.complex64),
         "sigma": np.asarray(edges["sigma"], dtype=np.float32),
+        "d_eff": np.zeros(n_edge, dtype=np.int32),
     }
 
     return GraphArrays(

--- a/README.md
+++ b/README.md
@@ -190,7 +190,11 @@ Amplitude energy now feeds a stress–energy field that scales edge delay by
 
 The helper ``engine.engine_v2.rho_delay.update_rho_delay`` applies this rule
 per edge, adding leakage and external intensity and mapping the resulting
-density to a logarithmically scaled effective delay.
+density to a logarithmically scaled effective delay. The engine v2 adapter
+recomputes this ``d_eff`` on every packet delivery, storing it with the edge
+and using the updated value to schedule the next hop. When a vertex window
+closes the adapter normalises accumulated amplitudes and records ``EQ`` via
+``engine.engine_v2.qtheta_c.close_window``.
 
 Scheduler steps also integrate a toy horizon thermodynamics model. Interior
 nodes may emit Hawking pairs with probability ``exp(-ΔE/T_H)``, and the

--- a/tests/test_adapter_eq_delay.py
+++ b/tests/test_adapter_eq_delay.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+from Causal_Web.engine.engine_v2.state import Packet
+from Causal_Web.config import Config
+
+
+def build_simple_graph():
+    graph = {
+        "nodes": [
+            {"id": "A", "window_len": 1},
+            {"id": "B", "window_len": 1},
+        ],
+        "edges": [
+            {"from": "A", "to": "B", "delay": 1.0, "density": 0.0},
+        ],
+        "params": {"W0": 1},
+    }
+    return graph
+
+
+def test_rho_to_d_eff_and_eq():
+    Config.rho_delay = {
+        "alpha_d": 0.0,
+        "alpha_leak": 0.0,
+        "eta": 0.0,
+        "gamma": 0.0,
+        "rho0": 1.0,
+    }
+    adapter = EngineAdapter()
+    adapter.build_graph(build_simple_graph())
+    # seed an initial packet to vertex A
+    adapter._scheduler.push(0, 0, 0, Packet(src=-1, dst=0, payload=None))
+    adapter.run_until_next_window_or(None)
+    # d_eff updated on edge
+    arrays = adapter._arrays
+    assert arrays is not None
+    assert int(arrays.edges["d_eff"][0]) == 1
+
+    # process packet delivered to B, triggering window close
+    adapter.run_until_next_window_or(None)
+    eq_val = arrays.vertices["EQ"][1]
+    assert eq_val == 1.0
+    assert np.allclose(arrays.vertices["psi_acc"][1], 0.0)
+    assert adapter._vertices[1]["lccm"]._eq == 1.0


### PR DESCRIPTION
## Summary
- recompute effective edge delay (d_eff) on packet delivery and store with edge data
- accumulate per-vertex amplitude, normalising and updating EQ on window close
- document rho→d_eff and EQ handling and add regression test

## Testing
- `black Causal_Web tests/test_adapter_eq_delay.py`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898323cd2dc832582407b4b3c81ac4f