### PR TITLE
Add deterministic scheduler test and optimize batch handling

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -244,17 +244,35 @@ class EngineAdapter:
                 self._scheduler.push(*item)
 
             if len(pkt_list) > 1:
+                psi_list: list[Any] = []
+                p_list: list[Any] = []
+                bit_list: list[Any] = []
+                depth_list: list[int] = []
+                for pd in packet_list:
+                    psi_list.append(pd["psi"])
+                    p_list.append(pd["p"])
+                    bit_list.append(pd["bit"])
+                    depth_list.append(pd["depth_arr"])
                 packets_struct = {
-                    "psi": [pd["psi"] for pd in packet_list],
-                    "p": [pd["p"] for pd in packet_list],
-                    "bit": [pd["bit"] for pd in packet_list],
-                    "depth_arr": [pd["depth_arr"] for pd in packet_list],
+                    "psi": psi_list,
+                    "p": p_list,
+                    "bit": bit_list,
+                    "depth_arr": depth_list,
                 }
+                alpha_list: list[float] = []
+                phi_list: list[float] = []
+                A_list: list[float] = []
+                U_list: list[Any] = []
+                for ep in edge_list:
+                    alpha_list.append(ep["alpha"])
+                    phi_list.append(ep["phi"])
+                    A_list.append(ep["A"])
+                    U_list.append(ep["U"])
                 edges_struct = {
-                    "alpha": [ep["alpha"] for ep in edge_list],
-                    "phi": [ep["phi"] for ep in edge_list],
-                    "A": [ep["A"] for ep in edge_list],
-                    "U": [ep["U"] for ep in edge_list],
+                    "alpha": alpha_list,
+                    "phi": phi_list,
+                    "A": A_list,
+                    "U": U_list,
                 }
                 depth_v, psi_acc, p_v, (bit, conf), intensity = deliver_packets_batch(
                     lccm.depth,

--- a/tests/test_depth_scheduler.py
+++ b/tests/test_depth_scheduler.py
@@ -52,3 +52,18 @@ def test_scheduler_same_dst_edge_seq_order():
         popped.append((dst, edge, pkt.payload))
 
     assert popped == [(1, 1, "b"), (1, 1, "c"), (1, 2, "a")]
+
+
+def test_scheduler_two_packet_edge_order():
+    """Ensure deterministic ordering for identical depths and destinations."""
+
+    sched = DepthScheduler()
+    sched.push(5, 1, 2, Packet(0, 0))
+    sched.push(5, 1, 1, Packet(0, 0))
+
+    popped = []
+    while sched:
+        depth, dst, edge, pkt = sched.pop()
+        popped.append((dst, edge))
+
+    assert popped == [(1, 1), (1, 2)]


### PR DESCRIPTION
## Summary
- add unit test verifying scheduler pops packets with same depth/destination in edge ID order
- streamline adapter's batch preparation using pre-built packet/edge lists to reduce Python overhead

## Testing
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a03aab104832594c5de817cb753bd