### PR TITLE
Refactor engine mode handling and clean TODOs

### DIFF
--- a/Causal_Web/__init__.py
+++ b/Causal_Web/__init__.py
@@ -15,6 +15,3 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - attribute access
     if name == "NodeManager":
         raise RuntimeError("NodeManager has been removed; use EngineAdapter instead")
     raise AttributeError(name)
-
-
-# TODO: legacy refactor

--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -4,6 +4,14 @@ import math
 import os
 import shutil
 import threading
+from enum import Enum
+
+
+class EngineMode(str, Enum):
+    """Enumeration of available simulation engines."""
+
+    TICK = "tick"
+    V2 = "v2"
 
 
 class Config:
@@ -28,8 +36,8 @@ class Config:
     backend:
         Compute backend to use: ``"cpu"`` (default) or ``"cupy"``.
     engine_mode:
-        Selects the simulation engine: ``"tick"`` for the legacy engine or
-        ``"v2"`` for the strict-local core.
+        Selects the simulation engine via :class:`EngineMode`. ``TICK`` refers
+        to the legacy engine while ``V2`` enables the strict-local core.
     windowing:
         Mapping of windowing coefficients used by the v2 engine. Expected keys
         include ``W0``, ``zeta1``, ``zeta2``, ``a``, ``b``, ``T_hold`` and
@@ -115,8 +123,8 @@ class Config:
     # Parameters for dispersion experiments
     dispersion = {"k_values": [0.0, 0.1]}
 
-    #: Selected engine implementation: ``"v2"`` (strict-local) or ``"tick"``
-    engine_mode = "v2"  # TODO: legacy refactor
+    #: Selected engine implementation.
+    engine_mode: EngineMode = EngineMode.V2
 
     # Parameters for the experimental strict-local engine (``engine_mode = "v2"``)
     windowing = {
@@ -601,6 +609,8 @@ class Config:
         for key, value in data.items():
             if not hasattr(cls, key):
                 continue
+            if key == "engine_mode":
+                value = EngineMode(value)
             if key == "graph_file" and not os.path.isabs(value):
                 value = os.path.join(base_dir, value)
             current = getattr(cls, key)

--- a/Causal_Web/engine/analysis/mc_paths.py
+++ b/Causal_Web/engine/analysis/mc_paths.py
@@ -70,6 +70,16 @@ def yen_k_shortest_paths(
     return paths
 
 
+def _edge_attr(data: dict, name: str, legacy: str, default: float) -> float:
+    """Return edge attribute ``name`` falling back to ``legacy``."""
+
+    if name in data:
+        return float(data[name])
+    if legacy in data:
+        return float(data[legacy])
+    return float(default)
+
+
 def accumulate_path(graph: nx.DiGraph, path: Sequence[Hashable]) -> PathInfo:
     """Accumulate delay, phase and attenuation for ``path``.
 
@@ -85,8 +95,6 @@ def accumulate_path(graph: nx.DiGraph, path: Sequence[Hashable]) -> PathInfo:
         Sequence of node identifiers representing a simple path.
     """
 
-    # TODO: legacy refactor
-
     delay = 0.0
     phase = 0.0
     attenuation = 1.0
@@ -94,8 +102,8 @@ def accumulate_path(graph: nx.DiGraph, path: Sequence[Hashable]) -> PathInfo:
     for u, v in nx.utils.pairwise(path):
         data = graph[u][v]
         delay += float(data.get("delay", 0.0))
-        phase += float(data.get("phase", data.get("phase_shift", 0.0)))
-        attenuation *= float(data.get("atten", data.get("attenuation", 1.0)))
+        phase += _edge_attr(data, "phase", "phase_shift", 0.0)
+        attenuation *= _edge_attr(data, "atten", "attenuation", 1.0)
 
     return PathInfo(list(path), delay, phase, attenuation)
 

--- a/Causal_Web/engine/logging/logger.py
+++ b/Causal_Web/engine/logging/logger.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 """Lightweight JSON line logger for the v2 engine."""
 
-# TODO: legacy refactor
-
 import json
 from pathlib import Path
 from typing import Any

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -21,7 +21,7 @@ from PySide6.QtWidgets import (
     QComboBox,
 )
 
-from ..config import Config
+from ..config import Config, EngineMode
 from ..graph.io import load_graph, save_graph, new_graph
 from ..graph.model import GraphModel
 from ..gui.state import (
@@ -211,7 +211,7 @@ class MainWindow(QMainWindow):
         self.tick_label = QLabel("0")
         layout.addRow("Arrival Depth", self.tick_label)
 
-        if getattr(Config, "engine_mode", "tick") == "v2":
+        if Config.engine_mode == EngineMode.V2:
             self.depth_label = QLabel("0")
             layout.addRow("Depth", self.depth_label)
             self.window_label = QLabel("0")
@@ -305,7 +305,7 @@ class MainWindow(QMainWindow):
         with Config.state_lock:
             running = Config.is_running
             tick = Config.current_tick
-        if getattr(Config, "engine_mode", "tick") == "v2" and running:
+        if Config.engine_mode == EngineMode.V2 and running:
             frame = tick_engine.step()
             tick = tick_engine.current_frame()
             Config.current_tick = tick
@@ -322,7 +322,7 @@ class MainWindow(QMainWindow):
                 tick_engine.graph.to_dict() if running else get_graph().to_dict()
             )
             self.tick_label.setText(str(tick))
-            if getattr(Config, "engine_mode", "tick") == "v2":
+            if Config.engine_mode == EngineMode.V2:
                 snap = tick_engine.snapshot_for_ui()
                 if hasattr(self, "depth_label"):
                     self.depth_label.setText(str(snap.get("depth", 0)))
@@ -391,7 +391,7 @@ class MainWindow(QMainWindow):
             strategy = f"modular-{self.modular_combo.currentText()}"
         Config.density_calc = strategy
         Config.max_ticks = self.limit_spin.value()
-        if getattr(Config, "engine_mode", "tick") == "v2":
+        if Config.engine_mode == EngineMode.V2:
             tick_engine.build_graph(Config.graph_file)
             with Config.state_lock:
                 if Config.is_running:
@@ -419,7 +419,7 @@ class MainWindow(QMainWindow):
         """Toggle between pausing and resuming the simulation."""
         with Config.state_lock:
             running = Config.is_running
-        if getattr(Config, "engine_mode", "tick") == "v2":
+        if Config.engine_mode == EngineMode.V2:
             if running:
                 tick_engine.pause()
                 with Config.state_lock:
@@ -440,7 +440,7 @@ class MainWindow(QMainWindow):
 
     def stop_simulation(self) -> None:
         """Stop the simulation immediately."""
-        if getattr(Config, "engine_mode", "tick") == "v2":
+        if Config.engine_mode == EngineMode.V2:
             tick_engine.stop()
             with Config.state_lock:
                 Config.is_running = False

--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ cost of memory.
 The `backend` option selects the compute backend. It defaults to `cpu` but
 may be set to `cupy` for CUDA acceleration.
 
-The `engine_mode` flag selects the simulation core. The default and only
-supported value `v2` enables the strict-local engine; the legacy `tick` engine
-has been removed. Parameter groups `windowing`, `rho_delay`, `epsilon_pairs`,
-`ancestry`, and `bell` provide advanced controls for the v2 engine. Each group
-is a nested mapping:
+The `engine_mode` flag selects the simulation core via the `EngineMode` enum.
+The default and only supported value `v2` (`EngineMode.V2`) enables the
+strict-local engine; the legacy `tick` engine has been removed. Parameter
+groups `windowing`, `rho_delay`, `epsilon_pairs`, `ancestry`, and `bell` provide
+advanced controls for the v2 engine. Each group is a nested mapping:
 
 ```json
 {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import json
 from copy import deepcopy
 import math
 import pytest
-from Causal_Web.config import Config
+from Causal_Web.config import Config, EngineMode
 
 
 def test_load_from_file_resolves_graph_file(tmp_path):
@@ -77,7 +77,7 @@ def test_load_engine_mode_and_param_groups(tmp_path):
     original_bell = Config.bell.copy()
     Config.load_from_file(str(cfg))
     try:
-        assert Config.engine_mode == "v2"
+        assert Config.engine_mode == EngineMode.V2
         assert Config.windowing["W0"] == 5
         assert Config.rho_delay["rho0"] == 1.2
         assert Config.epsilon_pairs["theta_max"] == 0.5


### PR DESCRIPTION
## Summary
- introduce `EngineMode` enum and parse `engine_mode` from config
- centralize legacy edge-attribute aliases in `mc_paths._edge_attr`
- remove obsolete legacy TODO comments and update README

## Testing
- `python -m compileall Causal_Web`
- `python -m Causal_Web.main --config /tmp/minconfig.json --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc376e0bc83258cf3455823af941c