### PR TITLE
Refine seed carry and delay handling

### DIFF
--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -191,6 +191,7 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
     }
 
     d0_arr = np.asarray(edges["d0"], dtype=np.float32)
+    d0_int = np.floor(d0_arr).astype(np.int32)
     edges = {
         "src": np.asarray(edges["src"], dtype=np.int32),
         "dst": np.asarray(edges["dst"], dtype=np.int32),
@@ -201,7 +202,7 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
         "A": np.asarray(edges["A"], dtype=np.float32),
         "U": np.asarray(edges["U"], dtype=np.complex64),
         "sigma": np.asarray(edges["sigma"], dtype=np.float32),
-        "d_eff": np.maximum(1, np.round(d0_arr)).astype(np.int32),
+        "d_eff": np.maximum(1, d0_int),
     }
 
     return GraphArrays(

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ twin-paradox demonstration showcasing this time dilation. Run
 `python -m Causal_Web.analysis.lensing` to approximate lensing wedge amplitudes
 via a Monte-Carlo path sampler over the graph's causal structure.
 
+### Recent Changes
+
+- Seed carrying now iterates through sorted depth arrivals, preserving
+  per-depth causality within a batch.
+- Baseline edge delays are floored to integers and the initial effective delay
+  `d_eff` uses this coerced value.
+- Non-incoming injection modes average per-packet intensities to avoid
+  saturation with high fan-in.
+
 ## Table of Contents
 - [Quick Start](#quick-start)
 - [Installation](#installation)


### PR DESCRIPTION
## Summary
- carry epsilon seeds at every depth within a batch to maintain per-depth causality
- floor baseline delay `d0` and derive initial `d_eff` from the integer value
- average per-packet intensities for non-incoming rho injections to avoid saturation

## Testing
- `black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ac03ff0a08325a3075acb2db0d0b5