### PR TITLE
Estimate bridge delays from incident edge latencies

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -8,7 +8,7 @@ according to the local causal consistency math.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from collections import deque
 import threading
 import time
@@ -174,6 +174,17 @@ class EngineAdapter:
         self._vertices.clear()
         edges = self._arrays.edges
         n_vert = len(self._arrays.vertices["depth"])
+
+        incident: Dict[int, List[int]] = {vid: [] for vid in range(n_vert)}
+        for idx in range(len(edges["src"])):
+            s = int(edges["src"][idx])
+            d = int(edges["dst"][idx])
+            d_eff = int(edges["d_eff"][idx]) if "d_eff" in edges else 1
+            incident[s].append(d_eff)
+            incident[d].append(d_eff)
+
+        self._epairs.set_incident_delays(incident)
+
         for vid in range(n_vert):
             out_idx = np.where(edges["src"] == vid)[0]
             in_idx = np.where(edges["dst"] == vid)[0]


### PR DESCRIPTION
## Summary
- derive bridge traversal delay from median effective delay of edges incident to its endpoints
- supply EPairs with per-vertex incident delays during graph build

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a410874908325b48d0ebcf45b8cd9