### PR TITLE
Implement depth-based ε-pair TTL and logarithmic rho-delay mapping

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -369,8 +369,8 @@ class EngineAdapter:
                 h_val = int.from_bytes(ancestry_arr.tobytes(), "little")
                 neigh = [int(edges["dst"][e]) for e in self._edges_by_src.get(dst, [])]
                 theta = float(np.angle(self._arrays.vertices["psi"][dst][0]))
-                self._epairs.carry(dst, neigh)
-                self._epairs.emit(dst, h_val, theta, neigh)
+                self._epairs.carry(dst, depth_arr, neigh)
+                self._epairs.emit(dst, h_val, theta, depth_arr, neigh)
 
             if lccm.layer != prev_layer:
                 if prev_layer == "Q" and lccm.layer == "Θ":

--- a/Causal_Web/engine/engine_v2/rho_delay.py
+++ b/Causal_Web/engine/engine_v2/rho_delay.py
@@ -30,10 +30,16 @@ def diffuse(rho: List[float], weight: float) -> List[float]:
     return [r + weight * (avg - r) for r in rho]
 
 
-def effective_delay(rho: float, cap: float = 1.0) -> float:
-    """Map density to an effective delay using a simple saturation."""
+def effective_delay(
+    rho: float,
+    *,
+    d0: float,
+    gamma: float,
+    rho0: float,
+) -> float:
+    """Map density to an effective delay using the saturating log rule."""
 
-    return min(rho, cap)
+    return float(max(1, d0 + round(gamma * math.log(1 + rho / rho0))))
 
 
 def update_rho_delay(

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -18,8 +18,8 @@ def _make_manager():
 def test_seed_binding_creates_bridge():
     mgr = _make_manager()
     # Seeds share a 4 bit prefix and close theta values
-    mgr.emit(origin=1, h_value=0b1101_1110, theta=0.10, neighbours=[3])
-    mgr.emit(origin=2, h_value=0b1101_0001, theta=0.15, neighbours=[3])
+    mgr.emit(origin=1, h_value=0b1101_1110, theta=0.10, depth_emit=0, neighbours=[3])
+    mgr.emit(origin=2, h_value=0b1101_0001, theta=0.15, depth_emit=0, neighbours=[3])
     assert (1, 2) in mgr.bridges
     bridge = mgr.bridges[(1, 2)]
     assert bridge.sigma == 1.0
@@ -55,12 +55,18 @@ def test_bridge_lifecycle_events(monkeypatch):
     )
 
     mgr = _make_manager()
-    mgr.emit(origin=1, h_value=0b1101_1110, theta=0.10, neighbours=[3])
-    mgr.emit(origin=2, h_value=0b1101_0001, theta=0.15, neighbours=[3])
-    assert any(lbl == "bridge_created" for lbl, _ in events)
+    mgr.emit(origin=1, h_value=0b1101_1110, theta=0.10, depth_emit=0, neighbours=[3])
+    mgr.emit(origin=2, h_value=0b1101_0001, theta=0.15, depth_emit=0, neighbours=[3])
+    assert any(
+        lbl == "bridge_created" and {"src", "dst", "sigma", "bridge_id"} <= value.keys()
+        for lbl, value in events
+    )
     mgr.lambda_decay = 1.0
     mgr.decay_all()
-    assert any(lbl == "bridge_removed" for lbl, _ in events)
+    assert any(
+        lbl == "bridge_removed" and {"src", "dst", "sigma", "bridge_id"} <= value.keys()
+        for lbl, value in events
+    )
 
 
 def test_bridge_full_lifecycle_removal_event(monkeypatch):
@@ -109,7 +115,7 @@ def test_bridge_id_stability():
 
 def test_seed_ttl_propagates_and_expires():
     mgr = EPairs(
-        delta_ttl=3,
+        delta_ttl=2,
         ancestry_prefix_L=4,
         theta_max=0.1,
         sigma0=1.0,
@@ -117,10 +123,10 @@ def test_seed_ttl_propagates_and_expires():
         sigma_reinforce=0.2,
         sigma_min=0.1,
     )
-    mgr.emit(origin=1, h_value=0b1101_0000, theta=0.1, neighbours=[2])
-    mgr.carry(2, [3])
+    mgr.emit(origin=1, h_value=0b1101_0000, theta=0.1, depth_emit=0, neighbours=[2])
+    mgr.carry(2, depth_curr=1, neighbours=[3])
     assert 2 not in mgr.seeds
-    assert mgr.seeds[3][0].ttl == 1
-    mgr.carry(3, [4])
+    assert mgr.seeds[3][0].expiry_depth == 2
+    mgr.carry(3, depth_curr=2, neighbours=[4])
     assert 3 not in mgr.seeds
     assert 4 not in mgr.seeds

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -120,6 +120,18 @@ def test_gate3_lccm_hysteresis_transitions():
 
 def test_gate4_epairs_locality_ttl_and_decay():
     mgr = EPairs(
+        delta_ttl=0,
+        ancestry_prefix_L=4,
+        theta_max=0.1,
+        sigma0=1.0,
+        lambda_decay=0.5,
+        sigma_reinforce=0.2,
+        sigma_min=0.1,
+    )
+    mgr.emit(origin=1, h_value=0b1101_0000, theta=0.1, depth_emit=0, neighbours=[3])
+    mgr.emit(origin=2, h_value=0b1101_1111, theta=0.1, depth_emit=0, neighbours=[3])
+    assert (1, 2) not in mgr.bridges
+    mgr2 = EPairs(
         delta_ttl=1,
         ancestry_prefix_L=4,
         theta_max=0.1,
@@ -128,20 +140,8 @@ def test_gate4_epairs_locality_ttl_and_decay():
         sigma_reinforce=0.2,
         sigma_min=0.1,
     )
-    mgr.emit(origin=1, h_value=0b1101_0000, theta=0.1, neighbours=[3])
-    mgr.emit(origin=2, h_value=0b1101_1111, theta=0.1, neighbours=[3])
-    assert (1, 2) not in mgr.bridges
-    mgr2 = EPairs(
-        delta_ttl=2,
-        ancestry_prefix_L=4,
-        theta_max=0.1,
-        sigma0=1.0,
-        lambda_decay=0.5,
-        sigma_reinforce=0.2,
-        sigma_min=0.1,
-    )
-    mgr2.emit(origin=1, h_value=0b1101_0000, theta=0.1, neighbours=[3])
-    mgr2.emit(origin=2, h_value=0b1101_1111, theta=0.1, neighbours=[3])
+    mgr2.emit(origin=1, h_value=0b1101_0000, theta=0.1, depth_emit=0, neighbours=[3])
+    mgr2.emit(origin=2, h_value=0b1101_1111, theta=0.1, depth_emit=0, neighbours=[3])
     assert (1, 2) in mgr2.bridges
     mgr2.lambda_decay = 1.0
     mgr2.decay_all()


### PR DESCRIPTION
## Summary
- Carry ε-pair seeds with an expiry depth to enforce depth-based TTL and log bridge lifecycle events with stable IDs
- Map stress–energy density to effective delay using the spec's logarithmic rule instead of simple clipping
- Guard edge delivery logging by sample rate to avoid logging when rate is zero

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68998959a5fc8325850c8abd133216fc