### PR TITLE
fix: handle HUD item when reloading scene

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -392,11 +392,16 @@ class CanvasWidget(QGraphicsView):
         if not self.editable:
             scene = self.scene()
             if scene is not None:
-                self._hud_item = QGraphicsSimpleTextItem("")
-                self._hud_item.setBrush(QBrush(Qt.white))
-                self._hud_item.setZValue(2)
-                self._hud_item.setPos(5, 5)
+                self._hud_item = self._create_hud_item()
                 scene.addItem(self._hud_item)
+
+    def _create_hud_item(self) -> QGraphicsSimpleTextItem:
+        """Return a configured HUD text item for read-only mode."""
+        item = QGraphicsSimpleTextItem("")
+        item.setBrush(QBrush(Qt.white))
+        item.setZValue(2)
+        item.setPos(5, 5)
+        return item
 
     def load_model(self, model: GraphModel) -> None:
         """Populate the scene from ``model``."""
@@ -411,8 +416,8 @@ class CanvasWidget(QGraphicsView):
         self.meta_nodes.clear()
         self.observers.clear()
         if self._hud_item is not None:
+            self._hud_item = self._create_hud_item()
             scene.addItem(self._hud_item)
-            self._hud_item.setPos(5, 5)
 
         for node_id, data in model.nodes.items():
             x, y = data.get("x", 0.0), data.get("y", 0.0)
@@ -447,7 +452,7 @@ class CanvasWidget(QGraphicsView):
             item = ObserverItem(idx, x, y, targets, self)
             scene.addItem(item)
             item.update_lines()
-        self.observers[idx] = item
+            self.observers[idx] = item
 
         self._update_label_visibility()
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ via a Monte-Carlo path sampler over the graph's causal structure.
   and lightweight real-time plots using ``pyqtgraph``.
 - Canvas performance improved with minimal viewport updates, item caching and
   label level-of-detail. HUD wording clarified and telemetry buffers capped.
+- Fixed a startup crash in read-only mode where a stale HUD item was
+  re-added after clearing the scene.
 - Visible "Tick" terminology has been replaced with "Frame" throughout the
   interface and tooltips.
 - Added local Forman curvature diagnostics with per-region statistics and

--- a/tests/test_canvas_widget.py
+++ b/tests/test_canvas_widget.py
@@ -1,0 +1,25 @@
+import os
+
+# Use offscreen platform to avoid GUI requirement
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication
+
+from Causal_Web.gui_pyside.canvas_widget import CanvasWidget
+from Causal_Web.graph.model import GraphModel
+
+
+def test_load_model_recreates_hud_item():
+    app = QApplication.instance() or QApplication([])
+    canvas = CanvasWidget(editable=False)
+    canvas.load_model(GraphModel.blank())
+    assert canvas._hud_item is not None
+    assert canvas._hud_item.scene() is canvas.scene()
+    # Calling again should recreate the HUD item without errors
+    canvas.load_model(GraphModel.blank())
+    assert canvas._hud_item.scene() is canvas.scene()
+    # Remove gui modules to avoid side effects on other tests
+    import sys
+
+    for name in [m for m in list(sys.modules) if m.startswith("Causal_Web.gui_pyside")]:
+        del sys.modules[name]


### PR DESCRIPTION
## Summary
- recreate HUD overlay when models are loaded to avoid stale references
- fix observer load loop and add regression test for HUD recreation
- document GUI startup crash fix in README

## Testing
- `python -m compileall Causal_Web/gui_pyside/canvas_widget.py`
- `pytest`
- `QT_QPA_PLATFORM=offscreen timeout 5 python -m Causal_Web.main` *(fails: This plugin does not support propagateSizeHints())*


------
https://chatgpt.com/codex/tasks/task_e_689e17c7a05c8325908a9b27dc4e0935