### PR TITLE
Integrate QΘC intensity and window metrics

### DIFF
--- a/Causal_Web/engine/engine_v2/state.py
+++ b/Causal_Web/engine/engine_v2/state.py
@@ -17,6 +17,8 @@ class VertexArray:
     """Struct-of-arrays representation of vertex data."""
 
     ids: list[int] = field(default_factory=list)
+    depth: list[int] = field(default_factory=list)
+    window_idx: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -24,6 +26,8 @@ class EdgeArray:
     """Struct-of-arrays representation of edge data."""
 
     ids: list[int] = field(default_factory=list)
+    src: list[int] = field(default_factory=list)
+    dst: list[int] = field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- route packet deliveries through `deliver_packet` to accumulate Q/Θ/C state and drive rho delay with intensity
- record per-vertex metrics and emit normalized EQ, E_Θ and E_C on window close
- flesh out engine v2 state containers with minimal fields

## Testing
- `pip install numpy networkx pytest pydantic`
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68983c478d2483258e82cf01e195fbf2