### PR TITLE
feat: add view snapshot dataclass

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -18,6 +18,8 @@ import math
 
 import numpy as np
 
+from Causal_Web.view import ViewSnapshot
+
 from ..logging.logger import log_record, flush_metrics
 from .lccm import LCCM, WindowParams, WindowState, on_window_close
 from .scheduler import DepthScheduler
@@ -1130,8 +1132,8 @@ class EngineAdapter:
 
         return frame
 
-    def snapshot_for_ui(self) -> dict:
-        """Return a minimal snapshot for the GUI."""
+    def snapshot_for_ui(self) -> ViewSnapshot:
+        """Return a minimal :class:`ViewSnapshot` for the GUI."""
 
         with self._lock:
             max_depth = 0
@@ -1140,7 +1142,7 @@ class EngineAdapter:
                 lccm = data["lccm"]
                 max_depth = max(max_depth, lccm.depth)
                 max_window = max(max_window, lccm.window_idx)
-            return {"depth": max_depth, "window": max_window}
+            return ViewSnapshot(frame=max_depth, counters={"window": max_window})
 
     def current_depth(self) -> int:
         """Return the current depth of the simulation."""

--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -325,14 +325,15 @@ class MainWindow(QMainWindow):
             if Config.engine_mode == EngineMode.V2:
                 snap = tick_engine.snapshot_for_ui()
                 if hasattr(self, "depth_label"):
-                    self.depth_label.setText(str(snap.get("depth", 0)))
+                    self.depth_label.setText(str(snap.frame))
+                window = snap.counters.get("window", 0)
                 if hasattr(self, "window_label"):
-                    self.window_label.setText(str(snap.get("window", 0)))
+                    self.window_label.setText(str(window))
                 if hasattr(self.sim_canvas, "update_hud"):
                     self.sim_canvas.update_hud(
                         tick,
-                        snap.get("depth", 0),
-                        snap.get("window", 0),
+                        snap.frame,
+                        window,
                     )
         self.sim_canvas.load_model(GraphModel.from_dict(model_dict))
         if not running:

--- a/Causal_Web/view.py
+++ b/Causal_Web/view.py
@@ -1,0 +1,40 @@
+"""UI-facing snapshot dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class NodeView:
+    """Lightweight representation of a node for the UI."""
+
+    id: str
+
+
+@dataclass(frozen=True)
+class EdgeView:
+    """Lightweight representation of an edge for the UI."""
+
+    src: str
+    dst: str
+
+
+@dataclass(frozen=True)
+class WindowEvent:
+    """Event describing a closed window in the simulation."""
+
+    window_idx: int
+
+
+@dataclass(frozen=True)
+class ViewSnapshot:
+    """Snapshot of engine state changes emitted to the GUI."""
+
+    frame: int
+    changed_nodes: List[NodeView] = field(default_factory=list)
+    changed_edges: List[EdgeView] = field(default_factory=list)
+    closed_windows: List[WindowEvent] = field(default_factory=list)
+    counters: Dict[str, int] = field(default_factory=dict)
+    invariants: Dict[str, float] = field(default_factory=dict)

--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ edge and vertex telemetry fields are appended without renaming existing keys so
 existing ingestion remains compatible.
 
 The adapter exposes methods like `build_graph`, `step`, `pause` and
-`snapshot_for_ui` to remain drop-in compatible.  Internally a depth-based
+`snapshot_for_ui` (returning a `ViewSnapshot` dataclass) to remain drop-in
+compatible.  Internally a depth-based
 scheduler orders packets by their arrival depth and advances vertex windows
 using the Local Causal Consistency Model (LCCM).  The LCCM computes a window
 size ``W(v)`` from the vertex's incident degree (fan-in plus fan-out) and local

--- a/tests/test_engine_adapter_api.py
+++ b/tests/test_engine_adapter_api.py
@@ -5,6 +5,7 @@ from Causal_Web.engine.engine_v2.state import (
     TelemetryFrame,
     VertexArray,
 )
+from Causal_Web.view import ViewSnapshot
 
 
 def test_step_returns_telemetry_frame():
@@ -21,7 +22,9 @@ def test_step_returns_telemetry_frame():
     assert isinstance(frame, TelemetryFrame)
     assert frame.events == 1
     assert frame.packets and isinstance(frame.packets[0], Packet)
-    assert adapter.snapshot_for_ui()["depth"] == frame.depth
+    snap = adapter.snapshot_for_ui()
+    assert isinstance(snap, ViewSnapshot)
+    assert snap.frame == frame.depth
     assert adapter.current_depth() == frame.depth
     assert isinstance(frame.window, int)
     assert adapter.current_frame() == 1


### PR DESCRIPTION
## Summary
- add unified `ViewSnapshot` dataclass and supporting view types
- emit `ViewSnapshot` from engine adapter and update GUI to consume it
- adjust engine adapter API test for the new snapshot interface

## Testing
- `black Causal_Web/engine/engine_v2/adapter.py Causal_Web/gui_pyside/main_window.py Causal_Web/view.py tests/test_engine_adapter_api.py`
- `python -m compileall Causal_Web`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d41a3dcb08325aaa83248616b67cc