### PR TITLE
Enhance Bell metadata and layer transition logging

### DIFF
--- a/Causal_Web/analysis/bell.py
+++ b/Causal_Web/analysis/bell.py
@@ -49,7 +49,7 @@ def compute_bell_statistics(
                 payload = obj.get("payload") or obj.get("value") or {}
                 if not metadata:
                     for key in [
-                        "mode",
+                        "mi_mode",
                         "kappa_a",
                         "kappa_xi",
                         "h_prefix_len",

--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -342,14 +342,15 @@ class EngineAdapter:
                         value={
                             "setting": a_D.tolist(),
                             "outcome": int(outcome),
-                            "mode": mi_mode,
-                        },
-                        metadata={
+                            "mi_mode": mi_mode,
                             "kappa_a": bell_cfg.get("kappa_a", 0.0),
                             "kappa_xi": bell_cfg.get("kappa_xi", 0.0),
                             "batch_id": self._frame,
-                            **meta,
+                            "h_prefix_len": Config.epsilon_pairs.get(
+                                "ancestry_prefix_L", 0
+                            ),
                         },
+                        metadata={"L": meta.get("L")},
                     )
                     packet_data.setdefault("ancestry", ancestry_arr)
                     packet_data.setdefault("m", m_arr)
@@ -379,6 +380,15 @@ class EngineAdapter:
                     reason = "recoh_threshold"
                 else:
                     reason = "layer_change"
+                if self._arrays is not None:
+                    p_v = vertex["p_v"]
+                    H_pv = (
+                        float(-(p_v * np.log2(p_v + 1e-12)).sum()) if p_v.size else 0.0
+                    )
+                    EQ = float(self._arrays.vertices["EQ"][dst])
+                else:
+                    H_pv = 0.0
+                    EQ = lccm._eq
                 log_record(
                     category="event",
                     label="layer_transition",
@@ -390,6 +400,8 @@ class EngineAdapter:
                         "reason": reason,
                         "window_idx": lccm.window_idx,
                         "Lambda_v": lccm._lambda,
+                        "EQ": EQ,
+                        "H_p": H_pv,
                     },
                 )
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ reload.
 The GUI now includes an **Analysis** menu with a *Bell Inequality Analysis...*
 action that opens a window showing CHSH statistics and a histogram of
 expectation values. Any metadata fields found in `entangled_log.jsonl`, such as
-`mode` or `kappa` parameters, are displayed alongside the CHSH score.
+`mi_mode`, `kappa_a`, `kappa_xi`, `batch_id` or `h_prefix_len`, are displayed
+alongside the CHSH score.
 
 Runs produce a set of JSON logs in `output/`. The script `bundle_run.py` can be used after a simulation to archive the results. Full descriptions of each log file and their fields are available in [docs/log_schemas.md](docs/log_schemas.md).
 

--- a/docs/log_schemas.md
+++ b/docs/log_schemas.md
@@ -207,7 +207,8 @@ The following lists describe the JSON keys recorded in each output file.
 - keyed by tick mapping nodes to stabilised law-wave frequencies.
 
 #### `layer_transition_log.json`
-- `tick`, `node`, source `from` layer, destination `to` layer and `trace_id`.
+- `tick`, `node`, source `from` layer, destination `to` layer, `reason`,
+  `window_idx`, `Lambda_v`, `EQ` and `H_p`.
 
 #### `layer_transition_events.json`
 - counts of layer transitions summarised as
@@ -241,8 +242,8 @@ The following lists describe the JSON keys recorded in each output file.
 #### `entangled_measurement.json`
 - event-driven record with `tick_id`, `observer_id`, `entangled_id`,
   `measurement_setting` and `binary_outcome` for each detected entangled tick.
-- optional fields: `mode`, `kappa_a`, `kappa_xi`, `h_prefix_len`,
-  `delta_ttl`, `batch_id`, `setting`, `outcome`.
+- optional fields: `mi_mode`, `kappa_a`, `kappa_xi`, `h_prefix_len`,
+  `batch_id`, `delta_ttl`, `setting`, `outcome`.
 
 #### `entangled_log.jsonl`
 - JSON lines file capturing entangled tick activity. `label` values include


### PR DESCRIPTION
## Summary
- Attach batch, measurement mode, kappa values and ancestry prefix length to entangled measurement logs for easier CHSH analysis
- Record EQ and Θ entropy alongside Λ_v during layer transitions
- Document θ reset policy toggle and new telemetry fields

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a00e6275c832580c2683d237d1423