### PR TITLE
Seed RNG for deterministic runs and refine edge logging

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -80,6 +80,7 @@ class Config:
     tick_limit = 10000
     allow_tick_override = True
     current_tick = 0  # Counter to display progress
+    run_seed = 0  # Seed for reproducible runs
     # Preallocated ticks for object pool
     TICK_POOL_SIZE = 10000
     N_DECOH = 3  # Fan-in threshold for thermodynamic behaviour

--- a/Causal_Web/engine/engine_v2/epairs.py
+++ b/Causal_Web/engine/engine_v2/epairs.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Tuple
 
+import numpy as np
+
 
 @dataclass
 class Seed:
@@ -62,7 +64,8 @@ class EPairs:
         Mapping of ``(a, b)`` node id pairs to :class:`Bridge` objects.
 
     Parameters are supplied on construction to avoid global state and to
-    make the component easy to test.
+    make the component easy to test. A ``seed`` may be provided for
+    deterministic behaviour in routines that rely on randomness.
     """
 
     def __init__(
@@ -74,6 +77,7 @@ class EPairs:
         lambda_decay: float,
         sigma_reinforce: float,
         sigma_min: float,
+        seed: int | None = None,
     ) -> None:
         self.delta_ttl = delta_ttl
         self.L = ancestry_prefix_L
@@ -84,6 +88,7 @@ class EPairs:
         self.sigma_min = sigma_min
         self.seeds: Dict[int, List[Seed]] = {}
         self.bridges: Dict[Tuple[int, int], Bridge] = {}
+        self._rng = np.random.default_rng(seed)
 
     # ------------------------------------------------------------------
     # seed handling

--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -141,17 +141,18 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
         "nbr_idx": np.asarray(nbr_idx, dtype=np.int32),
     }
 
+    d0_arr = np.asarray(edges["d0"], dtype=np.float32)
     edges = {
         "src": np.asarray(edges["src"], dtype=np.int32),
         "dst": np.asarray(edges["dst"], dtype=np.int32),
-        "d0": np.asarray(edges["d0"], dtype=np.float32),
+        "d0": d0_arr,
         "rho": np.asarray(edges["rho"], dtype=np.float32),
         "alpha": np.asarray(edges["alpha"], dtype=np.float32),
         "phi": np.asarray(edges["phi"], dtype=np.float32),
         "A": np.asarray(edges["A"], dtype=np.float32),
         "U": np.asarray(edges["U"], dtype=np.complex64),
         "sigma": np.asarray(edges["sigma"], dtype=np.float32),
-        "d_eff": np.zeros(n_edge, dtype=np.int32),
+        "d_eff": np.maximum(1, np.round(d0_arr)).astype(np.int32),
     }
 
     return GraphArrays(

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Engine v2 stores graph data in a struct-of-arrays format using `float32` and
 `complex64` types and batches deliveries by destination to vectorise quantum
 accumulation. A bucketed scheduler keyed by integer depth reduces heap
 operations to amortised *O*(1) and delivery logs may be sampled via
-`Config.log_delivery_sample_rate` to reduce I/O overhead.
-Edge hops can also be throttled by setting
-`Config.logging.sample_edge_rate` (0.0–1.0) which records only a
-fraction of per-hop `edge_delivery` events.
+`Config.log_delivery_sample_rate` to reduce I/O overhead. Edge hops can
+also be throttled by setting `Config.logging.sample_edge_rate`
+(0.0–1.0) which records only a fraction of per-hop `edge_delivery`
+events; a value of `0.0` disables per-edge logs while still emitting a
+per-window summary of edge activity.
 
 To cap memory growth for long coherent lines, the engine detects tensor clusters
 and represents them as Matrix Product States. Local edge unitaries contract with
@@ -154,6 +155,9 @@ how edge density relaxes toward a baseline. `epsilon_pairs` governs dynamic
 ε-pair behaviour – seeds with a limited TTL can bind to form temporary bridge
 edges whose `sigma` values decay unless reinforced – while `bell` sets mutual
 information gates for Bell pair matching.
+
+`run_seed` provides a deterministic seed used by sampling, Bell helpers and
+ε-pair routines, allowing reproducible runs.
 
 An adapter in ``engine_v2`` mirrors a subset of the legacy tick engine API and
 generates *synthetic telemetry frames* so the GUI can tick while the new


### PR DESCRIPTION
## Summary
- add `Config.run_seed` and propagate deterministic seeds to adapter, Bell helpers, and ε-pair manager
- correct layer transition reason labels and gate edge delivery logging behind sampling rate with per-window summaries
- initialise `d_eff` from edge delay and document new controls

## Testing
- `pip install numpy networkx pytest pydantic`
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689849ce7c748325b176eea52a2fd805