### PR TITLE
feat: add variational rho update and free-energy lccm

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -138,6 +138,14 @@ class Config:
         "rho0": 1.0,
         "inject_mode": "incoming",
     }
+    rho = {
+        "update_mode": "heuristic",
+        "variational": {"lambda_s": 0.2, "lambda_l": 0.01, "lambda_I": 1.0},
+    }
+    lccm = {
+        "mode": "thresholds",
+        "free_energy": {"k_theta": 1.0, "k_c": 1.0, "k_q": 0.2, "F_min": 0.3},
+    }
     epsilon_pairs = {
         "delta_ttl": 2 * windowing["W0"],
         "ancestry_prefix_L": 16,

--- a/Causal_Web/engine/engine_v2/lccm/free_energy.py
+++ b/Causal_Web/engine/engine_v2/lccm/free_energy.py
@@ -1,0 +1,30 @@
+"""Free-energy score for Θ→C transitions."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def free_energy_score(
+    entropy: float,
+    confidence: float,
+    eq_recent: float,
+    *,
+    k_theta: float,
+    k_c: float,
+    k_q: float,
+) -> float:
+    """Return the free-energy score ``F_v`` for a vertex."""
+
+    return k_theta * (1.0 - entropy) + k_c * confidence - k_q * eq_recent
+
+
+def stamp_lccm_metadata(
+    meta: Dict[str, object], mode: str, params: Dict[str, object]
+) -> None:
+    """Annotate run metadata with the LCCM mode and parameters."""
+
+    meta["lccm"] = {"mode": mode, **params}
+
+
+__all__ = ["free_energy_score", "stamp_lccm_metadata"]

--- a/Causal_Web/engine/engine_v2/rho/variational.py
+++ b/Causal_Web/engine/engine_v2/rho/variational.py
@@ -1,0 +1,75 @@
+"""Variational density update helpers."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+import numpy as np
+
+from ..rho_delay import effective_delay
+
+
+def lambda_to_coeffs(
+    lambda_s: float, lambda_l: float, lambda_I: float, eta: float
+) -> tuple[float, float, float]:
+    """Map variational weights to diffusion, leak and input coefficients."""
+    total = lambda_s + lambda_l + lambda_I
+    if total <= 0:
+        raise ValueError("sum of lambda coefficients must be positive")
+    alpha_d = lambda_s / total
+    alpha_leak = lambda_l / total
+    eta_eff = lambda_I * eta / total
+    return alpha_d, alpha_leak, eta_eff
+
+
+def coefficients(
+    lambda_s: float, lambda_l: float, lambda_I: float, eta: float
+) -> tuple[float, float, float]:
+    """Return ``A``, ``B`` and ``C`` coefficients of the closed-form update."""
+    total = lambda_s + lambda_l + lambda_I
+    if total <= 0:
+        raise ValueError("sum of lambda coefficients must be positive")
+    A = lambda_s / total
+    B = lambda_I / total
+    C = lambda_I * eta / total
+    return A, B, C
+
+
+def update_rho_variational(
+    rho: float,
+    neighbours: Iterable[float],
+    intensity: float,
+    *,
+    lambda_s: float,
+    lambda_l: float,
+    lambda_I: float,
+    eta: float,
+    d0: float,
+    gamma: float,
+    rho0: float,
+) -> tuple[float, int]:
+    """Update edge density using the variational objective."""
+    if isinstance(neighbours, np.ndarray):
+        mean = float(neighbours.mean()) if neighbours.size else 0.0
+    else:
+        nbr = list(neighbours)
+        mean = sum(nbr) / len(nbr) if nbr else 0.0
+    A, B, C = coefficients(lambda_s, lambda_l, lambda_I, eta)
+    rho_new = A * mean + B * rho + C * intensity
+    rho_new = max(0.0, rho_new)
+    d_eff = effective_delay(rho_new, d0=d0, gamma=gamma, rho0=rho0)
+    return rho_new, d_eff
+
+
+def stamp_rho_metadata(
+    meta: Dict[str, object], mode: str, params: Dict[str, object]
+) -> None:
+    """Annotate run metadata with the ρ update mode and parameters."""
+    meta["rho_update"] = {"mode": mode, **params}
+
+
+__all__ = [
+    "lambda_to_coeffs",
+    "coefficients",
+    "update_rho_variational",
+    "stamp_rho_metadata",
+]

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -51,7 +51,15 @@
         "eta": 0.0,
         "gamma": 0.0,
         "rho0": 0.0,
-        "inject_mode": "incoming"
+        "inject_mode": "incoming",
+    },
+    "rho": {
+        "update_mode": "heuristic",
+        "variational": {"lambda_s": 0.2, "lambda_l": 0.01, "lambda_I": 1.0},
+    },
+    "lccm": {
+        "mode": "thresholds",
+        "free_energy": {"k_theta": 1.0, "k_c": 1.0, "k_q": 0.2, "F_min": 0.3},
     },
     "epsilon_pairs": {
         "delta_ttl": 8,
@@ -64,7 +72,7 @@
         "decay_interval": 32,
         "decay_on_window_close": true,
         "max_seeds_per_site": 64,
-        "emit_per_delivery": false
+        "emit_per_delivery": false,
     },
     "bell": {
         "mi_mode": "MI_strict",
@@ -73,10 +81,7 @@
         "beta_m": 0.0,
         "beta_h": 0.0,
     },
-    "ancestry": {
-        "beta_m0": 0.1,
-        "delta_m": 0.02
-    },
+    "ancestry": {"beta_m0": 0.1, "delta_m": 0.02},
     "theta_reset": "renorm",
     "max_deque": 8,
     "propagation_control": {

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ mapping:
                  "T_hold": 2, "C_min": 0.1},
   "rho_delay": {"alpha_d": 0.1, "alpha_leak": 0.01, "eta": 0.2,
                 "gamma": 0.8, "rho0": 1.0, "inject_mode": "incoming"},
+  "rho": {"update_mode": "heuristic", "variational": {"lambda_s": 0.2, "lambda_l": 0.01, "lambda_I": 1.0}},
+  "lccm": {"mode": "thresholds", "free_energy": {"k_theta": 1.0, "k_c": 1.0, "k_q": 0.2, "F_min": 0.3}},
   "epsilon_pairs": {"delta_ttl": 8, "ancestry_prefix_L": 16,
                      "theta_max": 0.261799, "sigma0": 0.3,
                      "lambda_decay": 0.05, "sigma_reinforce": 0.1,
@@ -185,8 +187,8 @@ mapping:
 }
 ```
 
-The `windowing` values control vertex window advancement. `rho_delay` affects
-how edge density relaxes toward a baseline. The `inject_mode` option selects
+The `windowing` values control vertex window advancement. `rho_delay` affects how edge density relaxes toward a baseline. The `rho` group selects the update rule for ρ while `lccm` chooses the Θ→C transition criterion.
+The `inject_mode` option selects
 whether ρ input applies to `"incoming"` (default), `"incident"` or `"outgoing"` edges.
 `epsilon_pairs` governs dynamic
 ε-pair behaviour – seeds with a limited TTL can bind to form temporary bridge

--- a/tests/test_lccm_free_energy.py
+++ b/tests/test_lccm_free_energy.py
@@ -1,0 +1,51 @@
+from Causal_Web.engine.engine_v2.lccm import LCCM
+from Causal_Web.engine.engine_v2.lccm.free_energy import (
+    free_energy_score,
+    stamp_lccm_metadata,
+)
+
+from Causal_Web.engine.engine_v2.lccm import LCCM
+from Causal_Web.engine.engine_v2.lccm.free_energy import (
+    free_energy_score,
+    stamp_lccm_metadata,
+)
+
+
+def test_free_energy_score():
+    score = free_energy_score(0.2, 0.6, 0.1, k_theta=1.0, k_c=1.0, k_q=0.5)
+    assert score == 1.0 * (1 - 0.2) + 1.0 * 0.6 - 0.5 * 0.1
+
+
+def test_lccm_free_energy_transition():
+    l = LCCM(
+        1,
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        0.5,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        1,
+        2,
+        k_theta=1.0,
+        k_c=1.0,
+        mode="free_energy",
+        k_q=0.0,
+        F_min=0.3,
+    )
+    l.layer = "Θ"
+    for _ in range(2):
+        l.update_classical_metrics(0.0, 0.0, 1.0)
+        l.update_eq(0.0)
+        l.deliver()
+    assert l.layer == "C"
+
+
+def test_stamp_lccm_metadata():
+    meta = {}
+    stamp_lccm_metadata(meta, "free_energy", {"k_theta": 1.0})
+    assert meta["lccm"]["mode"] == "free_energy"
+    assert meta["lccm"]["k_theta"] == 1.0

--- a/tests/test_rho_variational.py
+++ b/tests/test_rho_variational.py
@@ -1,0 +1,38 @@
+import math
+
+from Causal_Web.engine.engine_v2.rho.variational import (
+    lambda_to_coeffs,
+    update_rho_variational,
+    stamp_rho_metadata,
+)
+
+
+def test_lambda_to_coeffs():
+    ad, al, et = lambda_to_coeffs(0.2, 0.1, 0.7, 0.5)
+    assert math.isclose(ad, 0.2)
+    assert math.isclose(al, 0.1)
+    assert math.isclose(et, 0.35)
+
+
+def test_update_rho_variational():
+    rho, d_eff = update_rho_variational(
+        1.0,
+        [0.0, 2.0],
+        3.0,
+        lambda_s=0.2,
+        lambda_l=0.1,
+        lambda_I=0.7,
+        eta=0.5,
+        d0=1.0,
+        gamma=1.0,
+        rho0=1.0,
+    )
+    assert math.isclose(rho, 1.95)
+    assert d_eff == 2
+
+
+def test_stamp_rho_metadata():
+    meta = {}
+    stamp_rho_metadata(meta, "variational", {"lambda_s": 0.2})
+    assert meta["rho_update"]["mode"] == "variational"
+    assert meta["rho_update"]["lambda_s"] == 0.2


### PR DESCRIPTION
## Summary
- add variational density update with lambda-to-coefficient mapping
- implement free-energy score for LCCM and mode switching
- expose configuration flags for rho and LCCM modes

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689adeadaaa48325ba6c55d85313594b