### PR TITLE
Fix graph view repainting artifacts

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -369,11 +369,13 @@ class CanvasWidget(QGraphicsView):
     ) -> None:
         """Initialize the canvas widget."""
         super().__init__(parent)
-        self.setViewportUpdateMode(QGraphicsView.MinimalViewportUpdate)
+        # Full viewport updates prevent the previous view from lingering when
+        # the scene is panned or zoomed.
+        self.setViewportUpdateMode(QGraphicsView.FullViewportUpdate)
         self.setOptimizationFlag(QGraphicsView.DontSavePainterState, True)
         viewport = self.viewport()
         viewport.setAttribute(Qt.WA_OpaquePaintEvent, True)
-        viewport.setAttribute(Qt.WA_NoSystemBackground, True)
+        self.setBackgroundBrush(QBrush(Qt.black))
         self.editable = editable
         self.setScene(QGraphicsScene(self))
         self.setRenderHint(QPainter.Antialiasing)


### PR DESCRIPTION
## Summary
- clear the graph canvas before each draw to prevent lingering copies when panning or zooming

## Testing
- `black Causal_Web/gui_pyside/canvas_widget.py`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- `QT_QPA_PLATFORM=offscreen python -m Causal_Web.main` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- `python bundle_run.py` *(fails: [Errno 2] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e2440b2348325b7ef1458c64609e5