### PR TITLE
Reduce churn and clarify meters

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -107,6 +107,8 @@ class Config:
         "zeta2": 0.3,
         "a": 0.7,
         "b": 0.4,
+        "k_theta": 0.7,
+        "k_c": 0.4,
         "T_hold": 2.0,
         "C_min": 0.1,
     }
@@ -143,6 +145,8 @@ class Config:
         # Probability that an individual edge delivery is recorded.
         # A value of 0.0 disables per-edge logs while 1.0 logs all deliveries.
         "sample_edge_rate": 0.0,
+        "sample_seed_rate": 1.0,
+        "sample_bridge_rate": 1.0,
     }
 
     # Mapping of ``category`` -> {``label``: bool} controlling which logs are

--- a/Causal_Web/engine/engine_v2/lccm.py
+++ b/Causal_Web/engine/engine_v2/lccm.py
@@ -23,8 +23,10 @@ class LCCM:
     degree to size the rolling window so that both fan-in and fan-out pressure
     influence window growth.  ``rho_mean`` is the mean local density used in
     ``W(v)`` and ``conf_min`` is the minimum bit-majority confidence required
-    for Θ→C transitions.  The public attributes ``depth``, ``window_idx`` and
-    ``layer`` expose the current state for callers.
+    for Θ→C transitions.  The coefficients ``k_theta`` and ``k_c`` weight the
+    ``E_Θ`` and ``E_C`` meters reported at window closure.  The public
+    attributes ``depth``, ``window_idx`` and ``layer`` expose the current state
+    for callers.
     """
 
     W0: int
@@ -39,6 +41,8 @@ class LCCM:
     H_max: float
     T_hold: int
     T_class: int
+    k_theta: float = 1.0
+    k_c: float = 0.5
     deg: int = 0  # incident degree (in + out) used in W(v)
     rho_mean: float = 0.0
     depth: int = 0

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ also be throttled by setting `Config.logging.sample_edge_rate`
 (0.0–1.0) which records only a fraction of per-hop `edge_delivery`
 events; a value of `0.0` disables per-edge logs while still emitting a
 per-window summary of edge activity.
+Seed and bridge events can be sampled in the same way using
+`Config.logging.sample_seed_rate` and `Config.logging.sample_bridge_rate`.
 
 To cap memory growth for long coherent lines, the engine detects tensor clusters
 and represents them as Matrix Product States. Local edge unitaries contract with

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -50,8 +50,10 @@ def test_seed_binding_creates_bridge():
 def test_bridge_reinforcement_and_decay():
     mgr = _make_manager()
     mgr.bridges[(1, 2)] = Bridge(0.3)
-    mgr.adjacency[1] = [2]
-    mgr.adjacency[2] = [1]
+    from array import array
+
+    mgr.adjacency[1] = array("i", [2])
+    mgr.adjacency[2] = array("i", [1])
     mgr.decay_all()
     mgr.reinforce(1, 2)
     # sigma: (1-0.5)*0.3 + 0.2 = 0.35 > sigma_min -> bridge persists


### PR DESCRIPTION
## Summary
- Preallocate packet and edge buffers in the adapter, caching identity and zero arrays to avoid per-event allocations and using cached partner lists for bridge traversal
- Store ε-pair bridge partners in fixed integer arrays with a free-list and add sampling controls for seed/bridge logs
- Separate k_theta and k_c meter coefficients in configuration/LCCM and document seed/bridge log sampling

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a4a5345c88325872d6c67a0159956