### PR TITLE
Expose explicit ancestry fields and deterministic hashing

### DIFF
--- a/Causal_Web/engine/engine_v2/epairs.py
+++ b/Causal_Web/engine/engine_v2/epairs.py
@@ -227,8 +227,7 @@ class EPairs:
     def _prefix(self, h_value: int) -> int:
         if self.L <= 0:
             return 0
-        shift = max(0, h_value.bit_length() - self.L)
-        return h_value >> shift
+        return (h_value >> (64 - self.L)) & ((1 << self.L) - 1)
 
     def _place_seed(self, site: int, seed: Seed) -> None:
         seeds = self.seeds.setdefault(site, [])

--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ Bridge propagation now occurs before observers handle a tick so detector events
 reflect entangled activity in the same cycle.
 These detector events are additionally written to `entangled_log.jsonl` for
 Bell inequality analysis.
-The underlying Bell helpers now track 256-bit ancestry fields and allow
-detector settings to be drawn either strictly independently or from a
-von Mises–Fisher distribution conditioned on shared ancestry.  This
-toggle enables controlled measurement dependence studies.
+The underlying Bell helpers now track explicit 256-bit ancestry hash lanes
+(`h0`–`h3`) and a three-component moment vector (`m0`–`m2`) with an
+associated normalisation (`m_norm`). Detector settings can be drawn either
+strictly independently or from a von Mises–Fisher distribution conditioned on
+shared ancestry.  This toggle enables controlled measurement dependence
+studies.
 Graphs may also define ``epsilon`` edges linking two nodes in a singlet state.
 When one node collapses, its ``epsilon`` partner is projected onto the opposite
 eigenvector, enabling Bell-test correlations without a bridge. Collapse now

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -25,7 +25,7 @@ def test_seed_binding_creates_bridge():
     edges = {"dst": [3], "d_eff": [1]}
     mgr.emit(
         origin=1,
-        h_value=0b1101_1110,
+        h_value=0xD00000000000000E,
         theta=0.10,
         depth_emit=0,
         edge_ids=[0],
@@ -33,7 +33,7 @@ def test_seed_binding_creates_bridge():
     )
     mgr.emit(
         origin=2,
-        h_value=0b1101_0001,
+        h_value=0xD000000000000001,
         theta=0.15,
         depth_emit=0,
         edge_ids=[0],
@@ -77,7 +77,7 @@ def test_bridge_lifecycle_events(monkeypatch):
     edges = {"dst": [3], "d_eff": [1]}
     mgr.emit(
         origin=1,
-        h_value=0b1101_1110,
+        h_value=0xD00000000000000E,
         theta=0.10,
         depth_emit=0,
         edge_ids=[0],
@@ -85,7 +85,7 @@ def test_bridge_lifecycle_events(monkeypatch):
     )
     mgr.emit(
         origin=2,
-        h_value=0b1101_0001,
+        h_value=0xD000000000000001,
         theta=0.15,
         depth_emit=0,
         edge_ids=[0],
@@ -160,7 +160,7 @@ def test_seed_ttl_propagates_and_expires():
     edges = {"dst": [2, 3, 4], "d_eff": [1, 1, 1]}
     mgr.emit(
         origin=1,
-        h_value=0b1101_0000,
+        h_value=0xD000000000000000,
         theta=0.1,
         depth_emit=0,
         edge_ids=[0],
@@ -179,7 +179,7 @@ def test_seed_expires_with_large_d_eff():
     edges = {"dst": [2], "d_eff": [5]}
     mgr.emit(
         origin=1,
-        h_value=0b1101_0000,
+        h_value=0xD000000000000000,
         theta=0.1,
         depth_emit=0,
         edge_ids=[0],
@@ -212,7 +212,7 @@ def test_seed_logging(monkeypatch):
     edges1 = {"dst": [2], "d_eff": [1]}
     mgr.emit(
         origin=1,
-        h_value=0b1101_0000,
+        h_value=0xD000000000000000,
         theta=0.0,
         depth_emit=0,
         edge_ids=[0],
@@ -225,7 +225,7 @@ def test_seed_logging(monkeypatch):
     edges3 = {"dst": [5], "d_eff": [1]}
     mgr.emit(
         origin=4,
-        h_value=0b1111_0000,
+        h_value=0xF000000000000000,
         theta=0.0,
         depth_emit=0,
         edge_ids=[0],
@@ -233,7 +233,7 @@ def test_seed_logging(monkeypatch):
     )
     mgr.emit(
         origin=5,
-        h_value=0b0000_0000,
+        h_value=0x0000000000000000,
         theta=0.0,
         depth_emit=0,
         edge_ids=[0],
@@ -244,7 +244,7 @@ def test_seed_logging(monkeypatch):
     edges4 = {"dst": [7], "d_eff": [1]}
     mgr.emit(
         origin=6,
-        h_value=0b1010_0000,
+        h_value=0xA000000000000000,
         theta=0.0,
         depth_emit=0,
         edge_ids=[0],
@@ -252,7 +252,7 @@ def test_seed_logging(monkeypatch):
     )
     mgr.emit(
         origin=7,
-        h_value=0b1010_1111,
+        h_value=0xA00000000000000F,
         theta=1.0,
         depth_emit=0,
         edge_ids=[0],


### PR DESCRIPTION
## Summary
- store ancestry as explicit `h0`–`h3` lanes and `m0`–`m2` moment with norm
- deterministically update ancestry using local phase statistics and splitmix64
- derive ε-pair prefixes from the MSBs of `h0` and adjust tests/README

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3a8dfb40832596df2239638750cf