### PR TITLE
fix: prevent runaway zoom on startup

### DIFF
--- a/Causal_Web/gui_pyside/canvas_widget.py
+++ b/Causal_Web/gui_pyside/canvas_widget.py
@@ -571,8 +571,18 @@ class CanvasWidget(QGraphicsView):
 
     # ---- interaction -------------------------------------------------
     def wheelEvent(self, event: QWheelEvent) -> None:
-        """Zoom the view and disable antialiasing when zoomed far out."""
-        factor = 1.15 if event.angleDelta().y() > 0 else 1 / 1.15
+        """Zoom the view and disable antialiasing when zoomed far out.
+
+        Some platforms emit wheel events with no ``angleDelta`` or ``pixelDelta``
+        values when the application starts, which previously triggered rapid
+        zooming. These zero-delta events are now ignored to prevent unwanted
+        zoom behaviour on launch.
+        """
+        delta = event.angleDelta().y() or event.pixelDelta().y()
+        if delta == 0:
+            event.ignore()
+            return
+        factor = 1.15 if delta > 0 else 1 / 1.15
         self.scale(factor, factor)
         self._update_label_visibility()
         scale_level = self.transform().m11()

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 
 ### Recent Changes
 
+- Fixed runaway zoom in the frames graph that occurred on startup.
 - Closing the GUI no longer hangs; the engine worker thread now shuts down
   cleanly.
 - GUI now includes a status bar with frame metrics, an engine profile panel


### PR DESCRIPTION
## Summary
- ignore zero-delta wheel events in CanvasWidget to stop automatic zooming when the app launches
- document the fix in the README

## Testing
- `python -m compileall Causal_Web`
- `pytest` *(fails: ImportError: libGL.so.1 cannot open shared object file)*
- `python -m Causal_Web.main` *(fails: ImportError: libGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689f67508eb0832598d707e0b661a1fa