### PR TITLE
Avoid per-edge dict allocation and throttle bridge decay

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -278,9 +278,13 @@ class EngineAdapter:
         events = 0
         packets = []
         edge_logs = 0
+        decay_counter = 0
+        DECAY_INTERVAL = 32
 
         while self._scheduler and events < limit:
-            self._epairs.decay_all()
+            if decay_counter == 0:
+                self._epairs.decay_all()
+            decay_counter = (decay_counter + 1) % DECAY_INTERVAL
             depth_arr, dst, edge_id, pkt = self._scheduler.pop()
             vertex = self._vertices.get(dst)
             if vertex is None:
@@ -370,25 +374,19 @@ class EngineAdapter:
                 self._scheduler.push(*item)
 
             if len(pkt_list) > 1:
-                packets_struct = {
-                    "psi": psi_list,
-                    "p": p_list,
-                    "bit": bit_list,
-                    "depth_arr": depth_list,
-                }
-                edges_struct = {
-                    "alpha": alpha_list,
-                    "phi": phi_list,
-                    "A": A_list,
-                    "U": U_list,
-                }
                 depth_v, psi_acc, p_v, (bit, conf), intensities = deliver_packets_batch(
                     lccm.depth,
                     vertex["psi_acc"],
                     vertex["p_v"],
                     vertex["bit_deque"],
-                    packets_struct,
-                    edges_struct,
+                    psi_list,
+                    p_list,
+                    bit_list,
+                    depth_list,
+                    alpha_list,
+                    phi_list,
+                    A_list,
+                    U_list,
                     update_p=lccm.layer == "Θ",
                 )
             else:

--- a/Causal_Web/engine/engine_v2/qtheta_c.py
+++ b/Causal_Web/engine/engine_v2/qtheta_c.py
@@ -103,8 +103,14 @@ def deliver_packets_batch(
     psi_acc: np.ndarray,
     p_v: np.ndarray,
     bit_deque: Deque[int],
-    packets: dict,
-    edges: dict,
+    psi: Iterable[np.ndarray],
+    p: Iterable[np.ndarray],
+    bits: Iterable[int],
+    depth_arr: Iterable[int] | None,
+    alpha: Iterable[float],
+    phi: Iterable[float],
+    A: Iterable[float],
+    U: Iterable[np.ndarray],
     max_deque: int = 8,
     update_p: bool = True,
 ) -> Tuple[int, np.ndarray, np.ndarray, Tuple[int, float], Tuple[float, float, float]]:
@@ -120,10 +126,10 @@ def deliver_packets_batch(
         Classical probability vector for the vertex.
     bit_deque:
         Recent bits used for majority voting.
-    packets:
-        Struct-of-arrays packet fields ``{psi, p, bit, depth_arr}``.
-    edges:
-        Struct-of-arrays edge parameters ``{alpha, phi, A, U}``.
+    psi, p, bits, depth_arr:
+        Packet fields supplied as sequences or arrays.
+    alpha, phi, A, U:
+        Edge parameters supplied as sequences or arrays.
     max_deque:
         Maximum length of ``bit_deque``.
     update_p:
@@ -136,17 +142,17 @@ def deliver_packets_batch(
         per-layer intensity contributions ``(I_Q, I_Θ, I_C)`` each in ``[0, 1]``.
     """
 
-    if packets.get("depth_arr") is not None:
-        depth_v = max(depth_v, int(np.max(packets.get("depth_arr"))))
+    if depth_arr is not None:
+        depth_v = max(depth_v, int(np.max(depth_arr)))
 
-    psi = np.asarray(packets.get("psi"), dtype=np.complex64)
-    p = np.asarray(packets.get("p"), dtype=np.float32)
-    bits = np.asarray(packets.get("bit", []), dtype=np.int8)
+    psi = np.asarray(list(psi), dtype=np.complex64)
+    p = np.asarray(list(p), dtype=np.float32)
+    bits = np.asarray(list(bits), dtype=np.int8)
 
-    U = np.asarray(edges.get("U"), dtype=np.complex64)
-    alpha = np.asarray(edges.get("alpha", 1.0), dtype=np.float32)
-    phi = np.asarray(edges.get("phi", 0.0), dtype=np.float32)
-    A = np.asarray(edges.get("A", 0.0), dtype=np.float32)
+    U = np.asarray(list(U), dtype=np.complex64)
+    alpha = np.asarray(list(alpha), dtype=np.float32)
+    phi = np.asarray(list(phi), dtype=np.float32)
+    A = np.asarray(list(A), dtype=np.float32)
 
     out = np.einsum("nij,nj->ni", U, psi)
     phase = np.exp(1j * (phi + A))[:, None]


### PR DESCRIPTION
## Summary
- Pass packet and edge views directly to `deliver_packets_batch` to avoid per-edge dict construction
- Decay ε-bridges every 32 scheduler pops instead of on every pop to reduce overhead

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a55347fcc8325b3995ee60e69da8b