### PR TITLE
Add engine micro-counters and residual metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,11 @@ The adapter exposes methods like `build_graph`, `step`, `pause` and
 compatible. Snapshots include the identifiers of nodes and edges touched since
 the previous call along with any closed window events, allowing the GUI to
 incrementally update its model. An EWMA of the energy conservation residual
-is tracked per window and surfaced via the snapshot counters. Internally a depth-based
+is tracked per window and surfaced via the snapshot counters. Additional
+micro-counters such as ``windows_closed``, ``bridges_active``,
+``events_processed`` and ``edges_traversed`` are exposed alongside global
+``residual_ewma`` and per-window ``residual_max`` to aid diagnostics. For Bell experiments the
+adapter also tracks a no-signaling delta under ``inv_no_signaling_delta``. Internally a depth-based
 scheduler orders packets by their arrival depth and advances vertex windows
 using the Local Causal Consistency Model (LCCM).  The LCCM computes a window
 size ``W(v)`` from the vertex's incident degree (fan-in plus fan-out) and local

--- a/tests/test_delta_counters.py
+++ b/tests/test_delta_counters.py
@@ -1,0 +1,28 @@
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+from Causal_Web.engine.engine_v2.state import Packet
+
+
+def test_delta_includes_micro_counters() -> None:
+    adapter = EngineAdapter()
+    graph = {
+        "params": {"W0": 1},
+        "nodes": [{"id": "0"}, {"id": "1"}],
+        "edges": [{"from": "0", "to": "1", "delay": 1.0}],
+    }
+    adapter.build_graph(graph)
+    adapter._scheduler.push(0, 0, 0, Packet(0, 1))
+    adapter.step(max_events=1)
+    delta = adapter._build_delta()
+    assert delta is not None
+    counters = delta["counters"]
+    for key in [
+        "windows_closed",
+        "bridges_active",
+        "events_processed",
+        "edges_traversed",
+        "residual_ewma",
+        "residual_max",
+    ]:
+        assert key in counters
+    invariants = delta["invariants"]
+    assert "inv_no_signaling_delta" in invariants


### PR DESCRIPTION
## Summary
- track windows closed, bridges active, events processed and edges traversed in engine telemetry
- expose residual EWMA, last-window residual max and no-signaling delta invariant
- document new counters and cover with tests

## Testing
- `python -m compileall Causal_Web`
- `pip install numpy networkx pytest pydantic`
- `pip install websockets`
- `pytest` *(fails: tests/test_soak_memory.py::test_soak_memory_growth_under_threshold)*
- `python bundle_run.py`

## PR Notes
- None

------
https://chatgpt.com/codex/tasks/task_e_68a5f9043af48325b6c5433d413b21f1