### PR TITLE
fix: add engine factory and bridge recalibration

### DIFF
--- a/Causal_Web/engine/engine_v2/qtheta_c.py
+++ b/Causal_Web/engine/engine_v2/qtheta_c.py
@@ -106,7 +106,10 @@ def deliver_packet(
     psi_acc:
         Accumulator for quantum amplitudes.
     p_v:
-        Classical probability vector for the vertex.
+        Classical probability vector for the vertex. After accumulation the
+        vector is clipped to ``[0, 1]``, renormalised and any non-finite
+        values are replaced with zeros so empty or NaN inputs yield an
+        all-zero vector.
     bit_deque:
         Recent bits used for majority voting.
     packet:
@@ -145,6 +148,7 @@ def deliver_packet(
         total = float(np.sum(p_v))
         if total > 0:
             p_v = p_v / total
+        p_v = np.where(np.isfinite(p_v), p_v, np.zeros_like(p_v))
 
     bit_deque.append(int(packet.get("bit", 0)))
     while len(bit_deque) > max_deque:
@@ -199,7 +203,10 @@ def deliver_packets_batch(
     psi_acc:
         Accumulator for quantum amplitudes.
     p_v:
-        Classical probability vector for the vertex.
+        Classical probability vector for the vertex. After accumulation the
+        vector is clipped to ``[0, 1]``, renormalised and non-finite values
+        are replaced with zeros so empty or NaN inputs yield an all-zero
+        vector.
     bit_deque:
         Recent bits used for majority voting.
     psi, p, bits, depth_arr:
@@ -238,6 +245,7 @@ def deliver_packets_batch(
         total = float(np.sum(p_v))
         if total > 0:
             p_v = p_v / total
+        p_v = np.where(np.isfinite(p_v), p_v, np.zeros_like(p_v))
 
     bit_deque.extend(bits.tolist())
     while len(bit_deque) > max_deque:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ via a Monte-Carlo path sampler over the graph's causal structure.
   invariants.
 - Replaced legacy `NodeManager` with v2 `EngineAdapter` and removed the former
   from the public API.
+- `EngineAdapter` now exposes a `get_engine()` factory; the module no longer
+  instantiates a global engine at import time.
 
 ## Table of Contents
 - [Quick Start](#quick-start)

--- a/tests/test_engine_factory.py
+++ b/tests/test_engine_factory.py
@@ -1,0 +1,20 @@
+from importlib import reload
+
+from Causal_Web.engine.engine_v2 import adapter
+
+
+def test_get_engine_singleton():
+    adapter_module = reload(adapter)
+    assert adapter_module._ENGINE is None
+    eng1 = adapter_module.get_engine()
+    eng2 = adapter_module.get_engine()
+    assert eng1 is eng2
+
+
+def test_get_engine_multi_run(monkeypatch):
+    adapter_module = reload(adapter)
+    eng1 = adapter_module.get_engine()
+    eng1.stop()
+    monkeypatch.setattr(adapter_module, "_ENGINE", None, raising=False)
+    eng2 = adapter_module.get_engine()
+    assert eng1 is not eng2

--- a/tests/test_epairs_dynamic.py
+++ b/tests/test_epairs_dynamic.py
@@ -425,3 +425,29 @@ def test_bridge_delay_updates_after_rho_change():
     bridge = adapter._epairs.bridges[(0, 1)]
     expected = int(np.median([9, adapter._arrays.edges["d_eff"][1]]))
     assert bridge.d_bridge == expected
+
+
+def test_bridge_delay_recalibrates_on_reinforce():
+    adapter = EngineAdapter()
+    graph = {
+        "nodes": [{"id": "0"}, {"id": "1"}],
+        "edges": [
+            {"from": "0", "to": "1", "delay": 1.0},
+            {"from": "1", "to": "0", "delay": 1.0},
+        ],
+    }
+    adapter.build_graph(graph)
+    adapter._epairs._create_bridge(0, 1)
+    bridge = adapter._epairs.bridges[(0, 1)]
+    assert bridge.d_bridge == 1
+
+    adapter._arrays.edges["d_eff"][0] = 9
+    target = int(np.median([9, adapter._arrays.edges["d_eff"][1]]))
+
+    adapter._epairs.reinforce(0, 1)
+    assert bridge.d_bridge == 2
+
+    for _ in range(target - 2):
+        adapter._epairs.reinforce(0, 1)
+
+    assert bridge.d_bridge == target


### PR DESCRIPTION
## Summary
- lazily construct EngineAdapter via new get_engine factory and update simulation helpers
- recalibrate bridge delays on reinforcement to track drift
- guard p_v normalization against NaN values and document engine factory
- clarify engine factory comment and ensure helpers use get_engine
- document p_v sanitization and add tests for engine factory reuse across runs

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce08e68cc8325a257137fa260722c