### PR TITLE
feat: add websocket engine stream server

### DIFF
--- a/Causal_Web/engine/engine_v2/adapter.py
+++ b/Causal_Web/engine/engine_v2/adapter.py
@@ -75,6 +75,7 @@ class EngineAdapter:
         self._energy_totals: Dict[int, float] = {}
         self._residuals: Dict[int, float] = {}
         self._residual: float = 0.0
+        self._experiment_status: Dict[str, Any] | None = None
 
     # ------------------------------------------------------------------
     def _get_pool_arr(
@@ -1271,6 +1272,7 @@ class EngineAdapter:
                 changed_edges=edges,
                 closed_windows=closed,
                 counters=counters,
+                invariants={"inv_conservation_residual": self._residual},
             )
 
     def current_depth(self) -> int:
@@ -1285,6 +1287,29 @@ class EngineAdapter:
         """Return the number of steps executed so far."""
 
         return self._frame
+
+    # ------------------------------------------------------------------
+    def set_experiment_status(self, status: Dict[str, Any]) -> None:
+        """Record the most recent experiment status.
+
+        Parameters
+        ----------
+        status:
+            Mapping containing ``id``, ``state``, ``progress`` and
+            ``best_metrics`` fields.
+        """
+
+        with self._lock:
+            self._experiment_status = status
+
+    # ------------------------------------------------------------------
+    def experiment_status(self) -> Dict[str, Any] | None:
+        """Return and clear the latest experiment status if available."""
+
+        with self._lock:
+            status = self._experiment_status
+            self._experiment_status = None
+        return status
 
 
 # Lazily constructed engine instance; GUI code may read this handle but

--- a/Causal_Web/engine/stream/__init__.py
+++ b/Causal_Web/engine/stream/__init__.py
@@ -1,0 +1,1 @@
+"""WebSocket streaming components for engine state."""

--- a/Causal_Web/engine/stream/server.py
+++ b/Causal_Web/engine/stream/server.py
@@ -1,0 +1,96 @@
+"""WebSocket server for publishing engine state deltas.
+
+This module exposes a :class:`DeltaBus` ring buffer and a ``serve`` coroutine
+that publishes graph metadata and snapshot deltas to connected clients. Payloads
+are encoded with `msgpack` and versioned via a ``type`` and ``v`` field.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Set
+
+import msgpack
+import websockets
+
+
+class DeltaBus:
+    """Double buffer retaining only the most recent snapshot delta.
+
+    The engine places freshly computed deltas into the bus. Consumers read the
+    latest value without worrying about intermediate frames.
+    """
+
+    def __init__(self) -> None:
+        self._slots = [None, None]
+        self._idx = 0
+
+    def put(self, delta: Dict[str, Any]) -> None:
+        """Store ``delta`` and swap buffers so it becomes the latest."""
+        self._idx ^= 1
+        self._slots[self._idx] = delta
+
+    def latest(self) -> Dict[str, Any] | None:
+        """Return the newest snapshot delta if available."""
+        return self._slots[self._idx]
+
+
+async def serve(
+    bus: DeltaBus,
+    adapter: Any,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+) -> None:
+    """Start a WebSocket server publishing engine deltas.
+
+    Parameters
+    ----------
+    bus:
+        :class:`DeltaBus` used to retain the latest snapshot delta.
+    adapter:
+        Object providing ``graph_static``, ``snapshot_delta``,
+        ``handle_control`` and ``experiment_status`` callables.
+    host, port:
+        Network location on which to serve the WebSocket.
+    """
+
+    clients: Set[websockets.WebSocketServerProtocol] = set()
+
+    async def handler(ws: websockets.WebSocketServerProtocol) -> None:
+        """Handle a single client connection."""
+
+        clients.add(ws)
+        try:
+            graph_static = {"type": "GraphStatic", "v": 1, **adapter.graph_static()}
+            await ws.send(msgpack.packb(graph_static))
+            async for raw in ws:
+                msg = msgpack.unpackb(raw)
+                cmd = msg.get("cmd")
+                if cmd == "pull":
+                    latest = bus.latest()
+                    if latest is not None:
+                        payload = {"type": "SnapshotDelta", "v": 1, **latest}
+                        await ws.send(msgpack.packb(payload))
+                else:
+                    adapter.handle_control(msg)
+        finally:
+            clients.remove(ws)
+
+    async with websockets.serve(handler, host, port):
+        while True:
+            delta = adapter.snapshot_delta()
+            if delta is not None:
+                bus.put(delta)
+                if clients:
+                    notify = {"type": "DeltaReady", "v": 1, "frame": delta.get("frame")}
+                    await asyncio.gather(
+                        *[ws.send(msgpack.packb(notify)) for ws in list(clients)]
+                    )
+            if hasattr(adapter, "experiment_status"):
+                status = adapter.experiment_status()
+                if status and clients:
+                    payload = {"type": "ExperimentStatus", "v": 1, **status}
+                    await asyncio.gather(
+                        *[ws.send(msgpack.packb(payload)) for ws in list(clients)]
+                    )
+            await asyncio.sleep(0)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ twin-paradox demonstration showcasing this time dilation. Run
 `python -m Causal_Web.analysis.lensing` to approximate lensing wedge amplitudes
 via a Monte-Carlo path sampler over the graph's causal structure.
 
-### Recent Changes
-
+- Engine can now publish a MessagePack-encoded WebSocket stream. Clients pull
+  `SnapshotDelta` updates on demand after a `DeltaReady` notification and also
+  receive `ExperimentStatus` messages and an EWMA of conservation residuals.
 - Fixed runaway zoom in the frames graph that occurred on startup.
 - Closing the GUI no longer hangs; the engine worker thread now shuts down
   cleanly.

--- a/tests/test_residual_tracking.py
+++ b/tests/test_residual_tracking.py
@@ -31,3 +31,4 @@ def test_residual_updates_on_window_close():
     adapter.run_until_next_window_or(None)
     snap = adapter.snapshot_for_ui()
     assert snap.counters["residual"] > 0.0
+    assert snap.invariants["inv_conservation_residual"] == snap.counters["residual"]


### PR DESCRIPTION
## Summary
- notify clients when new frames are ready and serve SnapshotDelta on `pull`
- expose experiment status updates and conservation residual EWMA in stream
- track residual in engine adapter invariants with helper to publish status

## Testing
- `python -m compileall Causal_Web`
- `python -m Causal_Web.main` *(fails: ImportError: libGL.so.1)*
- `pytest` *(fails: ImportError: libGL.so.1)*
- `python bundle_run.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f81d9e1a483259e8de7c4b6577fd6