### PR TITLE
feat: log gate metrics and persist configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Non-incoming injection modes average per-packet intensities to avoid
   saturation with high fan-in.
 - Added DOE runner with invariant checks and metrics logging.
+- Runner CLI now accepts separate experiment (`--exp`) and base (`--base`)
+  configs, persists per-sample seeds and gate metrics, and supports
+  parallel execution via `--parallel`.
 
 ## Table of Contents
 - [Quick Start](#quick-start)

--- a/config/normalizer.py
+++ b/config/normalizer.py
@@ -11,22 +11,19 @@ class Normalizer:
     def to_groups(self, raw: Dict[str, float]) -> Dict[str, float]:
         """Convert raw parameters to dimensionless groups."""
 
-        delta = raw["Delta"]
-        w0 = raw["W0"]
-        alpha_d = raw["alpha_d"]
-        leak = raw["leak"]
         return {
-            "Delta_over_W0": delta / w0,
-            "alpha_d_over_leak": alpha_d / leak,
+            "Delta_over_W0": raw["Delta"] / raw["W0"],
+            "alpha_d_over_leak": raw["alpha_d"] / raw["alpha_leak"],
         }
 
-    def to_raw(self, groups: Dict[str, float]) -> Dict[str, float]:
-        """Reconstruct raw parameters from groups using nominal scales."""
+    def to_raw(
+        self, base: Dict[str, float], groups: Dict[str, float]
+    ) -> Dict[str, float]:
+        """Reconstruct raw parameters from groups using a baseline config."""
 
-        # The nominal scales are arbitrary for demonstration purposes.
-        return {
-            "Delta": groups.get("Delta_over_W0", 0.0) * 1.0,
-            "W0": 1.0,
-            "alpha_d": groups.get("alpha_d_over_leak", 0.0) * 1.0,
-            "leak": 1.0,
-        }
+        raw = dict(base)
+        if "Delta_over_W0" in groups:
+            raw["Delta"] = groups["Delta_over_W0"] * raw["W0"]
+        if "alpha_d_over_leak" in groups:
+            raw["alpha_d"] = groups["alpha_d_over_leak"] * raw["alpha_leak"]
+        return raw

--- a/experiments/gates.py
+++ b/experiments/gates.py
@@ -1,0 +1,37 @@
+"""Gate metric helpers.
+
+This module provides a thin wrapper around the engine's gate
+benchmark suite. The implementation here is a placeholder that
+should be wired to the real engine entry points.  Each gate
+execution returns a flat mapping of metric names to values.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def run_gates(config: Dict[str, float], which: List[int]) -> Dict[str, float]:
+    """Execute selected gates and collect metrics.
+
+    Parameters
+    ----------
+    config:
+        Engine configuration passed to the gate harness.
+    which:
+        List of gate identifiers to execute.
+
+    Returns
+    -------
+    dict
+        Mapping of metric names to values.  Invariants derived
+        from the gate results may also be included in the mapping.
+
+    Notes
+    -----
+    This function currently returns an empty mapping and should be
+    connected to the real engine implementation.
+    """
+
+    # TODO: wire to your engine entrypoints
+    return {}

--- a/invariants/checks.py
+++ b/invariants/checks.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping, Sequence, Tuple
+from typing import Dict, Iterable, Mapping, Sequence, Tuple
 
 
 def causality(deliveries: Iterable[Mapping[str, float]]) -> bool:
@@ -32,3 +32,14 @@ def ancestry_determinism(seq: Sequence[Tuple[str, str, str]]) -> bool:
             return False
         seen[q] = (h, m)
     return True
+
+
+def from_metrics(m: Mapping[str, float | bool]) -> Dict[str, float | bool]:
+    """Extract invariant fields from a metrics mapping."""
+
+    return {
+        "inv_causality_ok": bool(m.get("inv_causality_ok", True)),
+        "inv_conservation_residual": float(m.get("inv_conservation_residual", 0.0)),
+        "inv_no_signaling_delta": float(m.get("inv_no_signaling_delta", 0.0)),
+        "inv_ancestry_ok": bool(m.get("inv_ancestry_ok", True)),
+    }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,7 +6,7 @@ from telemetry.metrics import MetricsLogger
 
 def test_metrics_logger(tmp_path: Path):
     logger = MetricsLogger(tmp_path)
-    logger.log(0, {"g": 1.0}, {"Delta": 1.0}, 0)
+    logger.log(0, {"g": 1.0}, {"Delta": 1.0}, 0, {}, {})
     logger.flush(
         type("Cfg", (), {"samples": 1, "groups": {"g": (0, 1)}, "seed": 0})(),
         [{"g": 1.0}],

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -3,10 +3,11 @@ from config.normalizer import Normalizer
 
 def test_normalizer_roundtrip():
     norm = Normalizer()
-    raw = {"Delta": 2.0, "W0": 1.0, "alpha_d": 10.0, "leak": 2.0}
+    raw = {"Delta": 2.0, "W0": 1.0, "alpha_d": 10.0, "alpha_leak": 2.0}
     groups = norm.to_groups(raw)
     assert groups["Delta_over_W0"] == 2.0
     assert groups["alpha_d_over_leak"] == 5.0
-    rebuilt = norm.to_raw(groups)
-    assert rebuilt["Delta"] == groups["Delta_over_W0"]
-    assert rebuilt["alpha_d"] == groups["alpha_d_over_leak"]
+    base = {"Delta": 1.0, "W0": 1.0, "alpha_d": 1.0, "alpha_leak": 2.0}
+    rebuilt = norm.to_raw(base, groups)
+    assert rebuilt["Delta"] == 2.0
+    assert rebuilt["alpha_d"] == 10.0


### PR DESCRIPTION
## Summary
- add placeholder `run_gates` helper for executing engine gate metrics
- normalizer now scales groups relative to a baseline config
- DOE runner derives per-sample seeds, writes configs, runs gates, and logs invariants
- metrics logger captures gate metrics, invariant checks, git commit and timestamp
- expose `--exp`, `--base`, `--out`, and `--parallel` CLI options

## Testing
- `black config experiments invariants telemetry`
- `python -m compileall config experiments invariants telemetry Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`
- `python bundle_run.py`


------
https://chatgpt.com/codex/tasks/task_e_689ad5103c248325a8088a0eb5a10129