### PR TITLE
feat: persist experiment leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - DOE queue manager can generate Latin Hypercube or grid sweeps, tracks live per-run invariant and fitness status, and dispatches runs to the engine via IPC.
 - New DOE panel integrates the queue manager into the Qt Quick UI with a Top-K table, scatter plot, parallel-coordinate view, fitness heatmap and live status updates for sampled configurations.
 - Added a lightweight Genetic Algorithm framework with tournament selection, uniform crossover, Gaussian mutation and elitism along with a GA panel showing population fitness, a Pareto-front view and a "Promote to baseline config" action.
+- DOE and GA batches now persist summaries under ``experiments/``:
+  - ``top_k.json`` records the best runs and is consumed by the Top-K UI table.
+  - ``hall_of_fame.json`` archives per-generation GA champions.
+  - ``best_config.yaml`` captures the promoted configuration for quick reuse.
+  - run directories under ``experiments/runs/<date>/<id>/`` hold per-run ``config.json``, ``result.json`` and ``delta_log.jsonl`` for replay.
 - GA evaluation can dispatch genomes to the engine via IPC, with engine-side handling of ``ExperimentControl`` messages for ``run`` requests.
 - GA panel evaluations now use the shared IPC loop so genomes are executed on the engine during interactive runs.
 - GA runs can be checkpointed and later resumed from disk—including any in-flight evaluations—to support reproducible interrupted searches.

--- a/experiments/__init__.py
+++ b/experiments/__init__.py
@@ -2,5 +2,22 @@
 
 from .queue import DOEQueueManager
 from .ga import GeneticAlgorithm
+from .artifacts import (
+    TopKEntry,
+    update_top_k,
+    load_top_k,
+    save_hall_of_fame,
+    load_hall_of_fame,
+    persist_run,
+)
 
-__all__ = ["DOEQueueManager", "GeneticAlgorithm"]
+__all__ = [
+    "DOEQueueManager",
+    "GeneticAlgorithm",
+    "TopKEntry",
+    "update_top_k",
+    "load_top_k",
+    "save_hall_of_fame",
+    "load_hall_of_fame",
+    "persist_run",
+]

--- a/experiments/artifacts.py
+++ b/experiments/artifacts.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+"""Utility functions for experiment result artifacts.
+
+This module persists and loads top-K and hall-of-fame records in a
+simple JSON format.  The records help surface the best runs in the UI
+and allow users to replay or promote configurations.
+"""
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+from datetime import datetime
+import json
+import secrets
+
+
+@dataclass
+class TopKEntry:
+    """Description of a single run in the top-K list."""
+
+    run_id: str
+    fitness: float
+    objectives: Dict[str, float]
+    groups: Dict[str, float]
+    toggles: Dict[str, str]
+    seed: int
+    path: str
+
+
+# ---------------------------------------------------------------------------
+def update_top_k(
+    entries: Iterable[TopKEntry], path: Path, k: int = 50
+) -> List[TopKEntry]:
+    """Merge ``entries`` into existing top-K data and persist it.
+
+    Parameters
+    ----------
+    entries:
+        Iterable of new :class:`TopKEntry` objects.
+    path:
+        Destination JSON path.
+    k:
+        Maximum number of rows to retain.
+
+    Returns
+    -------
+    List[TopKEntry]
+        Sorted top-K list that was written to disk.
+    """
+
+    existing: List[TopKEntry] = []
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            for row in data.get("rows", []):
+                existing.append(TopKEntry(**row))
+        except Exception:
+            pass
+    combined = existing + list(entries)
+    combined.sort(key=lambda e: e.fitness, reverse=True)
+    top = combined[:k]
+    payload = {"k": k, "rows": [asdict(e) for e in top]}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+    return top
+
+
+# ---------------------------------------------------------------------------
+def load_top_k(path: Path) -> Dict[str, object]:
+    """Load top-K data from ``path``."""
+
+    if not path.exists():
+        return {"k": 0, "rows": []}
+    data = json.loads(path.read_text())
+    return data
+
+
+# ---------------------------------------------------------------------------
+def save_hall_of_fame(entries: Iterable[Dict[str, object]], path: Path) -> None:
+    """Persist ``entries`` to ``path`` in the hall-of-fame schema."""
+
+    payload = {"archive": list(entries)}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+# ---------------------------------------------------------------------------
+def load_hall_of_fame(path: Path) -> Dict[str, object]:
+    """Load hall-of-fame data from ``path``."""
+
+    if not path.exists():
+        return {"archive": []}
+    return json.loads(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+def persist_run(
+    config: Dict[str, Any],
+    result: Dict[str, Any],
+    path: Path,
+    *,
+    delta_log: Path | None = None,
+) -> None:
+    """Write ``config`` and ``result`` details to ``path``.
+
+    A small directory is created containing ``config.json`` and ``result.json``
+    files.  When available a ``delta_log.jsonl`` capturing snapshot deltas is
+    also copied so runs can be deterministically replayed.
+    """
+
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config, indent=2))
+    (path / "result.json").write_text(json.dumps(result, indent=2))
+
+    if delta_log is None:
+        try:  # pragma: no cover - optional dependency
+            from Causal_Web.config import Config
+
+            delta_log = Path(Config.output_path("delta_log.jsonl"))
+        except Exception:  # pragma: no cover - fallback when Config missing
+            delta_log = None
+
+    if delta_log and delta_log.exists():
+        import shutil
+
+        shutil.copy(delta_log, path / "delta_log.jsonl")
+
+
+# ---------------------------------------------------------------------------
+def allocate_run_dir(root: Path = Path("experiments")) -> Tuple[str, Path, str]:
+    """Allocate a unique run directory under ``root``.
+
+    Parameters
+    ----------
+    root:
+        Root experiments directory. The run will be created inside
+        ``root / runs / <date>``.
+
+    Returns
+    -------
+    Tuple[str, Path, str]
+        A tuple of ``(run_id, path, relative_path)`` where ``run_id`` is a
+        timestamped identifier, ``path`` is the absolute directory path and
+        ``relative_path`` is the path relative to ``root`` suitable for
+        artifact records.
+    """
+
+    now = datetime.utcnow()
+    token = secrets.token_hex(3)
+    date = now.strftime("%Y-%m-%d")
+    run_id = f"{now.strftime('%Y-%m-%dT%H-%M-%SZ')}-{token}"
+    rel = Path("runs") / date / token
+    abs_path = root / rel
+    return run_id, abs_path, str(rel)
+
+
+__all__ = [
+    "TopKEntry",
+    "update_top_k",
+    "load_top_k",
+    "save_hall_of_fame",
+    "load_hall_of_fame",
+    "persist_run",
+    "allocate_run_dir",
+]

--- a/experiments/ga.py
+++ b/experiments/ga.py
@@ -9,6 +9,7 @@ manager.
 """
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -32,15 +33,28 @@ import numpy as np
 from config.normalizer import Normalizer
 from invariants import checks
 from .gates import run_gates
+from .artifacts import (
+    TopKEntry,
+    update_top_k,
+    save_hall_of_fame,
+    persist_run,
+    allocate_run_dir,
+)
 
 
 @dataclass
 class Genome:
-    """Container describing a single genome in the population."""
+    """Container describing a single genome in the population.
+
+    ``run_id`` and ``run_path`` are populated when the genome has been
+    evaluated and its configuration/result persisted to disk.
+    """
 
     groups: Dict[str, float]
     toggles: Dict[str, int]
     fitness: Optional[Union[float, Sequence[float]]] = None
+    run_id: Optional[str] = None
+    run_path: Optional[str] = None
 
 
 class GeneticAlgorithm:
@@ -111,11 +125,25 @@ class GeneticAlgorithm:
         self._normalizer = Normalizer()
         self.population: List[Genome] = []
         self.history: List[float] = []
+        self._hall_of_fame: List[Tuple[int, Genome]] = []
+        self._generation = 0
         self._client = client
         self._loop = loop
         self._pending: Dict[int, Tuple[Genome, asyncio.Future, int]] = {}
         self._next_id = 0
         self._init_population()
+
+    # ------------------------------------------------------------------
+    def set_client(self, client: Any | None) -> None:
+        """Assign an IPC ``client`` for engine communication."""
+
+        self._client = client
+
+    # ------------------------------------------------------------------
+    def set_event_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """Assign the AsyncIO ``loop`` used for IPC callbacks."""
+
+        self._loop = loop
 
     # ------------------------------------------------------------------
     def _seed_for_genome(self, genome: Genome) -> int:
@@ -169,7 +197,7 @@ class GeneticAlgorithm:
             if res.get("status") == "ok":
                 return res
             if attempt == 0:
-                await asyncio.sleep(2**attempt)
+                time.sleep(2**attempt)
         return res
 
     # ------------------------------------------------------------------
@@ -238,11 +266,11 @@ class GeneticAlgorithm:
         self._pending.pop(rid, None)
 
     def _evaluate(self, genome: Genome) -> Union[float, Sequence[float]]:
-        """Evaluate ``genome`` and cache its fitness."""
+        """Evaluate ``genome`` and persist its config/result on success."""
 
+        raw = self._normalizer.to_raw(self.base, genome.groups)
+        raw.update(genome.toggles)
         if self._client is None or self._loop is None:
-            raw = self._normalizer.to_raw(self.base, genome.groups)
-            raw.update(genome.toggles)
             metrics = run_gates(raw, self.gates)
             inv = checks.from_metrics(metrics)
             inv_ok = (
@@ -252,14 +280,27 @@ class GeneticAlgorithm:
                 and abs(inv.get("inv_no_signaling_delta", 0.0)) <= 1e-9
             )
             if inv_ok:
-                genome.fitness = self.fitness_fn(
-                    metrics, inv, genome.groups, genome.toggles
-                )
+                fit = self.fitness_fn(metrics, inv, genome.groups, genome.toggles)
+                res = {
+                    "status": "ok",
+                    "fitness": fit,
+                    "metrics": metrics,
+                    "invariants": inv,
+                }
             else:
-                genome.fitness = None
-            return genome.fitness
-        res = self.evaluate_blocking(genome)
+                res = {
+                    "status": "invalid",
+                    "metrics": metrics,
+                    "invariants": inv,
+                }
+        else:
+            res = self.evaluate_blocking(genome)
         genome.fitness = res.get("fitness") if res.get("status") == "ok" else None
+        if res.get("status") == "ok":
+            rid, abs_path, rel_path = allocate_run_dir()
+            persist_run(raw, res, abs_path)
+            genome.run_id = rid
+            genome.run_path = rel_path
         return genome.fitness
 
     # ------------------------------------------------------------------
@@ -305,6 +346,7 @@ class GeneticAlgorithm:
         self.population.sort(key=lambda g: self._score(g), reverse=True)
         best = self.population[0]
         self.history.append(self._score(best))
+        self._hall_of_fame.append((self._generation, best))
 
         next_pop: List[Genome] = self.population[: self.elite]
         while len(next_pop) < self.population_size:
@@ -316,6 +358,7 @@ class GeneticAlgorithm:
         self.population = next_pop
         for g in self.population[self.elite :]:
             g.fitness = None
+        self._generation += 1
         return best
 
     # ------------------------------------------------------------------
@@ -359,22 +402,75 @@ class GeneticAlgorithm:
         return best if best is not None else self.population[0]
 
     # ------------------------------------------------------------------
+    def save_artifacts(
+        self,
+        top_k_path: str,
+        hall_of_fame_path: str,
+        k: int = 50,
+    ) -> None:
+        """Persist top-K and hall-of-fame summaries to disk."""
+
+        top_entries: List[TopKEntry] = []
+        hof_entries: List[Dict[str, Any]] = []
+        for gen, g in self._hall_of_fame:
+            if g.run_id is None or g.run_path is None:
+                continue
+            obj = (
+                {f"f{i}": float(v) for i, v in enumerate(g.fitness)}
+                if isinstance(g.fitness, Sequence)
+                else {}
+            )
+            top_entries.append(
+                TopKEntry(
+                    run_id=g.run_id,
+                    fitness=self._score(g),
+                    objectives=obj,
+                    groups=g.groups,
+                    toggles=g.toggles,
+                    seed=self._seed_for_genome(g),
+                    path=g.run_path,
+                )
+            )
+            hof_entries.append(
+                {
+                    "gen": gen,
+                    "run_id": g.run_id,
+                    "fitness": self._score(g),
+                    "objectives": obj,
+                    "path": g.run_path,
+                }
+            )
+        update_top_k(top_entries, Path(top_k_path), k)
+        save_hall_of_fame(hof_entries, Path(hall_of_fame_path))
+
+    # ------------------------------------------------------------------
     def promote_best(self, path: str) -> None:
-        """Write the best genome's raw configuration to ``path`` as YAML."""
+        """Write the best genome's configuration to ``path`` as YAML.
+
+        If the genome has a persisted run directory, the configuration is
+        loaded from the saved ``config.json``.  Otherwise it is materialised
+        from the genome's groups and toggles.
+        """
 
         best = max(self.population, key=self._score)
-        raw = self._normalizer.to_raw(self.base, best.groups)
-        raw.update(best.toggles)
+        cfg: Dict[str, Any] | None = None
+        if best.run_path:
+            try:
+                cfg = json.loads(
+                    (Path("experiments") / best.run_path / "config.json").read_text()
+                )
+            except Exception:  # pragma: no cover - fall back to materialised config
+                cfg = None
+        if cfg is None:
+            raw = self._normalizer.to_raw(self.base, best.groups)
+            raw.update(best.toggles)
+            cfg = {
+                k: float(v) if isinstance(v, np.floating) else v for k, v in raw.items()
+            }
         import yaml
 
         with open(path, "w", encoding="utf8") as fh:
-            yaml.safe_dump(
-                {
-                    k: float(v) if isinstance(v, np.floating) else v
-                    for k, v in raw.items()
-                },
-                fh,
-            )
+            yaml.safe_dump(cfg, fh)
 
     # ------------------------------------------------------------------
     def save_checkpoint(self, path: str) -> None:

--- a/experiments/ga.py
+++ b/experiments/ga.py
@@ -197,7 +197,7 @@ class GeneticAlgorithm:
             if res.get("status") == "ok":
                 return res
             if attempt == 0:
-                time.sleep(2**attempt)
+                self._loop.run_until_complete(asyncio.sleep(2**attempt))
         return res
 
     # ------------------------------------------------------------------

--- a/tests/experiments/test_artifacts.py
+++ b/tests/experiments/test_artifacts.py
@@ -1,0 +1,50 @@
+import pathlib
+from experiments.artifacts import (
+    TopKEntry,
+    update_top_k,
+    load_top_k,
+    save_hall_of_fame,
+    load_hall_of_fame,
+    allocate_run_dir,
+    persist_run,
+)
+
+
+def test_top_k_merge(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "top_k.json"
+    e1 = TopKEntry("run1", 0.5, {}, {"g": 1.0}, {}, 1, "")
+    update_top_k([e1], path, k=2)
+    e2 = TopKEntry("run2", 0.8, {}, {"g": 2.0}, {}, 2, "")
+    update_top_k([e2], path, k=2)
+    data = load_top_k(path)
+    assert data["rows"][0]["run_id"] == "run2"
+    assert data["k"] == 2
+
+
+def test_hall_of_fame_roundtrip(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "hof.json"
+    entries = [
+        {"gen": 0, "run_id": "a", "fitness": 0.9, "objectives": {}, "path": "runs/a"}
+    ]
+    save_hall_of_fame(entries, path)
+    data = load_hall_of_fame(path)
+    assert data["archive"][0]["path"] == "runs/a"
+
+
+def test_allocate_run_dir_creates_unique_path(tmp_path: pathlib.Path) -> None:
+    run_id, abs_path, rel_path = allocate_run_dir(tmp_path)
+    assert abs_path == tmp_path / rel_path
+    assert rel_path.startswith("runs/")
+    persist_run({}, {}, abs_path)
+    assert abs_path.exists()
+
+
+def test_persist_run_copies_delta_log(tmp_path: pathlib.Path) -> None:
+    from Causal_Web.config import Config
+
+    Config.output_dir = str(tmp_path)
+    log = tmp_path / "delta_log.jsonl"
+    log.write_text("{}\n")
+    dest = tmp_path / "run"
+    persist_run({}, {}, dest)
+    assert (dest / "delta_log.jsonl").read_text() == "{}\n"

--- a/tests/experiments/test_doe_model.py
+++ b/tests/experiments/test_doe_model.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+import yaml
+
+from ui_new.state.DOE import DOEModel
+
+
+def test_doe_promote_uses_run_config(tmp_path, monkeypatch):
+    run_dir = tmp_path / "experiments" / "runs" / "2025-01-01" / "abc"
+    run_dir.mkdir(parents=True)
+    (run_dir / "config.json").write_text(json.dumps({"x": 1.0}))
+    monkeypatch.chdir(tmp_path)
+    model = DOEModel()
+    model._topk = [{"fitness": 0.0, "path": "runs/2025-01-01/abc"}]
+    model.promote()
+    data = yaml.safe_load((Path("experiments/best_config.yaml")).read_text())
+    assert data == {"x": 1.0}
+
+
+def test_doe_topk_paths_link_runs(tmp_path, monkeypatch) -> None:
+    from Causal_Web.config import Config
+
+    monkeypatch.chdir(tmp_path)
+    Config.output_dir = str(tmp_path)
+    (tmp_path / "delta_log.jsonl").write_text("{}\n")
+    model = DOEModel()
+    model.runLhs(1)
+    data = json.loads((tmp_path / "experiments/top_k.json").read_text())
+    row = data["rows"][0]
+    run_dir = tmp_path / "experiments" / row["path"]
+    assert (run_dir / "config.json").exists()
+    assert (run_dir / "result.json").exists()
+    assert (run_dir / "delta_log.jsonl").exists()
+
+
+def test_doe_persists_run_once(tmp_path, monkeypatch) -> None:
+    from Causal_Web.config import Config
+
+    monkeypatch.chdir(tmp_path)
+    Config.output_dir = str(tmp_path)
+    (tmp_path / "delta_log.jsonl").write_text("{}\n")
+    model = DOEModel()
+    model.runLhs(1)
+    data = json.loads((tmp_path / "experiments/top_k.json").read_text())
+    path1 = data["rows"][0]["path"]
+    # Trigger a second recompute and ensure the path stays the same
+    model._recompute()
+    data = json.loads((tmp_path / "experiments/top_k.json").read_text())
+    path2 = data["rows"][0]["path"]
+    assert path1 == path2

--- a/ui_new/main.qml
+++ b/ui_new/main.qml
@@ -137,12 +137,12 @@ Window {
         Tab { title: "Telemetry"; Telemetry { anchors.fill: parent; graphView: graphView } }
         Tab { title: "Meters"; Meters { anchors.fill: parent } }
         Tab { title: "Experiment"; Experiment { anchors.fill: parent; graphView: graphView } }
-        Tab { title: "Replay"; Replay { anchors.fill: parent } }
+        Tab { id: replayTab; title: "Replay"; Replay { anchors.fill: parent } }
         Tab { title: "Logs"; LogExplorer { anchors.fill: parent } }
         Tab { title: "Inspector"; Inspector { anchors.fill: parent } }
         Tab { title: "Validation"; Validation { anchors.fill: parent } }
-        Tab { title: "DOE"; DOE { anchors.fill: parent } }
-        Tab { title: "GA"; GA { anchors.fill: parent } }
+        Tab { title: "DOE"; DOE { anchors.fill: parent; panels: panels; replayTab: replayTab } }
+        Tab { title: "GA"; GA { anchors.fill: parent; panels: panels; replayTab: replayTab } }
         Tab { title: "Compare"; Compare { anchors.fill: parent } }
     }
 }

--- a/ui_new/panels/DOE.qml
+++ b/ui_new/panels/DOE.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 Rectangle {
+    property var panels
+    property var replayTab
     color: "#202020"
     anchors.fill: parent
 
@@ -10,7 +12,11 @@ Rectangle {
         anchors.fill: parent
         spacing: 4
 
-        Button { text: "Run LHS"; onClicked: doeModel.runLhs(20) }
+        Row {
+            spacing: 4
+            Button { text: "Run LHS"; onClicked: doeModel.runLhs(20) }
+            Button { text: "Promote"; onClicked: doeModel.promote() }
+        }
         Text { text: "Top-K"; color: "white" }
         ListView {
             width: parent.width
@@ -20,6 +26,14 @@ Rectangle {
                 spacing: 4
                 Text { text: (index + 1) + ":"; color: "white" }
                 Text { text: fitness.toFixed(3); color: "white" }
+                Button {
+                    text: "Replay"
+                    onClicked: {
+                        replayModel.load("experiments/" + path + "/delta_log.jsonl")
+                        if (panels && replayTab)
+                            panels.currentIndex = panels.indexOf(replayTab)
+                    }
+                }
             }
         }
         Text { text: "Scatter"; color: "white" }

--- a/ui_new/panels/GA.qml
+++ b/ui_new/panels/GA.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 Rectangle {
+    property var panels
+    property var replayTab
     color: "#202020"
     anchors.fill: parent
 
@@ -75,6 +77,25 @@ Rectangle {
                 }
             }
             Connections { target: gaModel; function onParetoChanged() { pareto.requestPaint() } }
+        }
+        Text { text: "Hall of Fame"; color: "white" }
+        ListView {
+            width: parent.width
+            height: 80
+            model: gaModel.hallOfFame
+            delegate: Row {
+                spacing: 4
+                Text { text: gen + ":"; color: "white" }
+                Text { text: fitness.toFixed(3); color: "white" }
+                Button {
+                    text: "Replay"
+                    onClicked: {
+                        replayModel.load("experiments/" + path + "/delta_log.jsonl")
+                        if (panels && replayTab)
+                            panels.currentIndex = panels.indexOf(replayTab)
+                    }
+                }
+            }
         }
     }
 }

--- a/ui_new/panels/GA.qml
+++ b/ui_new/panels/GA.qml
@@ -85,7 +85,7 @@ Rectangle {
             model: gaModel.hallOfFame
             delegate: Row {
                 spacing: 4
-                Text { text: gen + ":"; color: "white" }
+                Text { text: (typeof gen !== "undefined" ? gen : "?") + ":"; color: "white" }
                 Text { text: fitness.toFixed(3); color: "white" }
                 Button {
                     text: "Replay"


### PR DESCRIPTION
## Summary
- cache run IDs and paths in DOE run statuses so Top-K artifacts reference stable run directories
- persist run data only once per DOE evaluation and reuse recorded paths in leaderboard exports
- add regression test confirming DOE runs aren't reallocated on recompute
- load GA baseline configs from their saved run directories when promoting the best genome
- test GA promotion to ensure it reads the persisted run config
- capture delta logs alongside config and result so runs can be deterministically replayed, and wire Replay buttons to these logs

## Testing
- `python -m compileall Causal_Web experiments ui_new/state`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36fd88a8c8325acb8be0f974fd01c