### PR TITLE
Fix layer-specific intensity and ancestry updates

### DIFF
--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -184,8 +184,8 @@ def _energy_total():
     bit_deque: deque[int] = deque()
     packet = {"psi": np.array([1, 0], np.complex64), "p": [0.4, 0.6], "bit": 1}
     edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": np.eye(2, dtype=np.complex64)}
-    depth, psi_acc, p_v, (bit, conf), intensity = deliver_packet(
-        0, psi_acc, p_v, bit_deque, packet, edge, "Q"
+    depth, psi_acc, p_v, (bit, conf), intensities = deliver_packet(
+        0, psi_acc, p_v, bit_deque, packet, edge
     )
     psi, EQ = close_window(psi_acc)
     H_pv = float(-(p_v * np.log2(p_v + 1e-12)).sum())

--- a/tests/test_qtheta_c.py
+++ b/tests/test_qtheta_c.py
@@ -16,14 +16,14 @@ def test_deliver_packet_updates_fields():
         "U": [[1.0, 0.0], [0.0, 1.0]],
     }
 
-    depth, psi_acc, p_v, (bit, conf), intensity = deliver_packet(
-        depth, psi_acc, p_v, bits, packet, edge, "Q"
+    depth, psi_acc, p_v, (bit, conf), intensities = deliver_packet(
+        depth, psi_acc, p_v, bits, packet, edge
     )
 
     assert depth == 2
     assert np.allclose(p_v, np.array([0.4, 0.6]))
     assert bit == 1 and conf == 1.0
-    assert intensity == 1.0
+    assert intensities[0] == 1.0
 
     psi, EQ = close_window(psi_acc)
     assert np.isclose(EQ, np.vdot(psi_acc, psi_acc).real)
@@ -37,9 +37,8 @@ def test_intensity_theta_layer_ignores_other_contributions():
     packet = {"depth_arr": 1, "psi": [1.0, 0.0], "p": [0.1, 0.2], "bit": 1}
     edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": [[1.0, 0.0], [0.0, 1.0]]}
 
-    _, _, _, _, intensity = deliver_packet(depth, psi_acc, p_v, bits, packet, edge, "Θ")
-
-    assert intensity == pytest.approx(0.3, abs=1e-6)
+    _, _, _, _, intensities = deliver_packet(depth, psi_acc, p_v, bits, packet, edge)
+    assert intensities[1] == pytest.approx(0.3, abs=1e-6)
 
 
 def test_intensity_c_layer_only_counts_bits():
@@ -48,6 +47,5 @@ def test_intensity_c_layer_only_counts_bits():
     packet = {"depth_arr": 1, "psi": [1.0, 0.0], "p": [0.1, 0.2], "bit": 0}
     edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": [[1.0, 0.0], [0.0, 1.0]]}
 
-    _, _, _, _, intensity = deliver_packet(depth, psi_acc, p_v, bits, packet, edge, "C")
-
-    assert intensity == 0.0
+    _, _, _, _, intensities = deliver_packet(depth, psi_acc, p_v, bits, packet, edge)
+    assert intensities[2] == 0.0


### PR DESCRIPTION
## Summary
- compute per-layer intensities in q/θ/c delivery helpers
- update ancestry hash and phase moment only for Q-layer deliveries
- adjust adapter to select intensity by layer after transitions

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a42d6294083258abdf61d43c14c82