### PR TITLE
feat: add CuPy support to density and tensor ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ These settings drive the helper modules in ``experiments.dispersion`` and
 ## GPU and Distributed Acceleration
 The engine optionally accelerates per-edge calculations on the GPU when [Cupy](https://cupy.dev) is installed and can shard classical zones across a [Ray](https://www.ray.io) cluster. Classical nodes are partitioned into coherent zones and dispatched in parallel to Ray workers; if Ray is unavailable an info-level message is logged and processing continues locally. Select the backend with `Config.backend` or `--backend` (`cpu` by default, `cupy` for CUDA).
 
+Density accumulation and matrix-product-state propagation also leverage CuPy
+when the backend is set to `cupy`, keeping computation on the GPU.
+
 Ray cluster initialisation can be customised via the `--ray-init` flag. Pass a JSON string of keyword arguments forwarded to `ray.init`, for example:
 
 ```bash


### PR DESCRIPTION
## Summary
- support CuPy arrays when depositing energy into the density field
- run matrix product state propagation on the GPU when `Config.backend` is `cupy`
- document the additional GPU support in the README

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cbf2f31148325967c0fe039495eb1