### PR TITLE
Fix graph view repainting artifacts

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -369,7 +369,9 @@ class CanvasWidget(QGraphicsView):
     ) -> None:
         """Initialize the canvas widget."""
         super().__init__(parent)
-        self.setViewportUpdateMode(QGraphicsView.MinimalViewportUpdate)
+        # Full viewport updates prevent the previous view from lingering when
+        # the scene is panned or zoomed.
+        self.setViewportUpdateMode(QGraphicsView.FullViewportUpdate)
         self.setOptimizationFlag(QGraphicsView.DontSavePainterState, True)
         viewport = self.viewport()
         viewport.setAttribute(Qt.WA_OpaquePaintEvent, True)


### PR DESCRIPTION
## Summary
- avoid ghosting when panning or zooming by repainting the entire viewport in the graph canvas

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest` *(fails: cupy_backends.cuda.api.runtime.CUDARuntimeError: initialization error)*
- `QT_QPA_PLATFORM=offscreen python -m Causal_Web.main` *(fails: This plugin does not support propagateSizeHints())*

------
https://chatgpt.com/codex/tasks/task_e_689e2440b2348325b7ef1458c64609e5