### PR TITLE
Implement dynamic ε-pair bridges and configurable Bell measurements

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -120,6 +120,7 @@ class Config:
         "sigma_min": 0.0,
     }
     bell = {
+        "enabled": False,
         "mi_mode": "MI_strict",
         "kappa_a": 0.0,
         "kappa_xi": 0.0,

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ advanced controls for the v2 engine.  Each group is a nested mapping:
                      "theta_max": 0.0, "sigma0": 0.0,
                      "lambda_decay": 0.0, "sigma_reinforce": 0.0,
                      "sigma_min": 0.0},
-  "bell": {"mi_mode": "MI_strict", "kappa_a": 0.0, "kappa_xi": 0.0,
-            "beta_m": 0.0, "beta_h": 0.0}
+  "bell": {"enabled": false, "mi_mode": "MI_strict", "kappa_a": 0.0,
+            "kappa_xi": 0.0, "beta_m": 0.0, "beta_h": 0.0}
 }
 ```
 
@@ -154,7 +154,8 @@ The `windowing` values control vertex window advancement. `rho_delay` affects
 how edge density relaxes toward a baseline. `epsilon_pairs` governs dynamic
 ε-pair behaviour – seeds with a limited TTL can bind to form temporary bridge
 edges whose `sigma` values decay unless reinforced – while `bell` sets mutual
-information gates for Bell pair matching.
+information gates for Bell pair matching. The Bell block is disabled by default;
+set `"enabled": true` to activate measurement-interaction modes.
 
 `run_seed` provides a deterministic seed used by sampling, Bell helpers and
 ε-pair routines, allowing reproducible runs.

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -22,17 +22,22 @@ def test_seed_binding_creates_bridge():
     mgr.emit(origin=2, h_value=0b1101_0001, theta=0.15, neighbours=[3])
     assert (1, 2) in mgr.bridges
     assert mgr.bridges[(1, 2)].sigma == 1.0
+    assert 2 in mgr.adjacency.get(1, [])
+    assert 1 in mgr.adjacency.get(2, [])
 
 
 def test_bridge_reinforcement_and_decay():
     mgr = _make_manager()
-    mgr.bridges[(1, 2)] = Bridge(0.05)
+    mgr.bridges[(1, 2)] = Bridge(0.3)
+    mgr.adjacency[1] = [2]
+    mgr.adjacency[2] = [1]
+    mgr.decay_all()
     mgr.reinforce(1, 2)
-    # sigma: (1-0.5)*0.05 + 0.2 = 0.225 > sigma_min -> bridge persists
-    assert mgr.bridges[(1, 2)].sigma == (1 - 0.5) * 0.05 + 0.2
+    # sigma: (1-0.5)*0.3 + 0.2 = 0.35 > sigma_min -> bridge persists
+    assert mgr.bridges[(1, 2)].sigma == (1 - 0.5) * 0.3 + 0.2
     # decay below minimum removes the bridge
     mgr.lambda_decay = 0.8
     mgr.sigma_reinforce = 0.0
-    mgr.reinforce(1, 2)
+    mgr.decay_all()
     assert (1, 2) not in mgr.bridges
 


### PR DESCRIPTION
## Summary
- Track ε-pair bridges in an adjacency list, add decay step, and reinforce when traversed
- Schedule packets across transient bridges and log their sigma
- Add toggleable Bell experiment block controlled by `bell.enabled`
- Update configuration defaults, documentation and tests accordingly

## Testing
- `pip install numpy networkx pytest pydantic`
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main` *(fails: JSONDecodeError)*
- `python bundle_run.py`


------
https://chatgpt.com/codex/tasks/task_e_68984c69b60c832596dbe36782a3052d