### PR TITLE
Log EPairs bridge lifecycle events and assign stable IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ The `windowing` values control vertex window advancement. `rho_delay` affects
 how edge density relaxes toward a baseline. `epsilon_pairs` governs dynamic
 ε-pair behaviour – seeds with a limited TTL can bind to form temporary bridge
 edges whose `sigma` values decay unless reinforced – while `bell` sets mutual
-information gates for Bell pair matching. The Bell block is disabled by default;
+information gates for Bell pair matching. Bridge creation and removal now emit
+`bridge_created` and `bridge_removed` events (carrying a stable synthetic
+`bridge_id` and final `σ`), providing additional telemetry for analysis. The
+Bell block is disabled by default;
 set `"enabled": true` to activate measurement-interaction modes.
 
 `run_seed` provides a deterministic seed used by sampling, Bell helpers and


### PR DESCRIPTION
## Summary
- log bridge creation/removal events in EPairs with source, dest, sigma and synthetic ID
- allocate stable negative IDs for EPairs bridges until removal
- document bridge events in README and test lifecycle events and ID stability

## Testing
- `black Causal_Web/engine/engine_v2/epairs.py tests/test_epairs_dynamic.py`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`
- `python -m Causal_Web.main` *(fails: JSONDecodeError: Expecting property name enclosed in double quotes: line 9 column 5 (char 254))*
- `python bundle_run.py`


------
https://chatgpt.com/codex/tasks/task_e_68997d803c9c83259d3da8f051b56d45