### PR TITLE
Use tall format for metrics.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,8 @@ delivery avoids redundant exponentials.
 ## Output Logs
 Each run creates a timestamped directory under `output/runs` containing the graph, configuration and logs. Logging can be enabled or disabled via the GUI **Log Files** window or the `log_files` section of `config.json`. In `config.json` the keys are the categories (`tick`, `phenomena`, `event`) containing individual label flags. Logging cadence is event-driven; metrics and graph snapshots are written when windows advance or other triggers occur. The `logging_mode` option selects which categories are written: `diagnostic` (all logs), `tick`, `phenomena` and `events`.
 Logs are consolidated by category into `ticks_log.jsonl`, `phenomena_log.jsonl` and `events_log.jsonl`.
-An accompanying `metrics.csv` summarises event counts per frame.
+An accompanying `metrics.csv` summarises event counts per frame in a tall format
+with columns ``frame``, ``category`` and ``count``.
 Individual files can still be toggled via `log_files` for advanced filtering.
 Entangled tick metadata and detector outcomes are stored separately in
 `entangled_log.jsonl`.

--- a/tests/test_metric_aggregator.py
+++ b/tests/test_metric_aggregator.py
@@ -1,0 +1,28 @@
+import csv
+from pathlib import Path
+
+from Causal_Web.engine.logging.logger import MetricAggregator
+
+
+def test_metric_aggregator_writes_tall_csv(tmp_path: Path) -> None:
+    csv_path = tmp_path / "metrics.csv"
+    agg = MetricAggregator(csv_path)
+    # frame 0 events
+    agg.add(0, "A")
+    agg.add(0, "B")
+    agg.add(0, "A")
+    agg.flush(0)
+    # frame 1 events with new category
+    agg.add(1, "B")
+    agg.add(1, "C")
+    agg.flush(1)
+
+    with csv_path.open() as fh:
+        rows = list(csv.DictReader(fh))
+
+    assert rows == [
+        {"frame": "0", "category": "A", "count": "2"},
+        {"frame": "0", "category": "B", "count": "1"},
+        {"frame": "1", "category": "B", "count": "1"},
+        {"frame": "1", "category": "C", "count": "1"},
+    ]


### PR DESCRIPTION
## Summary
- ensure metrics aggregator writes tall CSV rows, keeping header stable
- document tall metrics layout
- add test verifying metrics CSV structure

## Testing
- `black Causal_Web/engine/logging/logger.py tests/test_metric_aggregator.py`
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d0f1707048325b7da3f484c316d82