### PR TITLE
Add curvature diagnostics and phi-linear delay mapping

### DIFF
--- a/Causal_Web/delay_maps.py
+++ b/Causal_Web/delay_maps.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Delay mapping strategies."""
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, Iterable
+
+
+def log_scalar(rho: float, *, d0: float, gamma: float, rho0: float) -> int:
+    """Logarithmic scalar delay map.
+
+    Parameters
+    ----------
+    rho:
+        Local density value.
+    d0, gamma, rho0:
+        Baseline delay and scaling parameters.
+    """
+
+    return int(max(1, d0 + math.floor(gamma * math.log(1 + rho / rho0))))
+
+
+@dataclass
+class PhiLinear:
+    """Φ-based linear delay map maintaining per-vertex scalars."""
+
+    omega: float = 0.2
+    alpha: float = 0.05
+    eta: float = 0.1
+    init: float = 0.0
+    phi: Dict[int, float] = field(default_factory=dict)
+
+    def update_vertex(self, v: int, neighbours: Iterable[int], rho_bar: float) -> float:
+        """Update the Φ value for vertex ``v``.
+
+        Parameters
+        ----------
+        v:
+            Vertex identifier.
+        neighbours:
+            Iterable of neighbouring vertex identifiers.
+        rho_bar:
+            Mean incident density for ``v``.
+        """
+
+        neighbour_list = list(neighbours)
+        deg = max(1, len(neighbour_list))
+        avg_phi = (
+            sum(self.phi.get(u, self.init) for u in neighbour_list) / deg
+            if neighbour_list
+            else 0.0
+        )
+        phi_v = (
+            (1 - self.omega) * self.phi.get(v, self.init)
+            + self.omega * avg_phi
+            + self.eta * rho_bar
+        )
+        self.phi[v] = phi_v
+        return phi_v
+
+    def effective_delay(self, d0: float, u: int, v: int) -> int:
+        """Compute ``d_eff`` for edge ``(u, v)`` using Φ values."""
+
+        phi_u = self.phi.get(u, self.init)
+        phi_v = self.phi.get(v, self.init)
+        deff = d0 * (1 + self.alpha * (phi_u + phi_v) / 2.0)
+        return int(max(1, math.floor(deff)))
+
+
+def stamp_delay_metadata(
+    meta: Dict[str, object], mode: str, params: Dict[str, object]
+) -> None:
+    """Annotate run metadata with the active delay map and parameters."""
+
+    meta["delay_map"] = {"mode": mode, **params}
+
+
+__all__ = ["log_scalar", "PhiLinear", "stamp_delay_metadata"]

--- a/Causal_Web/geometry/curvature.py
+++ b/Causal_Web/geometry/curvature.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Local curvature diagnostics."""
+
+import logging
+from collections import defaultdict
+from typing import Dict, Iterable, List
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def forman_curvature(d_eff: float, deg_u: int, deg_v: int) -> float:
+    """Compute a Forman-style curvature for a directed edge.
+
+    Parameters
+    ----------
+    d_eff:
+        Effective delay associated with the edge.
+    deg_u:
+        Outgoing degree of the source vertex.
+    deg_v:
+        Incoming degree of the destination vertex.
+
+    Returns
+    -------
+    float
+        Local curvature value ``F_e``.
+    """
+
+    if d_eff <= 0:
+        raise ValueError("d_eff must be positive")
+    term_u = 1.0 / deg_u if deg_u else 0.0
+    term_v = 1.0 / deg_v if deg_v else 0.0
+    return (term_u + term_v) / d_eff
+
+
+class CurvatureLogger:
+    """Aggregate and emit curvature statistics per region."""
+
+    def __init__(self) -> None:
+        self._values: Dict[str, List[float]] = defaultdict(list)
+
+    def log_edge(self, region: str, curvature: float) -> None:
+        """Record curvature for an edge belonging to ``region``."""
+
+        self._values[region].append(curvature)
+
+    def window_close(self) -> Dict[str, Dict[str, float]]:
+        """Flush accumulated values and return per-region stats.
+
+        The function logs curvature histograms for each region and returns a
+        mapping ``region -> {mean, var}``.
+        """
+
+        stats: Dict[str, Dict[str, float]] = {}
+        for region, vals in self._values.items():
+            arr = np.asarray(vals, dtype=float)
+            stats[region] = {
+                "mean": float(arr.mean()),
+                "var": float(arr.var()),
+            }
+            hist, bin_edges = np.histogram(arr, bins="auto")
+            logger.info(
+                "curvature_hist",
+                extra={
+                    "region": region,
+                    "hist": hist.tolist(),
+                    "bins": bin_edges.tolist(),
+                },
+            )
+        self._values.clear()
+        return stats
+
+
+__all__ = ["forman_curvature", "CurvatureLogger"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 
 ### Recent Changes
 
+- Added local Forman curvature diagnostics with per-region statistics and
+  histogram logging.
+- Introduced a switchable delay mapping system with the existing logarithmic
+  rule (`log_scalar`) and a new Φ-linear variant (`phi_linear`).
 - Seed carrying now iterates through sorted depth arrivals, preserving
   per-depth causality within a batch.
 - Baseline edge delays are floored to integers and the initial effective delay

--- a/tests/test_curvature.py
+++ b/tests/test_curvature.py
@@ -1,0 +1,20 @@
+import math
+
+from Causal_Web.geometry.curvature import CurvatureLogger, forman_curvature
+
+
+def test_forman_curvature_basic():
+    f = forman_curvature(4.0, deg_u=3, deg_v=2)
+    assert math.isclose(f, (1 / 3 + 1 / 2) / 4)
+
+
+def test_curvature_logger_stats():
+    logger = CurvatureLogger()
+    logger.log_edge("A", 0.2)
+    logger.log_edge("A", 0.3)
+    logger.log_edge("B", 0.1)
+    stats = logger.window_close()
+    assert math.isclose(stats["A"]["mean"], 0.25)
+    assert math.isclose(stats["A"]["var"], 0.0025)
+    assert math.isclose(stats["B"]["mean"], 0.1)
+    assert math.isclose(stats["B"]["var"], 0.0)

--- a/tests/test_delay_maps.py
+++ b/tests/test_delay_maps.py
@@ -1,0 +1,22 @@
+from Causal_Web.delay_maps import PhiLinear, log_scalar, stamp_delay_metadata
+
+
+def test_log_scalar_mapping():
+    out = log_scalar(2.0, d0=1.0, gamma=2.0, rho0=1.0)
+    assert out == 3
+
+
+def test_phi_linear_stronger_delay():
+    mapper = PhiLinear(alpha=0.1)
+    mapper.phi[2] = 5.0
+    mapper.update_vertex(1, [2], rho_bar=0.0)
+    d_phi = mapper.effective_delay(5.0, 1, 2)
+    d_log = log_scalar(0.0, d0=5.0, gamma=1.0, rho0=1.0)
+    assert d_phi > d_log
+
+
+def test_stamp_delay_metadata():
+    meta = {}
+    stamp_delay_metadata(meta, "phi_linear", {"alpha": 0.05})
+    assert meta["delay_map"]["mode"] == "phi_linear"
+    assert meta["delay_map"]["alpha"] == 0.05


### PR DESCRIPTION
## Summary
- add Forman-style curvature computation with regional aggregation
- introduce switchable delay maps with new `phi_linear` option
- document curvature telemetry and delay-map variants

## Testing
- `python -m black Causal_Web`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689add84b3348325903f6a2141c2c8a5