### PR TITLE
fix: shut down engine thread on window close

### DIFF
--- a/Causal_Web/gui_pyside/main_window.py
+++ b/Causal_Web/gui_pyside/main_window.py
@@ -156,8 +156,9 @@ class MainWindow(QMainWindow):
     # ---- UI setup ----
 
     def closeEvent(self, event: QCloseEvent) -> None:  # type: ignore[override]
-        """Stop the engine worker before closing."""
+        """Stop the engine worker and thread before closing."""
         self._engine_worker.stop()
+        self._engine_thread.quit()
         self._engine_thread.wait()
         super().closeEvent(event)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 
 ### Recent Changes
 
+- Closing the GUI no longer hangs; the engine worker thread now shuts down
+  cleanly.
 - GUI now includes a status bar with frame metrics, an engine profile panel
   and lightweight real-time plots using ``pyqtgraph``.
 - Canvas performance improved with minimal viewport updates, item caching and


### PR DESCRIPTION
## Summary
- prevent GUI hang on exit by quitting the engine thread before waiting
- document the fix in the project README

## Testing
- `python -m compileall Causal_Web`
- `pytest` *(fails: cupy_backends.cuda.api.runtime.CUDARuntimeError: Call to cuInit results in CUDA_ERROR_NO_DEVICE)*

------
https://chatgpt.com/codex/tasks/task_e_689f65a7d9f88325ae43720387e41579