### PR TITLE
Assign stable bridge IDs and configurable theta reset

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -46,6 +46,11 @@ class Config:
         Mutual information gate parameters for Bell pair matching. Supported
         keys include ``mi_mode``, ``kappa_a``, ``kappa_xi``, ``beta_m`` and
         ``beta_h``.
+    theta_reset:
+        Policy controlling how the Θ distribution ``p_v`` is reset when a
+        vertex window closes. Supported values are ``"uniform"`` to reset to
+        an even distribution, ``"renorm"`` to normalise the existing values
+        and ``"hold"`` to leave the distribution untouched.
     """
 
     # Base directories for package resources
@@ -127,6 +132,9 @@ class Config:
         "beta_m": 0.0,
         "beta_h": 0.0,
     }
+
+    #: Reset policy for Θ distribution after window closure
+    theta_reset = "uniform"
 
     #: Logging related settings used by the experimental engine.
     logging = {

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -68,6 +68,7 @@
         "beta_m": 0.0,
         "beta_h": 0.0,
     },
+    "theta_reset": "uniform",
     "propagation_control": {
         "enable_sip_child": true,
         "enable_sip_recomb": true,

--- a/README.md
+++ b/README.md
@@ -202,7 +202,10 @@ density to a logarithmically scaled effective delay. The engine v2 adapter
 recomputes this ``d_eff`` on every packet delivery, storing it with the edge
 and using the updated value to schedule the next hop. When a vertex window
 closes the adapter normalises accumulated amplitudes and records ``EQ`` via
-``engine.engine_v2.qtheta_c.close_window``.
+``engine.engine_v2.qtheta_c.close_window``. The post-window Θ distribution
+reset policy is governed by ``Config.theta_reset`` which accepts ``"uniform"``
+for an even reset, ``"renorm"`` to normalise existing values or ``"hold"`` to
+leave the distribution unchanged.
 
 Scheduler steps also integrate a toy horizon thermodynamics model. Interior
 nodes may emit Hawking pairs with probability ``exp(-ΔE/T_H)``, and the

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -21,7 +21,9 @@ def test_seed_binding_creates_bridge():
     mgr.emit(origin=1, h_value=0b1101_1110, theta=0.10, neighbours=[3])
     mgr.emit(origin=2, h_value=0b1101_0001, theta=0.15, neighbours=[3])
     assert (1, 2) in mgr.bridges
-    assert mgr.bridges[(1, 2)].sigma == 1.0
+    bridge = mgr.bridges[(1, 2)]
+    assert bridge.sigma == 1.0
+    assert bridge.edge_id < 0
     assert 2 in mgr.adjacency.get(1, [])
     assert 1 in mgr.adjacency.get(2, [])
 

--- a/tests/test_theta_reset_policy.py
+++ b/tests/test_theta_reset_policy.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from Causal_Web.config import Config
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+from Causal_Web.engine.engine_v2.state import Packet
+
+
+def _run_policy(policy: str) -> np.ndarray:
+    original_theta = Config.theta_reset
+    original_windowing = Config.windowing.copy()
+    try:
+        Config.theta_reset = policy
+        Config.windowing["W0"] = 2
+        Config.windowing["Dp"] = 2
+        graph = {
+            "params": {"W0": 2},
+            "nodes": [{"id": "0", "rho_mean": 0.0}],
+            "edges": [{"from": "0", "to": "0", "delay": 1.0}],
+        }
+        adapter = EngineAdapter()
+        adapter.build_graph(graph)
+        payload = {"p": np.array([1.0, 0.0], dtype=np.float32)}
+        adapter._scheduler.push(0, 0, 0, Packet(src=0, dst=0, payload=payload))
+        adapter.run_until_next_window_or(limit=10)
+        return adapter._vertices[0]["p_v"].copy()
+    finally:
+        Config.theta_reset = original_theta
+        Config.windowing = original_windowing
+
+
+def test_theta_reset_uniform():
+    p_final = _run_policy("uniform")
+    assert np.allclose(p_final, [0.5, 0.5])
+
+
+def test_theta_reset_hold():
+    p_final = _run_policy("hold")
+    assert np.allclose(p_final, [0.75, 0.25])
+
+
+def test_theta_reset_renorm():
+    p_final = _run_policy("renorm")
+    assert np.allclose(p_final, [0.75, 0.25])


### PR DESCRIPTION
## Summary
- allocate synthetic negative IDs for dynamic bridges to preserve deterministic ordering
- add `theta_reset` policy to control post-window Θ distribution
- document and test new options
- clarify documentation on bridge `edge_id` allocation and lifetime stability

## Testing
- `pip install numpy networkx pytest pydantic`
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main --no-gui --max_ticks 1 --config /tmp/minconfig.json`
- `python bundle_run.py`


------
https://chatgpt.com/codex/tasks/task_e_689853175f508325b91eda087a0851ba