### PR TITLE
feat: expose engine changes to UI snapshot

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -434,6 +434,10 @@ class MainWindow(QMainWindow):
         if "events_per_sec" in snap.counters:
             self._telemetry_x.append(snap.frame)
             self._telemetry_y.append(snap.counters["events_per_sec"])
+            max_points = 3000
+            if len(self._telemetry_x) > max_points:
+                self._telemetry_x = self._telemetry_x[-max_points:]
+                self._telemetry_y = self._telemetry_y[-max_points:]
             self._telemetry_curve.setData(self._telemetry_x, self._telemetry_y)
 
     def start_simulation(self) -> None:

--- a/Causal_Web/view.py
+++ b/Causal_Web/view.py
@@ -25,6 +25,7 @@ class EdgeView:
 class WindowEvent:
     """Event describing a closed window in the simulation."""
 
+    v_id: str
     window_idx: int
 
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,10 @@ existing ingestion remains compatible.
 
 The adapter exposes methods like `build_graph`, `step`, `pause` and
 `snapshot_for_ui` (returning a `ViewSnapshot` dataclass) to remain drop-in
-compatible.  Internally a depth-based
+compatible. Snapshots include the identifiers of nodes and edges touched since
+the previous call along with any closed window events, allowing the GUI to
+incrementally update its model. Energy conservation residuals are also tracked
+per window and surfaced via the snapshot counters. Internally a depth-based
 scheduler orders packets by their arrival depth and advances vertex windows
 using the Local Causal Consistency Model (LCCM).  The LCCM computes a window
 size ``W(v)`` from the vertex's incident degree (fan-in plus fan-out) and local


### PR DESCRIPTION
## Summary
- track nodes, edges and window closures in EngineAdapter and expose via `ViewSnapshot`
- compute window energy residuals on the adapter instead of relying on `EPairs`
- cap telemetry plot history to last 3000 points

## Testing
- `python -m compileall Causal_Web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d767d5c048325b9d32c761083fda4