### PR TITLE
Implement gate metrics for locality, conservation and Bell tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Gate harness now executes Gates 1–6 via engine primitives rather than
   returning proxy metrics.
 - Gate metrics now capture interference visibility, delay slopes and
-  relaxation times, and LCCM hysteresis transition depths for Gates 1–3.
+  relaxation times, LCCM hysteresis transition depths, ε-pair locality
+  statistics, conservation residuals and CHSH outcomes with marginal
+  bias for Gates 1–6.
 - Introduced split-step quantum walk helpers with dispersion and lightcone
   experiment utilities and configuration knobs.
 - Metrics logger now emits `summary_invariants.json` with pass rates for gate


### PR DESCRIPTION
## Summary
- Add epsilon-pair locality metrics (bridge count, bind depth, TTL violations, sigma lifetime)
- Compute conservation residual across windows for Gate 5
- Generate CHSH and marginal bias metrics for Gate 6 and wire into invariants

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689caeb0d19c8325af4727c138fde60c