### PR TITLE
Wire gate metrics and add DOE variance guard

### DIFF
--- a/experiments/gates.py
+++ b/experiments/gates.py
@@ -336,6 +336,13 @@ def run_gates(config: Dict[str, float], which: List[int]) -> Dict[str, float]:
     -------
     dict
         Mapping of metric names to values together with invariant checks.
+
+    Notes
+    -----
+    For backward compatibility the legacy short names ``G1``–``G6`` are
+    also emitted when a gate produces a single primary metric. These mirror
+    the more descriptive entries such as ``G1_visibility`` or
+    ``G6_CHSH``.
     """
 
     metrics: Dict[str, float | bool] = {}
@@ -346,6 +353,7 @@ def run_gates(config: Dict[str, float], which: List[int]) -> Dict[str, float]:
         vis1 = _gate1_visibility()
         vis2 = _gate1_visibility()
         metrics["G1_visibility"] = vis1
+        metrics["G1"] = vis1
         deliveries.append({"d_arr": 2.0, "d_src": 0.0})
         metrics["inv_gate_determinism_ok"] = checks.determinism([vis1, vis2], 1e-12)
         prob = _gate1_probability(np.pi / 2)
@@ -355,29 +363,34 @@ def run_gates(config: Dict[str, float], which: List[int]) -> Dict[str, float]:
         slope, tau = _gate2_delay()
         metrics["G2_delay_slope"] = slope
         metrics["G2_relax_tau"] = tau
+        metrics["G2"] = slope
     if 3 in which:
         q2t, t2q, width = _gate3_hysteresis()
         metrics["G3_q_to_theta_at"] = float(q2t)
         metrics["G3_theta_to_q_at"] = float(t2q)
         metrics["G3_hysteresis_width"] = float(width)
+        metrics["G3"] = float(width)
     if 4 in which:
-        metrics.update(_gate4_metrics())
+        gate4 = _gate4_metrics()
+        metrics.update(gate4)
+        metrics["G4"] = gate4.get("G4_bridge_count", 0.0)
 
     energy1 = _energy_total()
     energy2 = _energy_total()
     if 5 in which:
         residual = _gate5_conservation_residual()
         metrics["G5_conservation_residual"] = residual
+        metrics["G5"] = residual
     else:
         residual = energy2 - energy1
     bell_cfg = config.get("bell", {}) if isinstance(config, dict) else {}
     if 6 in which:
-        metrics.update(
-            _gate6_chsh(
-                bell_cfg.get("mi_mode", "MI_strict"),
-                float(bell_cfg.get("kappa_a", 0.0)),
-            )
+        gate6 = _gate6_chsh(
+            bell_cfg.get("mi_mode", "MI_strict"),
+            float(bell_cfg.get("kappa_a", 0.0)),
         )
+        metrics.update(gate6)
+        metrics["G6"] = gate6.get("G6_CHSH", 0.0)
     seq = [("q1", "h1", "m1")]
 
     metrics.update(

--- a/tests/test_experiments_runner.py
+++ b/tests/test_experiments_runner.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from experiments.runner import run
+import logging
 
 
 def create_config(tmp_path: Path) -> Path:
@@ -94,3 +95,12 @@ def test_runner_process_pool_determinism(tmp_path: Path):
             row.pop("ts", None)
 
     assert metrics1 == metrics2
+
+
+def test_variance_guard_emits_warning(tmp_path: Path, caplog):
+    cfg_path = create_config(tmp_path)
+    base_path = create_base(tmp_path)
+    out_dir = tmp_path / "warn"
+    with caplog.at_level(logging.WARNING):
+        run(cfg_path, base_path, out_dir)
+    assert any("no variation across DOE" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- route gate wrapper metrics to real per-gate helpers and emit both descriptive and legacy short names
- warn after DOE runs when any gate metric shows zero standard deviation
- cover variance guard with a regression test

## Testing
- `black experiments/gates.py experiments/runner.py tests/test_experiments_runner.py`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb4e3b9048325a1750349fcb7c174