### PR TITLE
Improve epsilon seeding angle and per-edge rho injection

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -135,6 +135,7 @@ class Config:
         "decay_interval": 32,
         "decay_on_window_close": True,
         "max_seeds_per_site": 64,
+        "emit_per_delivery": False,
     }
     ancestry = {
         "beta_m0": 0.1,

--- a/Causal_Web/engine/engine_v2/rho_delay.py
+++ b/Causal_Web/engine/engine_v2/rho_delay.py
@@ -93,7 +93,7 @@ def update_rho_delay(
 def update_rho_delay_vec(
     rho: np.ndarray,
     mean: np.ndarray,
-    intensity: float,
+    intensity: np.ndarray | float,
     *,
     alpha_d: float,
     alpha_leak: float,
@@ -111,7 +111,8 @@ def update_rho_delay_vec(
     mean:
         Mean neighbour density for each edge.
     intensity:
-        External input shared across updates.
+        External input for each edge. May be a scalar shared across updates or
+        a vector matching the shape of ``rho`` for per-edge intensities.
     d0:
         Baseline delays per edge.
 

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -63,7 +63,8 @@
         "sigma_min": 0.001,
         "decay_interval": 32,
         "decay_on_window_close": true,
-        "max_seeds_per_site": 64
+        "max_seeds_per_site": 64,
+        "emit_per_delivery": false
     },
     "bell": {
         "mi_mode": "MI_strict",

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ mapping:
                      "lambda_decay": 0.05, "sigma_reinforce": 0.1,
                      "sigma_min": 0.001, "decay_interval": 32,
                      "decay_on_window_close": true,
-                     "max_seeds_per_site": 64},
+                     "max_seeds_per_site": 64,
+                     "emit_per_delivery": false},
   "ancestry": {"beta_m0": 0.1, "delta_m": 0.02},
   "bell": {"enabled": false, "mi_mode": "MI_strict", "kappa_a": 0.0,
             "kappa_xi": 0.0, "beta_m": 0.0, "beta_h": 0.0},
@@ -173,7 +174,9 @@ scales with `W0` (`2*W0`) to simplify experiments, while the remaining
 parameters set decay and reinforcement dynamics. `decay_interval` controls how
 often bridges decay and `decay_on_window_close` toggles a decay step when a
 window closes. `max_seeds_per_site` bounds how many unmatched seeds a vertex
-retains, evicting the oldest when full. The `ancestry` group tunes
+retains, evicting the oldest when full. `emit_per_delivery` enables a
+high-fidelity mode where seeds emit on each Q-delivery instead of once per
+batch. The `ancestry` group tunes
 phase-moment updates and decay. `bell` sets mutual information gates for Bell
 pair matching. Bridge creation and removal now emit `bridge_created` and
 `bridge_removed` events (carrying a stable synthetic `bridge_id` and final `σ`),

--- a/tests/test_rho_delay_update.py
+++ b/tests/test_rho_delay_update.py
@@ -1,4 +1,9 @@
-from Causal_Web.engine.engine_v2.rho_delay import update_rho_delay
+import numpy as np
+
+from Causal_Web.engine.engine_v2.rho_delay import (
+    update_rho_delay,
+    update_rho_delay_vec,
+)
 
 
 def test_update_rho_delay():
@@ -15,3 +20,41 @@ def test_update_rho_delay():
     )
     assert abs(rho - 0.7) < 1e-9
     assert d_eff == 7
+
+
+def test_update_rho_delay_vec_intensity_array():
+    rho_vec, d_vec = update_rho_delay_vec(
+        np.array([0.5, 0.2], dtype=float),
+        np.array([0.75, 0.25], dtype=float),
+        np.array([1.0, 0.5], dtype=float),
+        alpha_d=0.1,
+        alpha_leak=0.05,
+        eta=0.2,
+        d0=np.array([3.0, 4.0], dtype=float),
+        gamma=2.0,
+        rho0=0.1,
+    )
+    r1, d1 = update_rho_delay(
+        0.5,
+        [0.75],
+        1.0,
+        alpha_d=0.1,
+        alpha_leak=0.05,
+        eta=0.2,
+        d0=3.0,
+        gamma=2.0,
+        rho0=0.1,
+    )
+    r2, d2 = update_rho_delay(
+        0.2,
+        [0.25],
+        0.5,
+        alpha_d=0.1,
+        alpha_leak=0.05,
+        eta=0.2,
+        d0=4.0,
+        gamma=2.0,
+        rho0=0.1,
+    )
+    assert np.allclose(rho_vec, [r1, r2])
+    assert np.array_equal(d_vec, np.array([d1, d2]))


### PR DESCRIPTION
## Summary
- derive epsilon seed angle from current moment vector
- add optional per-delivery epsilon emission and config switch
- support per-edge rho injection intensities and vectorized updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a9a32ae548325aaefa9d2a80bd19b