### PR TITLE
Streamline ancestry phase update and sample rho logs

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -150,9 +150,9 @@ class Config:
 
     #: Logging related settings used by the experimental engine.
     logging = {
-        # Probability that an individual edge delivery is recorded.
-        # A value of 0.0 disables per-edge logs while 1.0 logs all deliveries.
-        "sample_edge_rate": 0.0,
+        # Probability that a per-edge ρ/delay update is recorded.
+        # A value of 0.0 disables per-edge logs while 1.0 logs all updates.
+        "sample_rho_rate": 0.0,
         "sample_seed_rate": 1.0,
         "sample_bridge_rate": 1.0,
     }

--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ Engine v2 stores graph data in a struct-of-arrays format using `float32` and
 `complex64` types and batches deliveries by destination to vectorise quantum
 accumulation. A bucketed scheduler keyed by integer depth reduces heap
 operations to amortised *O*(1) and delivery logs may be sampled via
-`Config.log_delivery_sample_rate` to reduce I/O overhead. Edge hops can
-also be throttled by setting `Config.logging.sample_edge_rate`
+`Config.log_delivery_sample_rate` to reduce I/O overhead. Per-edge
+ρ/delay updates can also be throttled by setting `Config.logging.sample_rho_rate`
 (0.0–1.0) which records only a fraction of per-hop `edge_delivery`
 events; a value of `0.0` disables per-edge logs while still emitting a
-per-window summary of edge activity.
-Seed and bridge events can be sampled in the same way using
+per-window summary of edge activity. Seed and bridge events can be sampled in the same way using
 `Config.logging.sample_seed_rate` and `Config.logging.sample_bridge_rate`.
 
 To cap memory growth for long coherent lines, the engine detects tensor clusters

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -184,7 +184,7 @@ def _energy_total():
     bit_deque: deque[int] = deque()
     packet = {"psi": np.array([1, 0], np.complex64), "p": [0.4, 0.6], "bit": 1}
     edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": np.eye(2, dtype=np.complex64)}
-    depth, psi_acc, p_v, (bit, conf), intensities = deliver_packet(
+    depth, psi_acc, p_v, (bit, conf), intensities, mu, kappa = deliver_packet(
         0, psi_acc, p_v, bit_deque, packet, edge
     )
     psi, EQ = close_window(psi_acc)

--- a/tests/test_qtheta_c.py
+++ b/tests/test_qtheta_c.py
@@ -16,7 +16,7 @@ def test_deliver_packet_updates_fields():
         "U": [[1.0, 0.0], [0.0, 1.0]],
     }
 
-    depth, psi_acc, p_v, (bit, conf), intensities = deliver_packet(
+    depth, psi_acc, p_v, (bit, conf), intensities, mu, kappa = deliver_packet(
         depth, psi_acc, p_v, bits, packet, edge
     )
 
@@ -37,7 +37,9 @@ def test_intensity_theta_layer_ignores_other_contributions():
     packet = {"depth_arr": 1, "psi": [1.0, 0.0], "p": [0.1, 0.2], "bit": 1}
     edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": [[1.0, 0.0], [0.0, 1.0]]}
 
-    _, _, _, _, intensities = deliver_packet(depth, psi_acc, p_v, bits, packet, edge)
+    _, _, _, _, intensities, mu, kappa = deliver_packet(
+        depth, psi_acc, p_v, bits, packet, edge
+    )
     assert intensities[1] == pytest.approx(0.3, abs=1e-6)
 
 
@@ -47,5 +49,7 @@ def test_intensity_c_layer_only_counts_bits():
     packet = {"depth_arr": 1, "psi": [1.0, 0.0], "p": [0.1, 0.2], "bit": 0}
     edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": [[1.0, 0.0], [0.0, 1.0]]}
 
-    _, _, _, _, intensities = deliver_packet(depth, psi_acc, p_v, bits, packet, edge)
+    _, _, _, _, intensities, mu, kappa = deliver_packet(
+        depth, psi_acc, p_v, bits, packet, edge
+    )
     assert intensities[2] == 0.0


### PR DESCRIPTION
## Summary
- expose local phase stats (mu, kappa) from delivery helpers to reuse in ancestry updates
- add Config.logging.sample_rho_rate gate for per-edge density/delay logging
- document new logging option and adjust tests

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a7bf1f0a083259ea9164abfe5c6fd