### PR TITLE
Cache edge phases and neighbor means

### DIFF
--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -192,14 +192,17 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
 
     d0_arr = np.asarray(edges["d0"], dtype=np.float32)
     d0_int = np.floor(d0_arr).astype(np.int32)
+    phi_arr = np.asarray(edges["phi"], dtype=np.float32)
+    A_arr = np.asarray(edges["A"], dtype=np.float32)
     edges = {
         "src": np.asarray(edges["src"], dtype=np.int32),
         "dst": np.asarray(edges["dst"], dtype=np.int32),
         "d0": d0_arr,
         "rho": np.asarray(edges["rho"], dtype=np.float32),
         "alpha": np.asarray(edges["alpha"], dtype=np.float32),
-        "phi": np.asarray(edges["phi"], dtype=np.float32),
-        "A": np.asarray(edges["A"], dtype=np.float32),
+        "phi": phi_arr,
+        "A": A_arr,
+        "phase": np.exp(1j * (phi_arr + A_arr)).astype(np.complex64),
         "U": np.asarray(edges["U"], dtype=np.complex64),
         "sigma": np.asarray(edges["sigma"], dtype=np.float32),
         "d_eff": np.maximum(1, d0_int),

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ via a Monte-Carlo path sampler over the graph's causal structure.
   (mean and standard deviation).
 - Introduced split-step quantum walk helpers with dispersion and lightcone
   experiment utilities and configuration knobs.
+- Metrics logger now emits `summary_invariants.json` with pass rates for gate
+  invariants.
 
 ## Table of Contents
 - [Quick Start](#quick-start)

--- a/telemetry/metrics.py
+++ b/telemetry/metrics.py
@@ -60,7 +60,7 @@ class MetricsLogger:
         self.records.append(entry)
 
     def flush(self, cfg, samples: Iterable[Dict[str, float]]) -> None:
-        """Write all stored metrics to ``metrics.csv`` and ``summary.json``."""
+        """Write all stored metrics and summaries to disk."""
 
         self.out_dir.mkdir(parents=True, exist_ok=True)
         csv_path = self.out_dir / "metrics.csv"
@@ -92,3 +92,15 @@ class MetricsLogger:
             "metrics_agg": _aggregate(self.records) if self.records else {},
         }
         (self.out_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+
+        inv_keys = {
+            k for row in self.records for k in row.keys() if k.startswith("inv_")
+        }
+        if inv_keys:
+            inv_summary: Dict[str, float] = {}
+            for k in sorted(inv_keys):
+                vals = [bool(r.get(k)) for r in self.records]
+                inv_summary[k] = float(np.mean(vals))
+            (self.out_dir / "summary_invariants.json").write_text(
+                json.dumps(inv_summary, indent=2)
+            )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,8 +7,8 @@ from telemetry.metrics import MetricsLogger
 
 def test_metrics_logger(tmp_path: Path):
     logger = MetricsLogger(tmp_path)
-    logger.log(0, {"g": 1.0}, {"Delta": 1.0}, 0, {"G1": 1.0}, {})
-    logger.log(1, {"g": 2.0}, {"Delta": 2.0}, 1, {"G2": 2.0}, {})
+    logger.log(0, {"g": 1.0}, {"Delta": 1.0}, 0, {"G1": 1.0}, {"inv_ok": True})
+    logger.log(1, {"g": 2.0}, {"Delta": 2.0}, 1, {"G2": 2.0}, {"inv_ok": False})
     cfg = type(
         "Cfg",
         (),
@@ -25,3 +25,5 @@ def test_metrics_logger(tmp_path: Path):
     assert summary["metrics_agg"]["mean_G1"] == 1.0
     assert summary["metrics_agg"]["std_G1"] == 0.0
     assert summary["metrics_agg"]["mean_G2"] == 2.0
+    inv_summary = json.loads((tmp_path / "summary_invariants.json").read_text())
+    assert inv_summary["inv_ok"] == 0.5


### PR DESCRIPTION
## Summary
- cache edge phases and reuse neighbor mean computations in v2 adapter
- drop unused intensity output and rely on precomputed packet intensities
- log per-gate invariant pass rates to `summary_invariants.json`

## Testing
- `python -m compileall Causal_Web`
- `pytest` *(fails: import file mismatch for tests/test_gates.py)*
- `pytest tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_689b6b9c13248325b60bcaba9682d84b