### PR TITLE
Align Bell ancestry type and simplify scheduler

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -251,7 +251,6 @@ class EngineAdapter:
                         "layer": lccm.layer,
                         "Lambda_v": lccm._lambda,
                         "EQ": lccm._eq,
-                        "E_Theta": lccm.a * (1 - getattr(lccm, "_entropy", 0.0)),
                         "E_C": lccm.b * getattr(lccm, "_bit_fraction", 0.0),
                         "v_id": vid,
                     },

--- a/Causal_Web/engine/engine_v2/bell.py
+++ b/Causal_Web/engine/engine_v2/bell.py
@@ -22,12 +22,12 @@ class Ancestry:
     Parameters
     ----------
     h:
-        Rolling 256-bit hash stored as four ``uint64`` values.
+        Rolling hash stored as four ``int32`` segments.
     m:
         Three dimensional phase-moment vector.
     """
 
-    h: np.ndarray = field(default_factory=lambda: np.zeros(4, dtype=np.uint64))
+    h: np.ndarray = field(default_factory=lambda: np.zeros(4, dtype=np.int32))
     m: np.ndarray = field(default_factory=lambda: np.zeros(3, dtype=float))
 
 

--- a/Causal_Web/engine/engine_v2/scheduler.py
+++ b/Causal_Web/engine/engine_v2/scheduler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from bisect import bisect
 from collections import defaultdict
 import heapq
 from typing import Any, DefaultDict, List, Tuple
@@ -12,11 +11,12 @@ class DepthScheduler:
     """Arrival-depth bucketed priority queue.
 
     Events are grouped into buckets by integer arrival depth.  Each bucket
-    maintains its items ordered by ``(dst_id, edge_id, seq)`` ensuring a
-    deterministic processing order. A separate min-heap tracks which depths are
-    present, so heap operations occur only when a new depth is added or an
-    existing depth bucket becomes empty, yielding amortised :math:`O(1)` push and
-    pop operations for batches sharing the same depth.
+    retains items in the order they are scheduled, keyed by
+    ``(dst_id, edge_id, seq)`` to ensure deterministic processing. A separate
+    min-heap tracks which depths are present, so heap operations occur only when
+    a new depth is added or an existing depth bucket becomes empty, yielding
+    amortised :math:`O(1)` push and pop operations for batches sharing the same
+    depth.
     """
 
     def __init__(self) -> None:
@@ -33,8 +33,8 @@ class DepthScheduler:
         if not bucket:
             heapq.heappush(self._depths, depth_arr)
         key = (dst_id, edge_id, self._seq)
-        idx = bisect(bucket, (key, payload))
-        bucket.insert(idx, (key, payload))
+        bucket.append((key, payload))
+        bucket.sort()
         self._seq += 1
 
     def pop(self) -> Tuple[int, int, int, Any]:


### PR DESCRIPTION
## Summary
- drop unused entropy log in adapter
- store Bell ancestry hash as four int32 values to match loader
- remove unused bisect import and sort scheduler buckets directly

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68983427f90c8325ae7c8dc6e01e4b84