### PR TITLE
Add HUD metrics, controls and live diff overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ via a Monte-Carlo path sampler over the graph's causal structure.
   and lightweight real-time plots using ``pyqtgraph``.
 - Canvas performance improved with minimal viewport updates, item caching and
   label level-of-detail. HUD wording clarified and telemetry buffers capped.
+- Telemetry panel now exposes rolling counter and invariant histories for live plots.
+- HUD overlay reports frame, depth, active windows, active bridges, FPS,
+  events per second and residual metrics.
+- Experiment panel adds single-step controls, a rate slider and label/edge
+  visibility toggles.
+- Canvas renders the latest snapshot diffs at up to 60 FPS via a pull-based loop.
+- Window closures trigger brief red pulses on affected nodes for visual feedback.
 - Fixed a startup crash in read-only mode where a stale HUD item was
   re-added after clearing the scene.
 - Visible "Tick" terminology has been replaced with "Frame" throughout the

--- a/telemetry/__init__.py
+++ b/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Telemetry utilities for Causal Web."""
+
+from .rolling import RollingTelemetry, RollingSeries
+
+__all__ = ["RollingTelemetry", "RollingSeries"]

--- a/telemetry/rolling.py
+++ b/telemetry/rolling.py
@@ -1,0 +1,79 @@
+"""Rolling telemetry buffers for live plots."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+@dataclass
+class RollingSeries:
+    """Maintain a finite history of numeric samples."""
+
+    maxlen: int
+    _data: deque[float] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._data = deque(maxlen=self.maxlen)
+
+    def append(self, value: float) -> None:
+        """Append ``value`` keeping only the newest ``maxlen`` samples."""
+
+        self._data.append(value)
+
+    def as_list(self) -> list[float]:
+        """Return the stored samples as a list."""
+
+        return list(self._data)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        """Return the number of stored samples."""
+
+        return len(self._data)
+
+
+@dataclass
+class RollingTelemetry:
+    """Store rolling histories for counters and invariants.
+
+    Parameters
+    ----------
+    max_points:
+        Maximum number of samples to retain per series.
+    """
+
+    max_points: int = 100
+    counters: dict[str, RollingSeries] = field(default_factory=dict)
+    invariants: dict[str, RollingSeries] = field(default_factory=dict)
+
+    def record(
+        self,
+        counters: Mapping[str, float] | None = None,
+        invariants: Mapping[str, bool] | None = None,
+    ) -> None:
+        """Record a new telemetry sample.
+
+        ``counters`` and ``invariants`` are merged into their respective
+        histories. Older samples are discarded once ``max_points`` is reached.
+        """
+
+        counters = counters or {}
+        invariants = invariants or {}
+
+        for key, value in counters.items():
+            series = self.counters.setdefault(key, RollingSeries(self.max_points))
+            series.append(float(value))
+        for key, value in invariants.items():
+            series = self.invariants.setdefault(key, RollingSeries(self.max_points))
+            series.append(1.0 if value else 0.0)
+
+    def get_counters(self) -> dict[str, list[float]]:
+        """Return all counter histories as plain lists."""
+
+        return {key: series.as_list() for key, series in self.counters.items()}
+
+    def get_invariants(self) -> dict[str, list[float]]:
+        """Return all invariant histories as plain lists."""
+
+        return {key: series.as_list() for key, series in self.invariants.items()}

--- a/tests/test_experiment_model.py
+++ b/tests/test_experiment_model.py
@@ -1,0 +1,25 @@
+import asyncio
+
+from ui_new.state.Experiment import ExperimentModel
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send(self, msg) -> None:
+        self.sent.append(msg)
+
+
+def test_step_and_rate(monkeypatch):
+    model = ExperimentModel()
+    client = DummyClient()
+    model.set_client(client)
+
+    monkeypatch.setattr(asyncio, "create_task", lambda c: asyncio.run(c))
+
+    model.step()
+    model.setRate(0.5)
+
+    assert {"ExperimentControl": {"action": "step"}} in client.sent
+    assert {"ExperimentControl": {"action": "set_rate", "rate": 0.5}} in client.sent

--- a/tests/test_graph_view_pulses.py
+++ b/tests/test_graph_view_pulses.py
@@ -1,0 +1,20 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication
+from PySide6.QtQuick import QSGNode
+
+from ui_new.graph.GraphView import GraphView
+
+
+def test_closed_window_pulses_decay():
+    app = QApplication.instance() or QApplication([])
+    view = GraphView()
+    view.set_graph([(0.0, 0.0)], [], labels=["a"], colors=["white"], flags=[True])
+    view.apply_delta({"closed_windows": [("0", 0)]})
+    assert 0 in view._pulses
+    root = QSGNode()
+    for _ in range(view._pulse_duration):
+        view._update_pulses(root)
+    assert 0 not in view._pulses

--- a/tests/test_rolling_telemetry.py
+++ b/tests/test_rolling_telemetry.py
@@ -1,0 +1,17 @@
+from telemetry import RollingTelemetry
+
+
+def test_record_caps_length():
+    rt = RollingTelemetry(max_points=3)
+    for i in range(5):
+        rt.record({"a": float(i)}, {"inv": i % 2 == 0})
+    assert rt.get_counters()["a"] == [2.0, 3.0, 4.0]
+    assert rt.get_invariants()["inv"] == [1.0, 0.0, 1.0]
+
+
+def test_optional_arguments():
+    rt = RollingTelemetry(max_points=2)
+    rt.record({"x": 1.0})
+    rt.record(invariants={"ok": True})
+    assert rt.get_counters()["x"] == [1.0]
+    assert rt.get_invariants()["ok"] == [1.0]

--- a/tests/test_telemetry_model.py
+++ b/tests/test_telemetry_model.py
@@ -1,0 +1,10 @@
+from ui_new.state.Telemetry import TelemetryModel
+
+
+def test_record_updates_histories():
+    tm = TelemetryModel(max_points=2)
+    tm.record({"events": 1.0}, {"inv": True}, depth=3)
+    tm.record({"events": 2.0}, {"inv": False}, depth=4)
+    assert tm.counters["events"] == [1.0, 2.0]
+    assert tm.invariants["inv"] == [1.0, 0.0]
+    assert tm.depth == 4

--- a/ui_new/main.qml
+++ b/ui_new/main.qml
@@ -21,6 +21,24 @@ Window {
         anchors.right: panels.left
     }
 
+    Text {
+        id: hud
+        anchors.left: parent.left
+        anchors.top: parent.top
+        color: "white"
+        text: "frame: " + metersModel.frame +
+              " depth: " + telemetryModel.depth +
+              " windows: " +
+              (telemetryModel.counters["window"] ? telemetryModel.counters["window"][telemetryModel.counters["window"].length - 1] : 0) +
+              " bridges: " +
+              (telemetryModel.counters["active_bridges"] ? telemetryModel.counters["active_bridges"][telemetryModel.counters["active_bridges"].length - 1] : 0) +
+              " fps: " + metersModel.fps.toFixed(1) +
+              " events/s: " +
+              (telemetryModel.counters["events_per_sec"] ? telemetryModel.counters["events_per_sec"][telemetryModel.counters["events_per_sec"].length - 1].toFixed(1) : 0) +
+              " residual: " + experimentModel.residual.toFixed(3)
+        z: 10
+    }
+
     TabView {
         id: panels
         width: 250
@@ -30,7 +48,7 @@ Window {
 
         Tab { title: "Telemetry"; Telemetry { anchors.fill: parent; graphView: graphView } }
         Tab { title: "Meters"; Meters { anchors.fill: parent } }
-        Tab { title: "Experiment"; Experiment { anchors.fill: parent } }
+        Tab { title: "Experiment"; Experiment { anchors.fill: parent; graphView: graphView } }
         Tab { title: "Replay"; Replay { anchors.fill: parent } }
         Tab { title: "Logs"; LogExplorer { anchors.fill: parent } }
     }

--- a/ui_new/panels/Experiment.qml
+++ b/ui_new/panels/Experiment.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 Rectangle {
+    property var graphView
     color: "#202020"
     anchors.fill: parent
 
@@ -20,21 +21,33 @@ Rectangle {
         }
         Row {
             spacing: 4
-            Button {
-                text: "Start"
-                onClicked: experimentModel.start()
+            Button { text: "Start"; onClicked: experimentModel.start() }
+            Button { text: "Pause"; onClicked: experimentModel.pause() }
+            Button { text: "Step"; onClicked: experimentModel.step() }
+            Button { text: "Reset"; onClicked: experimentModel.reset() }
+        }
+        Row {
+            spacing: 4
+            Text { text: "Rate"; color: "white" }
+            Slider {
+                width: 120
+                from: 0.1
+                to: 2.0
+                value: experimentModel.rate
+                onValueChanged: experimentModel.setRate(value)
             }
-            Button {
-                text: "Pause"
-                onClicked: experimentModel.pause()
+        }
+        Row {
+            spacing: 4
+            CheckBox {
+                text: "Labels"
+                checked: graphView ? graphView.labelsVisible : true
+                onToggled: if (graphView) graphView.labelsVisible = checked
             }
-            Button {
-                text: "Resume"
-                onClicked: experimentModel.resume()
-            }
-            Button {
-                text: "Reset"
-                onClicked: experimentModel.reset()
+            CheckBox {
+                text: "Edges"
+                checked: graphView ? graphView.edgesVisible : true
+                onToggled: if (graphView) graphView.edgesVisible = checked
             }
         }
     }

--- a/ui_new/panels/RollingPlot.qml
+++ b/ui_new/panels/RollingPlot.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.15
+
+Canvas {
+    id: canvas
+    property var points: []
+    onPaint: {
+        var ctx = getContext('2d');
+        ctx.reset();
+        ctx.strokeStyle = 'lime';
+        ctx.beginPath();
+        var pts = points || [];
+        if (pts.length > 0) {
+            var max = Math.max.apply(Math, pts);
+            if (max <= 0) max = 1;
+            var step = width / Math.max(1, pts.length - 1);
+            ctx.moveTo(0, height - (pts[0] / max) * height);
+            for (var i = 1; i < pts.length; ++i)
+                ctx.lineTo(i * step, height - (pts[i] / max) * height);
+        }
+        ctx.stroke();
+    }
+    onPointsChanged: requestPaint()
+}

--- a/ui_new/panels/Telemetry.qml
+++ b/ui_new/panels/Telemetry.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import "."
 
 Rectangle {
     property var graphView
@@ -25,6 +26,18 @@ Rectangle {
         Text {
             text: "edges visible: " + (graphView.edgesVisible ? "yes" : "no")
             color: "white"
+        }
+        Text { text: "events/sec"; color: "white" }
+        RollingPlot {
+            width: parent.width
+            height: 40
+            points: telemetryModel.counters["events_per_sec"] || []
+        }
+        Text { text: "residual"; color: "white" }
+        RollingPlot {
+            width: parent.width
+            height: 40
+            points: telemetryModel.invariants["inv_conservation_residual"] || []
         }
     }
 }

--- a/ui_new/state/Meters.py
+++ b/ui_new/state/Meters.py
@@ -9,11 +9,13 @@ class MetersModel(QObject):
     """Track frames per second for display in the Meters panel."""
 
     fpsChanged = Signal(float)
+    frameChanged = Signal(int)
 
     def __init__(self) -> None:
         super().__init__()
         self._fps = 0.0
         self._frames = 0
+        self._frame_total = 0
         self._timer = QElapsedTimer()
         self._timer.start()
 
@@ -22,6 +24,8 @@ class MetersModel(QObject):
         """Record that a frame was rendered and update FPS when needed."""
 
         self._frames += 1
+        self._frame_total += 1
+        self.frameChanged.emit(self._frame_total)
         elapsed = self._timer.elapsed()
         if elapsed >= 1000:
             self._fps = self._frames * 1000.0 / elapsed
@@ -34,3 +38,9 @@ class MetersModel(QObject):
         return self._fps
 
     fps = Property(float, _get_fps, notify=fpsChanged)
+
+    # ------------------------------------------------------------------
+    def _get_frame(self) -> int:
+        return self._frame_total
+
+    frame = Property(int, _get_frame, notify=frameChanged)

--- a/ui_new/state/Telemetry.py
+++ b/ui_new/state/Telemetry.py
@@ -4,17 +4,24 @@ from __future__ import annotations
 
 from PySide6.QtCore import QObject, Property, Signal
 
+from telemetry import RollingTelemetry
+
 
 class TelemetryModel(QObject):
-    """Simple model reporting node and edge counts."""
+    """Report node/edge counts and rolling telemetry histories."""
 
     nodeCountChanged = Signal(int)
     edgeCountChanged = Signal(int)
+    countersChanged = Signal(dict)
+    invariantsChanged = Signal(dict)
+    depthChanged = Signal(int)
 
-    def __init__(self) -> None:
+    def __init__(self, max_points: int = 100) -> None:
         super().__init__()
         self._node_count = 0
         self._edge_count = 0
+        self._telemetry = RollingTelemetry(max_points=max_points)
+        self._depth = 0
 
     # ------------------------------------------------------------------
     def _get_node_count(self) -> int:
@@ -39,7 +46,40 @@ class TelemetryModel(QObject):
     edgeCount = Property(int, _get_edge_count, _set_edge_count, notify=edgeCountChanged)
 
     # ------------------------------------------------------------------
+    def _get_counters(self) -> dict[str, list[float]]:
+        return self._telemetry.get_counters()
+
+    counters = Property(dict, _get_counters, notify=countersChanged)
+
+    # ------------------------------------------------------------------
+    def _get_invariants(self) -> dict[str, list[float]]:
+        return self._telemetry.get_invariants()
+
+    invariants = Property(dict, _get_invariants, notify=invariantsChanged)
+
+    # ------------------------------------------------------------------
+    def record(
+        self,
+        counters: dict[str, float] | None = None,
+        invariants: dict[str, bool] | None = None,
+        depth: int | None = None,
+    ) -> None:
+        """Record a telemetry sample and emit change signals."""
+        if depth is not None and depth != self._depth:
+            self._depth = depth
+            self.depthChanged.emit(depth)
+        self._telemetry.record(counters, invariants)
+        self.countersChanged.emit(self._telemetry.get_counters())
+        self.invariantsChanged.emit(self._telemetry.get_invariants())
+
     def update_counts(self, nodes: int, edges: int) -> None:
         """Convenience method to update both counts."""
+
         self._set_node_count(nodes)
         self._set_edge_count(edges)
+
+    # ------------------------------------------------------------------
+    def _get_depth(self) -> int:
+        return self._depth
+
+    depth = Property(int, _get_depth, notify=depthChanged)


### PR DESCRIPTION
## Summary
- Include depth, counters, invariants and closed-window events in snapshot deltas
- Pull-based core loop renders only the latest snapshot at up to 60 FPS
- GraphView highlights window closures with transient red pulses and tests verify decay
- Document live diff loop and overlay pulses in the README

## Testing
- `python -m Causal_Web.main --help`
- `python -m compileall Causal_Web telemetry ui_new`
- `pip install numpy networkx pytest pydantic`
- `pip install websockets`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_rolling_telemetry.py tests/test_telemetry_model.py` 
- `pytest tests/test_rolling_telemetry.py tests/test_telemetry_model.py tests/test_graph_view_pulses.py` *(fails: ImportError: libGL.so.1)*
- `python bundle_run.py` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a00dff2488832587b93d3f45f183e7