### PR TITLE
test: guard against legacy tick imports

### DIFF
--- a/tests/test_no_tick_imports.py
+++ b/tests/test_no_tick_imports.py
@@ -1,0 +1,30 @@
+import ast
+from pathlib import Path
+
+FORBIDDEN = {"Causal_Web.engine.tick_engine", "Causal_Web.engine.models.tick"}
+
+
+def test_no_tick_engine_import_outside_legacy():
+    """Ensure legacy tick modules are not imported outside legacy folders."""
+    root = Path(__file__).resolve().parents[1]
+    for path in root.rglob("*.py"):
+        if any("legacy" in part for part in path.parts):
+            continue
+        with path.open("r", encoding="utf-8") as f:
+            try:
+                tree = ast.parse(f.read(), filename=str(path))
+            except SyntaxError:
+                continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in FORBIDDEN:
+                        raise AssertionError(f"{path} imports {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module in FORBIDDEN:
+                    raise AssertionError(f"{path} imports {module}")
+                for alias in node.names:
+                    full = f"{module}.{alias.name}" if module else alias.name
+                    if full in FORBIDDEN:
+                        raise AssertionError(f"{path} imports {full}")


### PR DESCRIPTION
## Summary
- add test that fails if legacy tick engine modules are imported outside any `legacy` folder
- tag v2.6-legacy-last for rollback before legacy removal

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b90204cec8325b9e9014885dcf477