### PR TITLE
Refactor gate harness and add scalar rho update option

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -138,6 +138,7 @@ class Config:
         "gamma": 0.8,
         "rho0": 1.0,
         "inject_mode": "incoming",
+        "vectorized": True,
     }
     rho = {
         "update_mode": "heuristic",

--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -707,7 +707,14 @@ class EngineAdapter:
                 ptr = adj.get("nbr_ptr")
                 nbr = adj.get("nbr_idx")
                 rho_arr = edges["rho"]
-                if ptr is not None and nbr is not None and len(ptr) > 1:
+                # Use cached neighbour sums for vectorised ρ updates unless
+                # explicitly disabled for Gauss–Seidel semantics.
+                if (
+                    ptr is not None
+                    and nbr is not None
+                    and len(ptr) > 1
+                    and Config.rho_delay.get("vectorized", True)
+                ):
                     if self._neigh_sums_frame != self._frame:
                         if nbr.size > 0:
                             self._neigh_sums_cache = np.add.reduceat(

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -53,6 +53,7 @@
         "gamma": 0.0,
         "rho0": 0.0,
         "inject_mode": "incoming",
+        "vectorized": true,
     },
     "rho": {
         "update_mode": "heuristic",

--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ mapping:
   "windowing": {"W0": 4, "zeta1": 0.3, "zeta2": 0.3, "a": 0.7, "b": 0.4,
                  "T_hold": 2, "C_min": 0.1, "k_rho": 1.0},
   "rho_delay": {"alpha_d": 0.1, "alpha_leak": 0.01, "eta": 0.2,
-                "gamma": 0.8, "rho0": 1.0, "inject_mode": "incoming"},
+                "gamma": 0.8, "rho0": 1.0, "inject_mode": "incoming",
+                "vectorized": true},
   "rho": {"update_mode": "heuristic", "variational": {"lambda_s": 0.2, "lambda_l": 0.01, "lambda_I": 1.0}},
   "lccm": {"mode": "thresholds", "free_energy": {"k_theta": 1.0, "k_c": 1.0, "k_q": 0.2, "F_min": 0.3}},
   "epsilon_pairs": {"delta_ttl": 8, "ancestry_prefix_L": 16,
@@ -192,7 +193,9 @@ mapping:
 The `windowing` values control vertex window advancement. `rho_delay` affects how edge density relaxes toward a baseline. The `rho` group selects the update rule for ρ while `lccm` chooses the Θ→C transition criterion.
 The `inject_mode` option selects
 whether ρ input applies to `"incoming"` (default), `"incident"` or `"outgoing"` edges.
-Non-incoming modes average per-packet Θ intensities over the window to set the injection intensity.
+Non-incoming modes average per-packet Θ intensities over the window to set the injection intensity. The optional
+`vectorized` flag toggles batch updates: set it to `false` to apply per-delivery Gauss–Seidel ordering when studies
+require exact event sequencing.
 `epsilon_pairs` governs dynamic
 ε-pair behaviour – seeds with a limited TTL can bind to form temporary bridge
 edges whose `sigma` values decay unless reinforced. The default `delta_ttl`
@@ -206,7 +209,8 @@ many seeds are removed due to this limit for post-run diagnostics.
 Q-delivery instead of the default moment-angle emission once per
 vertex-window. The `ancestry` group tunes
 phase-moment updates and decay. `bell` sets mutual information gates for Bell
-pair matching. Bridge creation and removal now emit `bridge_created` and
+pair matching. The hidden variable ζ is drawn from the destination's ancestry
+hash with optional noise blended according to `beta_h`. Bridge creation and removal now emit `bridge_created` and
 `bridge_removed` events (carrying a stable synthetic `bridge_id` and final `σ`),
 providing additional telemetry for analysis.
 `seed_emitted` and `seed_dropped` events capture ε-pair propagation and


### PR DESCRIPTION
## Summary
- Rewire gate benchmarks to engine v2 helpers and compute two-path visibility without legacy tick engine
- Add `rho_delay.vectorized` flag to allow scalar Gauss–Seidel ρ updates when strict event ordering is required
- Document Bell ζ source and new ρ update option in README

## Testing
- `pip install numpy networkx pytest pydantic`
- `black Causal_Web experiments/gates.py`
- `python -m compileall Causal_Web experiments`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b779298cc8325ba032169780afef3