### PR TITLE
feat: tighten ui websocket handling

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -305,6 +305,7 @@ class MainService:
             loop.run_forever()
 
         threading.Thread(target=_run_loop, daemon=True).start()
+        token = os.getenv("CW_SESSION_TOKEN", "secret")
         asyncio.run_coroutine_threadsafe(
             core.run(
                 "ws://localhost:8765",
@@ -316,6 +317,8 @@ class MainService:
                 store,
                 doe,
                 ga_model,
+                root,
+                token=token,
             ),
             loop,
         )

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Engine can now publish a MessagePack-encoded WebSocket stream. Clients pull
   `SnapshotDelta` updates on demand after a `DeltaReady` notification and also
   receive `ExperimentStatus` messages and an EWMA of conservation residuals.
+- WebSocket connections now expect a session token, send ping/pong keepalives
+  and accept only a single client by default. Set environment variable
+  `CW_ALLOW_MULTI=true` to permit multiple clients.
 - Fixed runaway zoom in the frames graph that occurred on startup.
 - Closing the GUI no longer hangs; the engine worker thread now shuts down
   cleanly.

--- a/tests/test_telemetry_model.py
+++ b/tests/test_telemetry_model.py
@@ -8,3 +8,6 @@ def test_record_updates_histories():
     assert tm.counters["events"] == [1.0, 2.0]
     assert tm.invariants["inv"] == [1.0, 0.0]
     assert tm.depth == 4
+    assert tm.depthLabel == "depth"
+    tm.record({"events": 3.0}, {"inv": True}, depth=5, label="frame")
+    assert tm.depthLabel == "frame"

--- a/ui_new/main.qml
+++ b/ui_new/main.qml
@@ -8,6 +8,7 @@ Window {
     id: root
     property bool editMode: true
     property string tool: "select"
+    property bool controlsEnabled: true
     width: 800
     height: 600
     visible: true
@@ -21,13 +22,14 @@ Window {
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: panels.left
+        enabled: root.controlsEnabled
     }
 
     // editing overlay
     MouseArea {
         id: editor
         anchors.fill: graphView
-        enabled: root.editMode
+        enabled: root.editMode && root.controlsEnabled
         onPressed: function(mouse) {
             var pos = Qt.point(mouse.x, mouse.y)
             if (root.tool === "add") {
@@ -84,6 +86,7 @@ Window {
         anchors.top: parent.top
         anchors.left: parent.left
         visible: root.editMode
+        enabled: root.controlsEnabled
         Button { text: "Select"; onClicked: root.tool = "select" }
         Button { text: "Add"; onClicked: root.tool = "add" }
         Button { text: "Connect"; onClicked: root.tool = "connect" }
@@ -95,6 +98,7 @@ Window {
         text: root.editMode ? "Run" : "Edit"
         anchors.top: parent.top
         anchors.right: panels.left
+        enabled: root.controlsEnabled
         onClicked: {
             root.editMode = !root.editMode
             graphView.editable = root.editMode
@@ -109,9 +113,9 @@ Window {
         anchors.left: parent.left
         anchors.top: parent.top
         color: "white"
-        text: "frame: " + metersModel.frame +
-              " depth: " + telemetryModel.depth +
-              " windows: " +
+          text: "frame: " + metersModel.frame +
+                " " + telemetryModel.depthLabel + ": " + telemetryModel.depth +
+                " windows: " +
               (telemetryModel.counters["window"] ? telemetryModel.counters["window"][telemetryModel.counters["window"].length - 1] : 0) +
               " bridges: " +
               (telemetryModel.counters["active_bridges"] ? telemetryModel.counters["active_bridges"][telemetryModel.counters["active_bridges"].length - 1] : 0) +
@@ -128,6 +132,7 @@ Window {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.right: parent.right
+        enabled: root.controlsEnabled
 
         Tab { title: "Telemetry"; Telemetry { anchors.fill: parent; graphView: graphView } }
         Tab { title: "Meters"; Meters { anchors.fill: parent } }

--- a/ui_new/state/Telemetry.py
+++ b/ui_new/state/Telemetry.py
@@ -15,6 +15,7 @@ class TelemetryModel(QObject):
     countersChanged = Signal(dict)
     invariantsChanged = Signal(dict)
     depthChanged = Signal(int)
+    depthLabelChanged = Signal(str)
 
     def __init__(self, max_points: int = 100) -> None:
         super().__init__()
@@ -22,6 +23,7 @@ class TelemetryModel(QObject):
         self._edge_count = 0
         self._telemetry = RollingTelemetry(max_points=max_points)
         self._depth = 0
+        self._depth_label = "depth"
 
     # ------------------------------------------------------------------
     def _get_node_count(self) -> int:
@@ -63,11 +65,15 @@ class TelemetryModel(QObject):
         counters: dict[str, float] | None = None,
         invariants: dict[str, bool] | None = None,
         depth: int | None = None,
+        label: str = "depth",
     ) -> None:
         """Record a telemetry sample and emit change signals."""
         if depth is not None and depth != self._depth:
             self._depth = depth
             self.depthChanged.emit(depth)
+        if label != self._depth_label:
+            self._depth_label = label
+            self.depthLabelChanged.emit(label)
         self._telemetry.record(counters, invariants)
         self.countersChanged.emit(self._telemetry.get_counters())
         self.invariantsChanged.emit(self._telemetry.get_invariants())
@@ -83,3 +89,9 @@ class TelemetryModel(QObject):
         return self._depth
 
     depth = Property(int, _get_depth, notify=depthChanged)
+
+    # ------------------------------------------------------------------
+    def _get_depth_label(self) -> str:
+        return self._depth_label
+
+    depthLabel = Property(str, _get_depth_label, notify=depthLabelChanged)


### PR DESCRIPTION
## Summary
- avoid redundant topology rebuilds by only calling `set_graph` for `GraphStatic` messages
- clarify telemetry depth/frame labelling
- add session-token handshake, heartbeat ping and single-client default for WebSockets with `CW_ALLOW_MULTI` override
- disable all UI controls when the WebSocket disconnects

## Testing
- `black Causal_Web/engine/stream/server.py`
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pip install websockets PySide6`
- `apt-get update`
- `apt-get install -y libgl1`
- `apt-get install -y libxkbcommon0`
- `apt-get install -y libegl1`
- `pytest` *(fails: KeyError: 'x' in multiple tests)*

## Notes
- No outstanding items from the original request

------
https://chatgpt.com/codex/tasks/task_e_68a2b161ebf08325a3a629f99eb1ec81