### PR TITLE
Use edge delays for seeds and bridge hops

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ Amplitude energy now feeds a stress–energy field that scales edge delay by
 ``Config.density_diffusion_weight`` (``α``).
 
 The helper ``engine.engine_v2.rho_delay.update_rho_delay`` applies this rule
-per edge, adding leakage and external intensity and mapping the resulting
-density to a logarithmically scaled effective delay. The engine v2 adapter
+per edge, adding leakage and layer-scoped external intensity and mapping the
+resulting density to a logarithmically scaled effective delay. The engine v2 adapter
 recomputes this ``d_eff`` on every packet delivery, storing it with the edge
 and using the updated value to schedule the next hop. When a vertex window
 closes the adapter normalises accumulated amplitudes and records ``EQ`` via

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -128,8 +128,23 @@ def test_gate4_epairs_locality_ttl_and_decay():
         sigma_reinforce=0.2,
         sigma_min=0.1,
     )
-    mgr.emit(origin=1, h_value=0b1101_0000, theta=0.1, depth_emit=0, neighbours=[3])
-    mgr.emit(origin=2, h_value=0b1101_1111, theta=0.1, depth_emit=0, neighbours=[3])
+    edges = {"dst": [3], "d_eff": [1]}
+    mgr.emit(
+        origin=1,
+        h_value=0b1101_0000,
+        theta=0.1,
+        depth_emit=0,
+        edge_ids=[0],
+        edges=edges,
+    )
+    mgr.emit(
+        origin=2,
+        h_value=0b1101_1111,
+        theta=0.1,
+        depth_emit=0,
+        edge_ids=[0],
+        edges=edges,
+    )
     assert (1, 2) not in mgr.bridges
     mgr2 = EPairs(
         delta_ttl=1,
@@ -140,8 +155,22 @@ def test_gate4_epairs_locality_ttl_and_decay():
         sigma_reinforce=0.2,
         sigma_min=0.1,
     )
-    mgr2.emit(origin=1, h_value=0b1101_0000, theta=0.1, depth_emit=0, neighbours=[3])
-    mgr2.emit(origin=2, h_value=0b1101_1111, theta=0.1, depth_emit=0, neighbours=[3])
+    mgr2.emit(
+        origin=1,
+        h_value=0b1101_0000,
+        theta=0.1,
+        depth_emit=0,
+        edge_ids=[0],
+        edges=edges,
+    )
+    mgr2.emit(
+        origin=2,
+        h_value=0b1101_1111,
+        theta=0.1,
+        depth_emit=0,
+        edge_ids=[0],
+        edges=edges,
+    )
     assert (1, 2) in mgr2.bridges
     mgr2.lambda_decay = 1.0
     mgr2.decay_all()
@@ -155,7 +184,7 @@ def _energy_total():
     packet = {"psi": np.array([1, 0], np.complex64), "p": [0.4, 0.6], "bit": 1}
     edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": np.eye(2, dtype=np.complex64)}
     depth, psi_acc, p_v, (bit, conf), intensity = deliver_packet(
-        0, psi_acc, p_v, bit_deque, packet, edge
+        0, psi_acc, p_v, bit_deque, packet, edge, "Q"
     )
     psi, EQ = close_window(psi_acc)
     H_pv = float(-(p_v * np.log2(p_v + 1e-12)).sum())

--- a/tests/test_qtheta_c.py
+++ b/tests/test_qtheta_c.py
@@ -16,7 +16,7 @@ def test_deliver_packet_updates_fields():
     }
 
     depth, psi_acc, p_v, (bit, conf), intensity = deliver_packet(
-        depth, psi_acc, p_v, bits, packet, edge
+        depth, psi_acc, p_v, bits, packet, edge, "Q"
     )
 
     assert depth == 2


### PR DESCRIPTION
## Summary
- respect per-edge `d_eff` when emitting and carrying ε-pair seeds
- track bridge traversal delay and use it when scheduling packets
- compute ρ-injection intensity from the active layer only

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a29cce370832586bcfb640ed2fcad