### PR TITLE
Handle dynamic metric keys and add DOE process pool option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Added DOE runner with invariant checks and metrics logging.
 - Runner CLI now accepts separate experiment (`--exp`) and base (`--base`)
   configs, persists per-sample seeds and gate metrics, and supports
-  parallel execution via `--parallel`.
+  parallel execution via `--parallel` (use `--processes` for a process pool).
 - DOE summaries now record selected gates and aggregate gate metrics
   (mean and standard deviation).
 - Introduced split-step quantum walk helpers with dispersion and lightcone

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,4 @@
+import csv
 import json
 from pathlib import Path
 
@@ -7,15 +8,20 @@ from telemetry.metrics import MetricsLogger
 def test_metrics_logger(tmp_path: Path):
     logger = MetricsLogger(tmp_path)
     logger.log(0, {"g": 1.0}, {"Delta": 1.0}, 0, {"G1": 1.0}, {})
+    logger.log(1, {"g": 2.0}, {"Delta": 2.0}, 1, {"G2": 2.0}, {})
     cfg = type(
         "Cfg",
         (),
-        {"samples": 1, "groups": {"g": (0, 1)}, "seed": 0, "gates": [1]},
+        {"samples": 2, "groups": {"g": (0, 1)}, "seed": 0, "gates": [1, 2]},
     )()
-    logger.flush(cfg, [{"g": 1.0}])
-    assert (tmp_path / "metrics.csv").exists()
+    logger.flush(cfg, [{"g": 1.0}, {"g": 2.0}])
+    csv_path = tmp_path / "metrics.csv"
+    assert csv_path.exists()
+    rows = list(csv.DictReader(csv_path.open()))
+    assert rows[1]["G2"] == "2.0"
     summary = json.loads((tmp_path / "summary.json").read_text())
     assert summary["seed"] == 0
-    assert summary["gates"] == [1]
+    assert summary["gates"] == [1, 2]
     assert summary["metrics_agg"]["mean_G1"] == 1.0
     assert summary["metrics_agg"]["std_G1"] == 0.0
+    assert summary["metrics_agg"]["mean_G2"] == 2.0


### PR DESCRIPTION
## Summary
- Ensure `MetricsLogger.flush` writes all observed metric keys and aggregates gate metrics from every record
- Simplify DOE runner result collection and add `--processes` flag to switch to `ProcessPoolExecutor`
- Document new runner flag and extend metrics logger tests

## Testing
- `python -m compileall Causal_Web telemetry experiments tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b5cc51f288325945b951949ac5553