### PR TITLE
Track dynamic bridge delays and persist window meters

### DIFF
--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -95,6 +95,8 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
         "rho_mean": np.asarray(
             [nodes[nid].get("rho_mean", 0.0) for nid in nodes], dtype=np.float32
         ),
+        "E_theta": np.zeros(n_vert, dtype=np.float32),
+        "E_C": np.zeros(n_vert, dtype=np.float32),
     }
 
     # Initialise ancestry hashes using SplitMix64 and seed the moment vector.

--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ resulting density to a logarithmically scaled effective delay. The engine v2 ada
 recomputes this ``d_eff`` on every packet delivery, storing it with the edge
 and using the updated value to schedule the next hop. When a vertex window
 closes the adapter normalises accumulated amplitudes and records ``EQ`` via
-``engine.engine_v2.qtheta_c.close_window``. The post-window Θ distribution
-reset policy is governed by ``Config.theta_reset`` which accepts ``"uniform"``
-for an even reset, ``"renorm"`` to normalise existing values or ``"hold"`` to
-leave the distribution unchanged (default ``"renorm"``).
+``engine.engine_v2.qtheta_c.close_window``. The Θ and C meters ``E_theta`` and
+``E_C`` are persisted to the vertex arrays for diagnostics. The post-window Θ
+distribution reset policy is governed by ``Config.theta_reset`` which accepts
+``"uniform"`` for an even reset, ``"renorm"`` to normalise existing values or
+``"hold"`` to leave the distribution unchanged (default ``"renorm"``).
 
 Scheduler steps also integrate a toy horizon thermodynamics model. Interior
 nodes may emit Hawking pairs with probability ``exp(-ΔE/T_H)``, and the

--- a/tests/test_bridge_degree.py
+++ b/tests/test_bridge_degree.py
@@ -1,0 +1,14 @@
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+from Causal_Web.engine.engine_v2.state import Packet
+
+
+def test_bridges_contribute_to_degree():
+    adapter = EngineAdapter()
+    graph = {"nodes": [{"id": "0"}, {"id": "1"}], "edges": []}
+    adapter.build_graph(graph)
+    adapter._epairs._create_bridge(0, 1, d_bridge=1)
+    lccm = adapter._vertices[0]["lccm"]
+    window = lccm._window_size()
+    adapter._scheduler.push(window, 0, -1, Packet(src=0, dst=0))
+    adapter.run_until_next_window_or(None)
+    assert adapter._vertices[0]["lccm"].deg == adapter._vertices[0]["base_deg"] + 1

--- a/tests/test_meter_persistence.py
+++ b/tests/test_meter_persistence.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+from Causal_Web.engine.engine_v2.state import Packet
+
+
+def test_theta_c_meters_persist():
+    adapter = EngineAdapter()
+    graph = {"nodes": [{"id": "0"}], "edges": []}
+    adapter.build_graph(graph)
+    lccm = adapter._vertices[0]["lccm"]
+    window = lccm._window_size()
+    adapter._scheduler.push(window, 0, -1, Packet(src=0, dst=0))
+    adapter.run_until_next_window_or(None)
+    v_arr = adapter._arrays.vertices
+    assert np.isclose(v_arr["E_theta"][0], lccm.k_theta)
+    assert np.isclose(v_arr["E_C"][0], lccm.k_c)


### PR DESCRIPTION
## Summary
- compute bridge latency from live edge delays via callback
- include transient bridges in incident degree when windows close
- persist `E_theta` and `E_C` meters for diagnostics

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a5263eef88325b1fdbdd5fd9078d2