### PR TITLE
Refine ε-pair phase and prefix handling

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -51,7 +51,8 @@ class Config:
         Policy controlling how the Θ distribution ``p_v`` is reset when a
         vertex window closes. Supported values are ``"uniform"`` to reset to
         an even distribution, ``"renorm"`` to normalise the existing values
-        and ``"hold"`` to leave the distribution untouched.
+        and ``"hold"`` to leave the distribution untouched. Defaults to
+        ``"renorm"``.
     """
 
     # Base directories for package resources
@@ -135,7 +136,7 @@ class Config:
     }
 
     #: Reset policy for Θ distribution after window closure
-    theta_reset = "uniform"
+    theta_reset = "renorm"
 
     #: Logging related settings used by the experimental engine.
     logging = {

--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -448,7 +448,12 @@ class EngineAdapter:
             U_local = edge_list[0]["U"]
             theta = 0.0
             if lccm.layer == "Q":
-                theta = float(np.angle(psi_local[0])) if len(psi_local) else 0.0
+                if len(psi_local):
+                    phases = np.angle(psi_local)
+                    weights = np.abs(psi_local) ** 2
+                    s = np.einsum("i,i->", weights, np.sin(phases))
+                    c = np.einsum("i,i->", weights, np.cos(phases))
+                    theta = float(np.arctan2(s, c))
                 ancestry_arr, m_arr = self._update_ancestry(
                     dst,
                     edge_id_list[0],

--- a/Causal_Web/engine/engine_v2/epairs.py
+++ b/Causal_Web/engine/engine_v2/epairs.py
@@ -229,9 +229,28 @@ class EPairs:
     # Internal helpers -------------------------------------------------
 
     def _prefix(self, h_value: int) -> int:
+        """Return the first ``L`` MSBs of a 64-bit ancestry lane.
+
+        Parameters
+        ----------
+        h_value:
+            Value of the ``h0`` ancestry lane.  ``h_value`` is cast to
+            ``uint64`` to ensure consistent semantics irrespective of the
+            magnitude of the input integer.
+
+        Returns
+        -------
+        int
+            The ``L``-bit prefix extracted from the most significant bits of
+            ``h_value``.  ``L`` values ``<= 0`` yield ``0``.
+        """
+
         if self.L <= 0:
             return 0
-        return (h_value >> (64 - self.L)) & ((1 << self.L) - 1)
+
+        h0 = np.uint64(h_value)
+        prefix = (h0 >> np.uint64(64 - self.L)) & np.uint64((1 << self.L) - 1)
+        return int(prefix)
 
     def _place_seed(self, site: int, seed: Seed) -> None:
         seeds = self.seeds.setdefault(site, [])

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -68,7 +68,7 @@
         "beta_m": 0.0,
         "beta_h": 0.0,
     },
-    "theta_reset": "uniform",
+    "theta_reset": "renorm",
     "propagation_control": {
         "enable_sip_child": true,
         "enable_sip_recomb": true,

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ advanced controls for the v2 engine.  Each group is a nested mapping:
                      "sigma_min": 0.001},
   "bell": {"enabled": false, "mi_mode": "MI_strict", "kappa_a": 0.0,
             "kappa_xi": 0.0, "beta_m": 0.0, "beta_h": 0.0},
-  "theta_reset": "uniform"
+  "theta_reset": "renorm"
 }
 ```
 
@@ -224,7 +224,7 @@ closes the adapter normalises accumulated amplitudes and records ``EQ`` via
 ``engine.engine_v2.qtheta_c.close_window``. The post-window Θ distribution
 reset policy is governed by ``Config.theta_reset`` which accepts ``"uniform"``
 for an even reset, ``"renorm"`` to normalise existing values or ``"hold"`` to
-leave the distribution unchanged.
+leave the distribution unchanged (default ``"renorm"``).
 
 Scheduler steps also integrate a toy horizon thermodynamics model. Interior
 nodes may emit Hawking pairs with probability ``exp(-ΔE/T_H)``, and the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,3 +112,7 @@ def test_delta_ttl_scales_with_W0(tmp_path):
     finally:
         Config.windowing = original_windowing
         Config.epsilon_pairs = original_epairs
+
+
+def test_theta_reset_default():
+    assert Config.theta_reset == "renorm"

--- a/theory.md
+++ b/theory.md
@@ -198,7 +198,7 @@ $$
 
 where $\bar\rho_v$ is the mean $\rho$ of edges incident to $v$. $W(v)\ge 1$.
 
-* **Θ reset policy:** $\theta_\text{reset}\in\{\text{uniform},\text{renorm},\text{hold}\}$ chooses how $p_v$ is reset when the window closes.
+* **Θ reset policy:** $\theta_\text{reset}\in\{\text{uniform},\text{renorm},\text{hold}\}$ chooses how $p_v$ is reset when the window closes (default $\text{renorm}$).
 
 ## 5.2 Thresholds & timers
 


### PR DESCRIPTION
## Summary
- Ensure ε-pair ancestry prefixes always derive from the MSBs of a 64-bit lane
- Compute ε angle tags from the weighted mean phase of ψ components
- Default Θ reset policy to `renorm` and document available options

## Testing
- `python -m black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a474a90688325b0c7acff5e24127d