### PR TITLE
Compute and surface energy residuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ The adapter exposes methods like `build_graph`, `step`, `pause` and
 `snapshot_for_ui` (returning a `ViewSnapshot` dataclass) to remain drop-in
 compatible. Snapshots include the identifiers of nodes and edges touched since
 the previous call along with any closed window events, allowing the GUI to
-incrementally update its model. Energy conservation residuals are also tracked
-per window and surfaced via the snapshot counters. Internally a depth-based
+incrementally update its model. An EWMA of the energy conservation residual
+is tracked per window and surfaced via the snapshot counters. Internally a depth-based
 scheduler orders packets by their arrival depth and advances vertex windows
 using the Local Causal Consistency Model (LCCM).  The LCCM computes a window
 size ``W(v)`` from the vertex's incident degree (fan-in plus fan-out) and local

--- a/tests/test_residual_tracking.py
+++ b/tests/test_residual_tracking.py
@@ -1,0 +1,33 @@
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+from Causal_Web.engine.engine_v2.state import Packet
+from Causal_Web.config import Config
+
+
+def build_graph():
+    return {
+        "nodes": [
+            {"id": "A", "window_len": 1},
+            {"id": "B", "window_len": 1},
+        ],
+        "edges": [
+            {"from": "A", "to": "B", "delay": 1.0, "density": 0.0},
+        ],
+        "params": {"W0": 1},
+    }
+
+
+def test_residual_updates_on_window_close():
+    Config.rho_delay = {
+        "alpha_d": 0.0,
+        "alpha_leak": 0.0,
+        "eta": 0.0,
+        "gamma": 0.0,
+        "rho0": 1.0,
+    }
+    adapter = EngineAdapter()
+    adapter.build_graph(build_graph())
+    adapter._scheduler.push(0, 0, 0, Packet(src=-1, dst=0, payload=None))
+    adapter.run_until_next_window_or(None)
+    adapter.run_until_next_window_or(None)
+    snap = adapter.snapshot_for_ui()
+    assert snap.counters["residual"] > 0.0


### PR DESCRIPTION
## Summary
- compute per-vertex energy residuals at window close and maintain a short EWMA
- expose EWMA residual in GUI snapshots
- document residual tracking and add regression test

## Testing
- `python -m compileall Causal_Web`
- `python -m Causal_Web.main` *(fails: JSONDecodeError: Expecting property name enclosed in double quotes)*
- `python bundle_run.py` *(fails: [Errno 2] No such file or directory)*
- `pip install numpy networkx pytest pydantic`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e01e554b483258fc8020597a8673b