### PR TITLE
Remove obsolete propagation and density controls

### DIFF
--- a/Causal_Web/config.py
+++ b/Causal_Web/config.py
@@ -39,9 +39,6 @@ class Config:
 
     Attributes
     ----------
-    propagation_control:
-        Dictionary containing ``enable_sip`` and ``enable_csp`` flags used to
-        toggle the two propagation mechanisms.
     log_interval:
         Number of ticks between metric log writes and graph snapshots.
     headless:
@@ -460,13 +457,6 @@ class Config:
     random_seed: int | None = None
     thread_count = 1
     log_verbosity = "info"
-    use_dynamic_density = False
-    density_radius = 1
-    delay_density_scaling = 1.0
-    density_calc = "local_tick_saturation"
-    traffic_decay = 0.9
-    traffic_weight = 0.1
-    density_overlay_file: str | None = None
     # interval between metric logs
     log_interval = 1
     # disable observers and intermediate logging when True
@@ -489,23 +479,6 @@ class Config:
         "phase_offsets": {},  # per-node phase offsets when strategy == "static"
     }
 
-    # SIP recombination
-    SIP_RECOMB_MIN_TRUST = 0.75
-    SIP_MUTATION_SCALE = 0.005
-
-    # SIP failure
-    SIP_STABILIZATION_WINDOW = 5
-    SIP_FAILURE_ENTROPY_INJECTION = 0.1
-
-    # CSP
-    CSP_RADIUS = 80
-    CSP_MAX_NODES = 3
-    CSP_TICK_BURST = 25
-    CSP_STABILIZATION_WINDOW = 6
-    CSP_COLLAPSE_INTENSITY_THRESHOLD = 0.4
-    CSP_DECOHERENCE_THRESHOLD = 0.3
-    CSP_ENTROPY_INJECTION = 0.2
-
     # Propagation limits
     max_children_per_node = 0  # 0 disables limit
 
@@ -514,10 +487,6 @@ class Config:
 
     # Decay factor for stored tick energy per tick
     tick_decay_factor = 1.0
-
-    # Phase smoothing
-    smooth_phase = False
-    phase_smoothing_alpha = 0.1
 
     # Natural propagation limits
     max_cumulative_delay = 25
@@ -540,13 +509,6 @@ class Config:
 
     # Range for per-edge weights influencing delay/attenuation
     edge_weight_range = [1.0, 1.0]
-
-    # Toggle propagation mechanisms
-    propagation_control = {
-        "enable_sip_child": True,
-        "enable_sip_recomb": True,
-        "enable_csp": True,
-    }
 
     # Database connection details
     database = {

--- a/Causal_Web/input/config.json
+++ b/Causal_Web/input/config.json
@@ -24,18 +24,9 @@
     "tick_threshold": 1,
     "refractory_period": 2.0,
     "tick_decay_factor": 1.0,
-    "smooth_phase": false,
-    "phase_smoothing_alpha": 0.1,
     "total_max_concurrent_firings": 0,
     "max_concurrent_firings_per_cluster": 0,
     "edge_weight_range": [1.0, 1.0],
-    "use_dynamic_density": false,
-    "density_radius": 1,
-    "delay_density_scaling": 1.0,
-    "density_calc": "local_tick_saturation",
-    "traffic_decay": 0.9,
-    "traffic_weight": 0.1,
-    "density_overlay_file": null,
     "windowing": {
         "W0": 0.0,
         "zeta1": 0.0,
@@ -89,11 +80,6 @@
     "ancestry": {"beta_m0": 0.1, "delta_m": 0.02},
     "theta_reset": "renorm",
     "max_deque": 8,
-    "propagation_control": {
-        "enable_sip_child": true,
-        "enable_sip_recomb": true,
-        "enable_csp": true
-    },
     "database": {
         "host": "localhost",
         "port": 5432,

--- a/Causal_Web/input/tooltip.json
+++ b/Causal_Web/input/tooltip.json
@@ -66,10 +66,6 @@
   "tick_evaluation_log.json": "Evaluation results for each potential frame",
   "tick_propagation_log.json": "Frames travelling across edges",
   "tick_seed_log.json": "Activity injected by the seeder",
-  "smooth_phase": "Apply exponential smoothing to oscillator phases",
-  "enable_sip_child": "Enable SIP budding propagation",
-  "enable_sip_recomb": "Enable SIP recombination propagation",
-  "enable_csp": "Enable collapse seeded propagation",
   "detector_mode": "Perform binary measurements on entangled frames",
   "measurement_settings": "Comma separated list of measurement angles"
 }

--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -47,11 +47,6 @@ def _add_config_args(
             _add_config_args(parser, value, prefix=f"{prefix}{key}.")
             continue
         arg_type = type(value)
-        if dest == "density_calc":
-            parser.add_argument(
-                "--density-calc", f"--{prefix}{key}", type=arg_type, dest=dest
-            )
-            continue
         if dest == "backend":
             parser.add_argument(arg_name, choices=["cpu", "cupy"], dest=dest)
             continue
@@ -116,7 +111,6 @@ class MainService:
         args, cfg = self._parse_args()
         _apply_overrides(args, cfg)
         self._apply_log_overrides(args)
-        self._apply_propagation_overrides(args)
         Config.profile_output = getattr(args, "profile_output", None)
         if args.init_db:
             self._init_db(args.config)
@@ -148,18 +142,6 @@ class MainService:
                     label = label.strip()
                     if label:
                         cfg[label] = False
-
-    # ------------------------------------------------------------------
-    @staticmethod
-    def _apply_propagation_overrides(args: argparse.Namespace) -> None:
-        """Update propagation control flags from CLI."""
-
-        if getattr(args, "disable_sip_child", False):
-            Config.propagation_control["enable_sip_child"] = False
-        if getattr(args, "disable_sip_recomb", False):
-            Config.propagation_control["enable_sip_recomb"] = False
-        if getattr(args, "disable_csp", False):
-            Config.propagation_control["enable_csp"] = False
 
     # ------------------------------------------------------------------
     def _parse_args(self) -> tuple[argparse.Namespace, dict[str, Any]]:
@@ -228,21 +210,6 @@ class MainService:
             "--disable-events",
             default="",
             help="Comma-separated event types to disable",
-        )
-        parser.add_argument(
-            "--disable-sip-child",
-            action="store_true",
-            help="Disable SIP budding propagation",
-        )
-        parser.add_argument(
-            "--disable-sip-recomb",
-            action="store_true",
-            help="Disable SIP recombination propagation",
-        )
-        parser.add_argument(
-            "--disable-csp",
-            action="store_true",
-            help="Disable collapse seeded propagation",
         )
         args = parser.parse_args(self.argv)
         Config.graph_file = args.graph

--- a/README.md
+++ b/README.md
@@ -287,16 +287,6 @@ using an exponentially weighted moving average of neighbour densities.  The
 function maintains ``M_v`` and ``W_v`` per vertex and rate-limits adjustments to
 avoid oscillation while keeping memory usage ``O(1)``.
 
-The `density_calc` option controls how edge density is computed. Set one of:
-
-- `local_tick_saturation` (default) – density increases with recent traffic
-- `modular-<mode>` – use a registered modular function (`tick_history`,
-  `node_coherence`, `spatial_field`, `bridge_saturation`)
-- `manual_overlay` – sample values from an external overlay file defined by
-  `density_overlay_file`.
-
-`density_calc` can also be specified via `--density-calc` on the command line.
-
 Amplitude energy now feeds a stress–energy field that scales edge delay by
 ``1 + κρ``. This density diffuses each scheduler step with weight
 ``Config.density_diffusion_weight`` (``α``).
@@ -404,21 +394,6 @@ The resulting `*_sweep.csv` and `*_heatmap.png` files summarise Bell scores,
 interference visibility and proper-time ratios. Sweeps seed module-level random
 generators, so parallel sweeps should run in separate processes to avoid
 contention.
-
-### Phase smoothing
-
-The `smooth_phase` option applies exponential decay to each node's internal
-oscillator phase. Enable it from the GUI control panel or set `"smooth_phase":
-true` in `Causal_Web/input/config.json`.
-
-### Propagation control
-
-Check boxes on the control panel allow SIP budding, SIP recombination and
-collapse seeded propagation to be disabled independently. The
-`propagation_control` section of `Causal_Web/input/config.json` contains
-`enable_sip_child`, `enable_sip_recomb` and `enable_csp` flags. These can also
-be toggled via the CLI using `--disable-sip-child`, `--disable-sip-recomb` and
-`--disable-csp`.
 
 ## Contributing
 Unit tests live under `tests/` and can be run with `pytest`. Coding guidelines and packaging instructions are documented in [AGENTS.md](AGENTS.md) and [docs/developer_guide.md](docs/developer_guide.md).

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -8,7 +8,6 @@ def test_cli_flags_exposed_without_config(tmp_path):
     cfg.write_text("{}")
     old_max = Config.max_ticks
     old_host = Config.database["host"]
-    old_calc = getattr(Config, "density_calc", "local_tick_saturation")
     try:
         service = MainService(
             argv=[
@@ -18,36 +17,14 @@ def test_cli_flags_exposed_without_config(tmp_path):
                 "5",
                 "--database.host",
                 "example.com",
-                "--density-calc=manual_overlay",
             ]
         )
         args, data = service._parse_args()
         assert args.max_ticks == 5
         assert args.database_host == "example.com"
-        assert args.density_calc == "manual_overlay"
         _apply_overrides(args, data)
         assert Config.max_ticks == 5
         assert Config.database["host"] == "example.com"
-        assert Config.density_calc == "manual_overlay"
     finally:
         Config.max_ticks = old_max
         Config.database["host"] = old_host
-        Config.density_calc = old_calc
-
-
-def test_cli_disable_propagation_flags(tmp_path):
-    cfg = tmp_path / "c.json"
-    cfg.write_text("{}")
-    original = Config.propagation_control.copy()
-    try:
-        service = MainService(
-            argv=["--config", str(cfg), "--disable-sip-child", "--disable-csp"]
-        )
-        args, data = service._parse_args()
-        _apply_overrides(args, data)
-        MainService._apply_propagation_overrides(args)
-        assert Config.propagation_control["enable_sip_child"] is False
-        assert Config.propagation_control["enable_csp"] is False
-        assert Config.propagation_control["enable_sip_recomb"] is True
-    finally:
-        Config.propagation_control = original

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,28 +35,6 @@ def test_logging_mode_filters_categories():
         Config.log_files = original_files
 
 
-def test_load_smooth_phase_flag(tmp_path):
-    cfg = tmp_path / "config.json"
-    cfg.write_text(json.dumps({"smooth_phase": True}))
-    original = getattr(Config, "smooth_phase", False)
-    Config.load_from_file(str(cfg))
-    try:
-        assert Config.smooth_phase is True
-    finally:
-        Config.smooth_phase = original
-
-
-def test_load_propagation_flags(tmp_path):
-    cfg = tmp_path / "config.json"
-    cfg.write_text(json.dumps({"propagation_control": {"enable_sip_child": False}}))
-    original = Config.propagation_control.copy()
-    Config.load_from_file(str(cfg))
-    try:
-        assert Config.propagation_control["enable_sip_child"] is False
-    finally:
-        Config.propagation_control = original
-
-
 def test_load_engine_mode_and_param_groups(tmp_path):
     cfg = tmp_path / "config.json"
     cfg.write_text(


### PR DESCRIPTION
## Summary
- Drop unused GUI controls for smooth phase, SIP budding/recombination, CSP, and density strategy
- Remove related configuration and CLI flags
- Clean up documentation, tooltips, and tests

## Testing
- `python -m compileall Causal_Web`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `python -m Causal_Web.main --no-gui`
- `python bundle_run.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e2192170c8325ab463c08502a736d