### PR TITLE
Remove obsolete legacy refactor TODO

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -3,10 +3,9 @@
 The :class:`EngineAdapter` exposes a subset of the legacy tick engine API but
 drives a new depth-based scheduler and the lightweight :mod:`lccm` model.  The
 adapter processes packets ordered by arrival depth and advances vertex windows
-according to the local causal consistency math.
+according to the local causal consistency math. The module has been refactored
+to remove outdated hooks from the legacy engine.
 """
-
-# TODO: legacy refactor
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- remove outdated TODO comment in engine adapter
- clarify adapter module docstring to note legacy hooks have been removed

## Testing
- `pip install numpy networkx pytest pydantic black`
- `black Causal_Web/engine/engine_v2/adapter.py`
- `python -m compileall Causal_Web`
- `pytest`
- `python -m Causal_Web.main` *(fails: JSONDecodeError expecting property name)*
- `python bundle_run.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccfb2b3148325883315a3f80bb6e8