### PR TITLE
Implement seed TTL propagation across hops

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -369,6 +369,7 @@ class EngineAdapter:
                 h_val = int.from_bytes(ancestry_arr.tobytes(), "little")
                 neigh = [int(edges["dst"][e]) for e in self._edges_by_src.get(dst, [])]
                 theta = float(np.angle(self._arrays.vertices["psi"][dst][0]))
+                self._epairs.carry(dst, neigh)
                 self._epairs.emit(dst, h_val, theta, neigh)
 
             if lccm.layer != prev_layer:

--- a/Causal_Web/engine/engine_v2/epairs.py
+++ b/Causal_Web/engine/engine_v2/epairs.py
@@ -133,6 +133,32 @@ class EPairs:
             if seed.ttl > 0:
                 self._place_seed(n, seed)
 
+    def carry(self, site: int, neighbours: Iterable[int]) -> None:
+        """Propagate existing seeds at ``site`` to its neighbours.
+
+        Each hop consumes one unit of TTL. Seeds whose TTL drops to zero
+        or below are discarded. Seeds are removed from ``site`` once they
+        have been carried.
+        """
+
+        seeds = self.seeds.pop(site, [])
+        for seed in seeds:
+            if seed.ttl <= 0:
+                continue
+            ttl = seed.ttl - 1
+            if ttl <= 0:
+                continue
+            for n in neighbours:
+                self._place_seed(
+                    n,
+                    Seed(
+                        origin=seed.origin,
+                        ttl=ttl,
+                        h_prefix=seed.h_prefix,
+                        theta=seed.theta,
+                    ),
+                )
+
     # Internal helpers -------------------------------------------------
 
     def _prefix(self, h_value: int) -> int:

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -75,3 +75,22 @@ def test_bridge_id_stability():
     mgr._remove_bridge(1, 2)
     mgr._create_bridge(1, 2)
     assert mgr.bridges[(1, 2)].edge_id != id1
+
+
+def test_seed_ttl_propagates_and_expires():
+    mgr = EPairs(
+        delta_ttl=3,
+        ancestry_prefix_L=4,
+        theta_max=0.1,
+        sigma0=1.0,
+        lambda_decay=0.5,
+        sigma_reinforce=0.2,
+        sigma_min=0.1,
+    )
+    mgr.emit(origin=1, h_value=0b1101_0000, theta=0.1, neighbours=[2])
+    mgr.carry(2, [3])
+    assert 2 not in mgr.seeds
+    assert mgr.seeds[3][0].ttl == 1
+    mgr.carry(3, [4])
+    assert 3 not in mgr.seeds
+    assert 4 not in mgr.seeds


### PR DESCRIPTION
## Summary
- propagate epsilon-pair seeds across hops with TTL decrement and expiry
- integrate TTL carrying into engine adapter
- add tests covering seed propagation and expiry

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689982957f1483258532c9f5fe601542