### PR TITLE
Add tests for ancestry decay and bridge delay updates

### DIFF
--- a/tests/test_ancestry_decay.py
+++ b/tests/test_ancestry_decay.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+from Causal_Web.engine.engine_v2.state import Packet
+
+
+def test_delta_m_decay_no_q_arrivals():
+    adapter = EngineAdapter()
+    graph = {
+        "params": {"W0": 2},
+        "nodes": [{"id": "0"}],
+        "edges": [{"from": "0", "to": "0", "delay": 1.0}],
+    }
+    adapter.build_graph(graph)
+
+    v_arr = adapter._arrays.vertices
+    v_arr["m0"][0] = 1.0
+    v_arr["m1"][0] = 0.0
+    v_arr["m2"][0] = 0.0
+    v_arr["m_norm"][0] = 1.0
+
+    lccm = adapter._vertices[0]["lccm"]
+    lccm.layer = "Θ"
+
+    adapter._scheduler.push(0, 0, 0, Packet(src=0, dst=0))
+    adapter.run_until_next_window_or(limit=10)
+
+    m = np.array([v_arr["m0"][0], v_arr["m1"][0], v_arr["m2"][0]])
+    assert np.allclose(m, np.array([1.0, 0.0, 0.0]))
+    assert v_arr["m_norm"][0] < 1.0
+
+    adapter._update_ancestry(0, 0, 0, 0, np.pi / 2, 1.0)
+
+    m = np.array([v_arr["m0"][0], v_arr["m1"][0], v_arr["m2"][0]])
+    assert m[1] > 0.0
+
+
+def test_lambda_q_downweights_only_q_arrivals():
+    adapter = EngineAdapter()
+    adapter.build_graph({"nodes": [{"id": "0"}], "edges": []})
+
+    v_arr = adapter._arrays.vertices
+    v_arr["m0"][0] = 1.0
+    v_arr["m1"][0] = 0.0
+    v_arr["m2"][0] = 0.0
+    v_arr["m_norm"][0] = 1.0
+
+    lccm = adapter._vertices[0]["lccm"]
+    lccm._lambda = 100
+    lccm._lambda_q = 0
+
+    adapter._update_ancestry(0, 0, 0, 0, np.pi / 2, 1.0)
+
+    m = np.array([v_arr["m0"][0], v_arr["m1"][0], v_arr["m2"][0]])
+    assert m[1] > 0.05

--- a/tests/test_bridge_degree.py
+++ b/tests/test_bridge_degree.py
@@ -12,3 +12,26 @@ def test_bridges_contribute_to_degree():
     adapter._scheduler.push(window, 0, -1, Packet(src=0, dst=0))
     adapter.run_until_next_window_or(None)
     assert adapter._vertices[0]["lccm"].deg == adapter._vertices[0]["base_deg"] + 1
+
+
+def test_bridges_adjust_window_size():
+    adapter = EngineAdapter()
+    graph = {
+        "params": {"W0": 2, "zeta1": 2.0},
+        "nodes": [{"id": "0"}, {"id": "1"}],
+        "edges": [],
+    }
+    adapter.build_graph(graph)
+    lccm = adapter._vertices[0]["lccm"]
+    base_deg = adapter._vertices[0]["base_deg"]
+    w0 = lccm._window_size()
+
+    adapter._epairs._create_bridge(0, 1, d_bridge=1)
+    lccm.deg = base_deg + len(adapter._epairs.partners(0))
+    w1 = lccm._window_size()
+    assert w1 > w0
+
+    adapter._epairs._remove_bridge(0, 1)
+    lccm.deg = base_deg + len(adapter._epairs.partners(0))
+    w2 = lccm._window_size()
+    assert w2 == w0

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -345,3 +345,26 @@ def test_bridge_delay_reads_live_d_eff():
     bridge = adapter._epairs.bridges[(0, 1)]
     expected = int(np.median([9, adapter._arrays.edges["d_eff"][1]]))
     assert bridge.d_bridge == expected
+
+
+def test_bridge_delay_updates_after_rho_change():
+    adapter = EngineAdapter()
+    graph = {
+        "nodes": [{"id": "0"}, {"id": "1"}],
+        "edges": [
+            {"from": "0", "to": "1", "delay": 1.0},
+            {"from": "1", "to": "0", "delay": 1.0},
+        ],
+    }
+    adapter.build_graph(graph)
+
+    adapter._epairs._create_bridge(0, 1)
+    bridge = adapter._epairs.bridges[(0, 1)]
+    assert bridge.d_bridge == 1
+
+    adapter._epairs._remove_bridge(0, 1)
+    adapter._arrays.edges["d_eff"][0] = 9
+    adapter._epairs._create_bridge(0, 1)
+    bridge = adapter._epairs.bridges[(0, 1)]
+    expected = int(np.median([9, adapter._arrays.edges["d_eff"][1]]))
+    assert bridge.d_bridge == expected

--- a/tests/test_qtheta_c.py
+++ b/tests/test_qtheta_c.py
@@ -53,3 +53,15 @@ def test_intensity_c_layer_only_counts_bits():
         depth, psi_acc, p_v, bits, packet, edge
     )
     assert intensities[2] == 0.0
+
+
+def test_p_v_unchanged_when_update_p_false():
+    depth, psi_acc, p_v = 0, np.zeros(2, dtype=np.complex128), np.array([0.7, 0.3])
+    bits = deque()
+    packet = {"depth_arr": 1, "psi": [1.0, 0.0], "p": [0.1, 0.9], "bit": 1}
+    edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": [[1.0, 0.0], [0.0, 1.0]]}
+
+    _, _, p_out, _, _, _, _ = deliver_packet(
+        depth, psi_acc, p_v, bits, packet, edge, update_p=False
+    )
+    assert np.allclose(p_out, p_v)


### PR DESCRIPTION
## Summary
- cover phase moment decay and ensure Lambda^q ignores classical traffic
- verify bridge binding uses fresh effective delays after density changes
- check bridges affect window size and probability field remains stable outside Θ

## Testing
- `black Causal_Web tests/test_ancestry_decay.py tests/test_epairs_dynamic.py tests/test_bridge_degree.py tests/test_qtheta_c.py`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a7e3ba9f08325a32a53e4e2c835b1