### PR TITLE
Add deprecation warnings for legacy logging stubs

### DIFF
--- a/Causal_Web/legacy/__init__.py
+++ b/Causal_Web/legacy/__init__.py
@@ -1,3 +1,9 @@
 """Legacy modules retained for compatibility."""
 
-# TODO: legacy refactor
+import warnings
+
+warnings.warn(
+    "Causal_Web.legacy is deprecated and will be removed",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/Causal_Web/legacy/logging/__init__.py
+++ b/Causal_Web/legacy/logging/__init__.py
@@ -1,3 +1,9 @@
 """Legacy logging helpers kept for reference."""
 
-# TODO: legacy refactor
+import warnings
+
+warnings.warn(
+    "Causal_Web.legacy.logging is deprecated and will be removed",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/Causal_Web/legacy/logging/log_interpreter.py
+++ b/Causal_Web/legacy/logging/log_interpreter.py
@@ -1,9 +1,14 @@
 """Stub interpreter for legacy log files."""
 
-# TODO: legacy refactor
-
 from __future__ import annotations
+import warnings
 from typing import Any
+
+warnings.warn(
+    "Causal_Web.legacy.logging.log_interpreter is deprecated and will be removed",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def run_interpreter(*args: Any, **kwargs: Any) -> None:

--- a/Causal_Web/legacy/logging/log_utils.py
+++ b/Causal_Web/legacy/logging/log_utils.py
@@ -1,46 +1,61 @@
 """No-op utilities for legacy logging hooks."""
 
-# TODO: legacy refactor
-
 from __future__ import annotations
+import warnings
 from typing import Any
+
+warnings.warn(
+    "Causal_Web.legacy.logging.log_utils is deprecated and will be removed",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def attach_graph(graph: Any) -> None:
+    """Placeholder that ignores the provided graph."""
     return None
 
 
 def log_meta_node_ticks(tick: int) -> None:
+    """No-op for legacy tick logging."""
     return None
 
 
 def log_curvature_per_tick(tick: int) -> None:
+    """No-op for legacy curvature logging."""
     return None
 
 
 def snapshot_graph(tick: int) -> dict[str, Any]:
+    """Return an empty snapshot for compatibility."""
     return {}
 
 
 def write_output() -> None:
+    """No-op retained for compatibility."""
     return None
 
 
 def log_bridge_states(global_tick: int) -> None:
+    """No-op for legacy bridge state logging."""
     return None
 
 
 def log_metrics_per_tick(tick: int, metrics: dict[str, float] | None = None) -> None:
+    """No-op for per-tick metric logging."""
     return None
 
 
 def export_curvature_map(graph: Any) -> None:
+    """Placeholder that does nothing."""
     return None
 
 
 def export_global_diagnostics(graph: Any) -> None:
+    """Placeholder that does nothing."""
     return None
 
 
 def export_regional_maps(graph: Any) -> None:
+    """Placeholder that does nothing."""
     return None

--- a/tests/test_no_tick_imports.py
+++ b/tests/test_no_tick_imports.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 FORBIDDEN = {"legacy.engine.tick_engine", "legacy.engine.models.tick"}
 
-# TODO: legacy refactor
+# The legacy tick engine should remain isolated within legacy modules.
 
 
 def test_no_tick_engine_import_outside_legacy():


### PR DESCRIPTION
## Summary
- add deprecation warnings to legacy modules and logging helpers
- document isolation of tick engine imports in tests

## Testing
- `python -m compileall Causal_Web`
- `python -m Causal_Web.main` *(fails: JSONDecodeError: Expecting property name enclosed in double quotes)*
- `pytest`
- `python bundle_run.py` *(fails: can't open file 'bundle_run.py')*

------
https://chatgpt.com/codex/tasks/task_e_689ccc93ae2c8325982f52efe7de29c5