### PR TITLE
Implement adaptive window sizing helper for LCCM

### DIFF
--- a/Causal_Web/engine/engine_v2/lccm/__init__.py
+++ b/Causal_Web/engine/engine_v2/lccm/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from .free_energy import free_energy_score
+from .window import WindowParams, WindowState, on_window_close
 
 
 @dataclass
@@ -177,4 +178,4 @@ class LCCM:
                 self._eq_hold = 0
 
 
-__all__ = ["LCCM"]
+__all__ = ["LCCM", "WindowParams", "WindowState", "on_window_close"]

--- a/Causal_Web/engine/engine_v2/lccm/window.py
+++ b/Causal_Web/engine/engine_v2/lccm/window.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+"""Event-driven window sizing helpers for the LCCM.
+
+This module implements a strictly local update rule for the LCCM window size
+``W(v)``.  The rule maintains an exponentially weighted moving average (EWMA) of
+the neighbour-density mean and maps it to a target window size that adapts to
+both density and vertex degree.  The actual ``W(v)`` is rate-limited toward the
+target to avoid oscillation.
+"""
+
+from dataclasses import dataclass
+import math
+from typing import Iterable, Sequence
+
+import numpy as np
+
+
+def robust_weighted_mean(
+    values: Sequence[float], weights: Sequence[float], *, trim: float = 0.1
+) -> float:
+    """Return a 10% trimmed weighted mean.
+
+    The values are sorted and a fraction ``trim`` of the total weight is dropped
+    from each tail before computing the weighted mean.  When ``trim`` is ``0``
+    the regular weighted mean is returned.
+    """
+
+    if len(values) == 0:
+        raise ValueError("values must be non-empty")
+    if len(values) != len(weights):
+        raise ValueError("values and weights must be the same length")
+    if not 0 <= trim < 0.5:
+        raise ValueError("trim fraction must be in [0, 0.5)")
+
+    v = np.asarray(values, dtype=float)
+    w = np.asarray(weights, dtype=float)
+
+    order = np.argsort(v)
+    v = v[order]
+    w = w[order]
+    total = w.sum()
+    if total <= 0:
+        raise ValueError("weights must sum to a positive number")
+
+    if trim > 0:
+        cum = np.cumsum(w)
+        lower = trim * total
+        upper = (1.0 - trim) * total
+        mask = (cum >= lower) & (cum <= upper)
+        if not mask.any():
+            # If everything was trimmed due to extreme weights just return simple mean
+            return float(np.average(v, weights=w))
+        v = v[mask]
+        w = w[mask]
+        # Adjust edge weights for partial trimming
+        cum = cum[mask]
+        w = w.copy()
+        w[0] -= cum[0] - lower
+        w[-1] -= upper - cum[-1]
+
+    return float(np.average(v, weights=w))
+
+
+@dataclass
+class WindowParams:
+    """Parameters controlling the adaptive window update."""
+
+    W0: float = 8.0
+    brho: float = 0.4
+    rho0: float = 1.0
+    bdeg: float = 0.2
+    deg0: float = 3.0
+    Wmin: float = 2.0
+    Wmax: float = 64.0
+    half_life_windows: float = 12.0
+    beta: float | None = 0.1
+    mu: float | None = None
+
+
+@dataclass
+class WindowState:
+    """Per-vertex state for adaptive window sizing."""
+
+    M_v: float = 0.0
+    W_v: float = 8.0
+
+
+def on_window_close(
+    rhos: Sequence[float],
+    weights: Sequence[float],
+    params: WindowParams,
+    state: WindowState,
+    *,
+    k: int = 1,
+    deg_v: int | None = None,
+) -> None:
+    """Update the EWMA and window size when a vertex window closes.
+
+    Parameters
+    ----------
+    rhos:
+        Iterable of neighbour densities ``rho_u``.
+    weights:
+        Edge weights ``w_{v→u}`` corresponding to ``rhos``.  They do not need to
+        be normalised; a normalisation step is performed internally.
+    params:
+        Static parameters controlling the update rule.
+    state:
+        Mutable state for the vertex.  ``state`` is updated in-place.
+    k:
+        Number of windows elapsed since the last update.  Defaults to ``1``.
+    deg_v:
+        Optional degree override.  If ``None`` the degree is inferred from the
+        length of ``rhos``.
+    """
+
+    if len(rhos) == 0:
+        return
+
+    w = np.asarray(weights, dtype=float)
+    if w.sum() <= 0:
+        return
+    w = w / w.sum()
+    r = np.asarray(rhos, dtype=float)
+
+    m_inst = robust_weighted_mean(r, w)
+
+    alpha = math.log(2.0) / params.half_life_windows
+    alpha_eff = 1.0 - (1.0 - alpha) ** k
+    state.M_v = (1.0 - alpha_eff) * state.M_v + alpha_eff * m_inst
+
+    deg = float(max(deg_v if deg_v is not None else len(r), 1))
+    deg_term = 1.0 + params.bdeg * math.log1p(deg / params.deg0)
+    rho_term = 1.0 + params.brho * math.log1p(state.M_v / params.rho0)
+
+    W_target = params.W0 * rho_term * deg_term
+    W_target = float(np.clip(W_target, params.Wmin, params.Wmax))
+
+    if params.beta is not None:
+        state.W_v = (1.0 - params.beta) * state.W_v + params.beta * W_target
+    else:
+        mu = params.mu if params.mu is not None else 0.1
+        r_ratio = W_target / max(state.W_v, 1e-9)
+        r_ratio = float(np.clip(r_ratio, 1.0 - mu, 1.0 + mu))
+        state.W_v *= r_ratio
+
+
+__all__ = [
+    "WindowParams",
+    "WindowState",
+    "on_window_close",
+    "robust_weighted_mean",
+]

--- a/README.md
+++ b/README.md
@@ -262,7 +262,6 @@ The adapter exposes methods like `build_graph`, `step`, `pause` and
 scheduler orders packets by their arrival depth and advances vertex windows
 using the Local Causal Consistency Model (LCCM).  The LCCM computes a window
 size ``W(v)`` from the vertex's incident degree (fan-in plus fan-out) and local
-density and transitions between
 quantum ``Q``, decohered ``Θ`` and classical ``C`` layers with simple hysteresis
 timers.  A lightweight loader converts graph JSON into struct-of-arrays via
 ``engine_v2.loader.load_graph_arrays`` to prime this core.
@@ -270,6 +269,11 @@ The LCCM recomputes the mean incident edge density ``ρ`` at every window
 boundary so that subsequent window sizes adapt to current traffic.  Classical
 dominance (Θ→C) additionally requires the majority-vote confidence to exceed
 ``conf_min`` alongside the existing bit fraction and entropy thresholds.
+
+An event-driven helper ``on_window_close`` provides adaptive window sizing
+using an exponentially weighted moving average of neighbour densities.  The
+function maintains ``M_v`` and ``W_v`` per vertex and rate-limits adjustments to
+avoid oscillation while keeping memory usage ``O(1)``.
 
 The `density_calc` option controls how edge density is computed. Set one of:
 

--- a/tests/test_adaptive_window.py
+++ b/tests/test_adaptive_window.py
@@ -1,0 +1,32 @@
+import math
+
+from Causal_Web.engine.engine_v2.lccm import WindowParams, WindowState, on_window_close
+
+
+def test_on_window_close_updates_state():
+    params = WindowParams()
+    state = WindowState(M_v=0.0, W_v=8.0)
+    rhos = [0.5, 1.0, 1.5]
+    weights = [1.0, 1.0, 1.0]
+    on_window_close(rhos, weights, params, state)
+
+    assert 0 < state.M_v < 1.0
+    assert state.W_v > 8.0
+
+
+def test_rate_limited_update_mu():
+    params = WindowParams(beta=None, mu=0.1)
+    state = WindowState(M_v=0.0, W_v=10.0)
+    rhos = [10.0, 10.0, 10.0]
+    weights = [1.0, 1.0, 1.0]
+    on_window_close(rhos, weights, params, state)
+    assert 10.0 < state.W_v <= 11.0
+
+
+def test_robust_mean_trims_outliers():
+    params = WindowParams()
+    state = WindowState()
+    rhos = [1.0, 1.0, 100.0]
+    weights = [0.45, 0.45, 0.10]
+    on_window_close(rhos, weights, params, state)
+    assert state.M_v < 5.0


### PR DESCRIPTION
## Summary
- expose adaptive window sizing via `on_window_close` with EWMA smoothing and rate limiting
- export helper types from LCCM package and document usage
- add tests for adaptive window update behaviour

## Testing
- `python -m compileall Causal_Web`
- `python -m Causal_Web.main` *(fails: Expecting property name enclosed in double quotes)*
- `python bundle_run.py` *(fails: can't open file 'bundle_run.py')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf00220f88325ace8afe0c2f4a7bb