### PR TITLE
Cache edge phases and default incremental ρ updates

### DIFF
--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -2,7 +2,9 @@
 
 The :func:`load_graph_arrays` helper converts a graph JSON dictionary
 into arrays suitable for the experimental engine. Missing fields are
-filled from :mod:`Causal_Web.config.Config` defaults.
+filled from :mod:`Causal_Web.config.Config` defaults. Edge dictionaries
+include a cached ``phase`` value computed as ``exp(1j * (phi + A))`` so
+packet delivery routines can skip per-event exponentiation.
 """
 
 from __future__ import annotations
@@ -195,6 +197,7 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
     d0_int = np.floor(d0_arr).astype(np.int32)
     phi_arr = np.asarray(edges["phi"], dtype=np.float32)
     A_arr = np.asarray(edges["A"], dtype=np.float32)
+    phase_arr = np.exp(1j * (phi_arr + A_arr)).astype(np.complex64)
     edges = {
         "src": np.asarray(edges["src"], dtype=np.int32),
         "dst": np.asarray(edges["dst"], dtype=np.int32),
@@ -203,7 +206,7 @@ def load_graph_arrays(graph_json: Dict[str, Any]) -> GraphArrays:
         "alpha": np.asarray(edges["alpha"], dtype=np.float32),
         "phi": phi_arr,
         "A": A_arr,
-        "phase": np.exp(1j * (phi_arr + A_arr)).astype(np.complex64),
+        "phase": phase_arr,
         "U": np.asarray(edges["U"], dtype=np.complex64),
         "sigma": np.asarray(edges["sigma"], dtype=np.float32),
         "d_eff": np.maximum(1, d0_int),

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The `inject_mode` option selects
 whether ρ input applies to `"incoming"` (default), `"incident"` or `"outgoing"` edges.
 Non-incoming modes average per-packet Θ intensities over the window to set the injection intensity. The optional
 `vectorized` flag toggles batch updates: set it to `false` to apply per-delivery Gauss–Seidel ordering when studies
-require exact event sequencing.
+require exact event sequencing. With vectorized updates enabled (the default) neighbour sums are maintained incrementally so large fan-in bursts avoid full recomputation while approximating Gauss–Seidel behaviour.
 `epsilon_pairs` governs dynamic
 ε-pair behaviour – seeds with a limited TTL can bind to form temporary bridge
 edges whose `sigma` values decay unless reinforced. The default `delta_ttl`
@@ -325,6 +325,8 @@ Edge propagation now batches phase factors and attenuations before offloading th
 complex multiply to CuPy, falling back to vectorised NumPy when CUDA is
 unavailable. A micro-benchmark under `tests/perf_edge_kernel.py` asserts the
 kernel processes one million edges in under 100 ms on compatible hardware.
+Edge phases ``exp(1j * (phi + A))`` are cached during graph loading so packet
+delivery avoids redundant exponentials.
 
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. The `log_interval` option controls how often metrics and graph snapshots are written, while `logging_mode` selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.

--- a/experiments/gates.py
+++ b/experiments/gates.py
@@ -34,7 +34,11 @@ def _gate1_visibility() -> float:
         p_v.copy(),
         deque(),
         {"psi": np.array([1, 0], np.complex64), "p": [0.0, 0.0], "bit": 0},
-        {"alpha": 0.5, "phi": 0.0, "U": np.eye(2, dtype=np.complex64)},
+        {
+            "alpha": 0.5,
+            "phase": 1.0 + 0.0j,
+            "U": np.eye(2, dtype=np.complex64),
+        },
         update_p=False,
     )
     _, psi_acc, _, _, _, _, _ = deliver_packet(
@@ -43,7 +47,11 @@ def _gate1_visibility() -> float:
         p_v.copy(),
         deque(),
         {"psi": psi_a, "p": [0.0, 0.0], "bit": 0},
-        {"alpha": 1.0, "phi": 0.0, "U": np.eye(2, dtype=np.complex64)},
+        {
+            "alpha": 1.0,
+            "phase": 1.0 + 0.0j,
+            "U": np.eye(2, dtype=np.complex64),
+        },
         update_p=False,
     )
 
@@ -54,7 +62,11 @@ def _gate1_visibility() -> float:
         p_v.copy(),
         deque(),
         {"psi": np.array([1, 0], np.complex64), "p": [0.0, 0.0], "bit": 0},
-        {"alpha": 0.5, "phi": np.pi / 2, "U": np.eye(2, dtype=np.complex64)},
+        {
+            "alpha": 0.5,
+            "phase": np.exp(1j * (np.pi / 2)),
+            "U": np.eye(2, dtype=np.complex64),
+        },
         update_p=False,
     )
     _, psi_acc, _, _, _, _, _ = deliver_packet(
@@ -63,7 +75,11 @@ def _gate1_visibility() -> float:
         p_v.copy(),
         deque(),
         {"psi": psi_b, "p": [0.0, 0.0], "bit": 0},
-        {"alpha": 1.0, "phi": 0.0, "U": np.eye(2, dtype=np.complex64)},
+        {
+            "alpha": 1.0,
+            "phase": 1.0 + 0.0j,
+            "U": np.eye(2, dtype=np.complex64),
+        },
         update_p=False,
     )
 
@@ -161,7 +177,11 @@ def _energy_total() -> float:
     p_v = np.zeros(2, dtype=np.float32)
     bit_deque: deque[int] = deque()
     packet = {"psi": np.array([1, 0], np.complex64), "p": [0.4, 0.6], "bit": 1}
-    edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": np.eye(2, dtype=np.complex64)}
+    edge = {
+        "alpha": 1.0,
+        "phase": 1.0 + 0.0j,
+        "U": np.eye(2, dtype=np.complex64),
+    }
     _, psi_acc, p_v, (bit, conf), *_ = deliver_packet(
         0, psi_acc, p_v, bit_deque, packet, edge
     )

--- a/tests/test_qtheta_c.py
+++ b/tests/test_qtheta_c.py
@@ -16,8 +16,7 @@ def test_deliver_packet_updates_fields():
     packet = {"depth_arr": 2, "psi": [1.0, 0.0], "p": [0.2, 0.8], "bit": 1}
     edge = {
         "alpha": 0.5,
-        "phi": 0.1,
-        "A": 0.2,
+        "phase": np.exp(1j * (0.1 + 0.2)),
         "U": [[1.0, 0.0], [0.0, 1.0]],
     }
 
@@ -40,7 +39,11 @@ def test_intensity_theta_layer_ignores_other_contributions():
     depth, psi_acc, p_v = 0, np.zeros(2, dtype=np.complex128), np.array([0.5, 0.5])
     bits = deque()
     packet = {"depth_arr": 1, "psi": [1.0, 0.0], "p": [0.1, 0.2], "bit": 1}
-    edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": [[1.0, 0.0], [0.0, 1.0]]}
+    edge = {
+        "alpha": 1.0,
+        "phase": 1.0 + 0.0j,
+        "U": [[1.0, 0.0], [0.0, 1.0]],
+    }
 
     _, _, _, _, intensities, mu, kappa = deliver_packet(
         depth, psi_acc, p_v, bits, packet, edge
@@ -52,7 +55,11 @@ def test_intensity_c_layer_only_counts_bits():
     depth, psi_acc, p_v = 0, np.zeros(2, dtype=np.complex128), np.array([0.5, 0.5])
     bits = deque()
     packet = {"depth_arr": 1, "psi": [1.0, 0.0], "p": [0.1, 0.2], "bit": 0}
-    edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": [[1.0, 0.0], [0.0, 1.0]]}
+    edge = {
+        "alpha": 1.0,
+        "phase": 1.0 + 0.0j,
+        "U": [[1.0, 0.0], [0.0, 1.0]],
+    }
 
     _, _, _, _, intensities, mu, kappa = deliver_packet(
         depth, psi_acc, p_v, bits, packet, edge
@@ -64,7 +71,11 @@ def test_p_v_unchanged_when_update_p_false():
     depth, psi_acc, p_v = 0, np.zeros(2, dtype=np.complex128), np.array([0.7, 0.3])
     bits = deque()
     packet = {"depth_arr": 1, "psi": [1.0, 0.0], "p": [0.1, 0.9], "bit": 1}
-    edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": [[1.0, 0.0], [0.0, 1.0]]}
+    edge = {
+        "alpha": 1.0,
+        "phase": 1.0 + 0.0j,
+        "U": [[1.0, 0.0], [0.0, 1.0]],
+    }
 
     _, _, p_out, _, _, _, _ = deliver_packet(
         depth, psi_acc, p_v, bits, packet, edge, update_p=False

--- a/tests_legacy/test_gates.py
+++ b/tests_legacy/test_gates.py
@@ -183,7 +183,11 @@ def _energy_total():
     p_v = np.zeros(2, dtype=np.float32)
     bit_deque: deque[int] = deque()
     packet = {"psi": np.array([1, 0], np.complex64), "p": [0.4, 0.6], "bit": 1}
-    edge = {"alpha": 1.0, "phi": 0.0, "A": 0.0, "U": np.eye(2, dtype=np.complex64)}
+    edge = {
+        "alpha": 1.0,
+        "phase": 1.0 + 0.0j,
+        "U": np.eye(2, dtype=np.complex64),
+    }
     depth, psi_acc, p_v, (bit, conf), intensities, mu, kappa = deliver_packet(
         0, psi_acc, p_v, bit_deque, packet, edge
     )


### PR DESCRIPTION
## Summary
- precompute `exp(i(phi + A))` for each edge and drop runtime phase exponentials
- document incremental neighbour-sum updates as the default density strategy

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `python -m Causal_Web.main` *(fails: JSONDecodeError: Expecting property name enclosed in double quotes)*
- `python bundle_run.py` *(fails: file not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c1c17de488325be99fe428b21ed14