### PR TITLE
Improve DOE gate plumbing and metrics logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Runner CLI now accepts separate experiment (`--exp`) and base (`--base`)
   configs, persists per-sample seeds and gate metrics, and supports
   parallel execution via `--parallel`.
+- DOE summaries now record selected gates and mean gate metrics.
 
 ## Table of Contents
 - [Quick Start](#quick-start)

--- a/config/normalizer.py
+++ b/config/normalizer.py
@@ -14,6 +14,9 @@ class Normalizer:
         return {
             "Delta_over_W0": raw["Delta"] / raw["W0"],
             "alpha_d_over_leak": raw["alpha_d"] / raw["alpha_leak"],
+            "sigma_reinforce_over_decay": raw["sigma_reinforce"] / raw["lambda_decay"],
+            "a_over_b": raw["a"] / raw["b"],
+            "eta_times_W0": raw["eta"] * raw["W0"],
         }
 
     def to_raw(
@@ -26,4 +29,12 @@ class Normalizer:
             raw["Delta"] = groups["Delta_over_W0"] * raw["W0"]
         if "alpha_d_over_leak" in groups:
             raw["alpha_d"] = groups["alpha_d_over_leak"] * raw["alpha_leak"]
+        if "sigma_reinforce_over_decay" in groups:
+            raw["sigma_reinforce"] = (
+                groups["sigma_reinforce_over_decay"] * raw["lambda_decay"]
+            )
+        if "a_over_b" in groups:
+            raw["a"] = groups["a_over_b"] * raw["b"]
+        if "eta_times_W0" in groups:
+            raw["eta"] = groups["eta_times_W0"] / raw["W0"]
         return raw

--- a/experiments/gates.py
+++ b/experiments/gates.py
@@ -29,9 +29,14 @@ def run_gates(config: Dict[str, float], which: List[int]) -> Dict[str, float]:
 
     Notes
     -----
-    This function currently returns an empty mapping and should be
-    connected to the real engine implementation.
+    This function currently returns placeholder invariant fields and
+    should be connected to the real engine implementation.
     """
 
     # TODO: wire to your engine entrypoints
-    return {}
+    return {
+        "inv_causality_ok": True,
+        "inv_conservation_residual": 0.0,
+        "inv_no_signaling_delta": 0.0,
+        "inv_ancestry_ok": True,
+    }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,11 +6,15 @@ from telemetry.metrics import MetricsLogger
 
 def test_metrics_logger(tmp_path: Path):
     logger = MetricsLogger(tmp_path)
-    logger.log(0, {"g": 1.0}, {"Delta": 1.0}, 0, {}, {})
-    logger.flush(
-        type("Cfg", (), {"samples": 1, "groups": {"g": (0, 1)}, "seed": 0})(),
-        [{"g": 1.0}],
-    )
+    logger.log(0, {"g": 1.0}, {"Delta": 1.0}, 0, {"G1": 1.0}, {})
+    cfg = type(
+        "Cfg",
+        (),
+        {"samples": 1, "groups": {"g": (0, 1)}, "seed": 0, "gates": [1]},
+    )()
+    logger.flush(cfg, [{"g": 1.0}])
     assert (tmp_path / "metrics.csv").exists()
     summary = json.loads((tmp_path / "summary.json").read_text())
     assert summary["seed"] == 0
+    assert summary["gates"] == [1]
+    assert summary["metrics_agg"]["mean_G1"] == 1.0

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -3,11 +3,37 @@ from config.normalizer import Normalizer
 
 def test_normalizer_roundtrip():
     norm = Normalizer()
-    raw = {"Delta": 2.0, "W0": 1.0, "alpha_d": 10.0, "alpha_leak": 2.0}
+    raw = {
+        "Delta": 2.0,
+        "W0": 1.0,
+        "alpha_d": 10.0,
+        "alpha_leak": 2.0,
+        "sigma_reinforce": 4.0,
+        "lambda_decay": 2.0,
+        "a": 8.0,
+        "b": 4.0,
+        "eta": 0.5,
+    }
     groups = norm.to_groups(raw)
     assert groups["Delta_over_W0"] == 2.0
     assert groups["alpha_d_over_leak"] == 5.0
-    base = {"Delta": 1.0, "W0": 1.0, "alpha_d": 1.0, "alpha_leak": 2.0}
+    assert groups["sigma_reinforce_over_decay"] == 2.0
+    assert groups["a_over_b"] == 2.0
+    assert groups["eta_times_W0"] == 0.5
+    base = {
+        "Delta": 1.0,
+        "W0": 1.0,
+        "alpha_d": 1.0,
+        "alpha_leak": 2.0,
+        "sigma_reinforce": 1.0,
+        "lambda_decay": 2.0,
+        "a": 4.0,
+        "b": 4.0,
+        "eta": 0.1,
+    }
     rebuilt = norm.to_raw(base, groups)
     assert rebuilt["Delta"] == 2.0
     assert rebuilt["alpha_d"] == 10.0
+    assert rebuilt["sigma_reinforce"] == 4.0
+    assert rebuilt["a"] == 8.0
+    assert rebuilt["eta"] == 0.5


### PR DESCRIPTION
## Summary
- return placeholder invariant metrics from `run_gates`
- allow experiment configs to supply invariant tolerances
- expand normalizer with additional dimensionless groups
- cache git commit and add gate aggregates to DOE summary

## Testing
- `python -m compileall Causal_Web experiments config telemetry invariants`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ad8b171208325afc23bd7a64915f0