### PR TITLE
feat: add run index and resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ via a Monte-Carlo path sampler over the graph's causal structure.
   saturation with high fan-in.
 - Added DOE runner with invariant checks and metrics logging.
 - Runner CLI now accepts separate experiment (`--exp`) and base (`--base`)
-  configs, persists per-sample seeds and gate metrics, and supports
-  parallel execution via `--parallel` (use `--processes` for a process pool).
+  configs, persists per-sample seeds and gate metrics, supports
+  parallel execution via `--parallel` (use `--processes` for a process pool),
+  and can re-evaluate cached configurations with `--force`. The genetic
+  algorithm runner exposes the same `--force` option to rerun cached genomes.
 - DOE summaries now record selected gates and aggregate gate metrics
   (mean and standard deviation).
 - DOE queue manager can generate Latin Hypercube or grid sweeps, tracks live per-run invariant and fitness status, and dispatches runs to the engine via IPC.
@@ -123,8 +125,10 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - GA panel evaluations now use the shared IPC loop so genomes are executed on the engine during interactive runs.
 - GA runs can be checkpointed and later resumed from disk—including any in-flight evaluations—to support reproducible interrupted searches.
 - Sweeps and GA populations reuse existing results via a persistent run index
-  keyed by a deterministic run hash, allowing duplicate submissions to be
-  skipped and interrupted batches to resume safely.
+  at ``experiments/runs/index.json`` keyed by a deterministic run hash,
+  skipping duplicate configurations and allowing interrupted batches to
+  resume safely. Command-line sweeps accept ``--force`` to re-evaluate
+  configurations even when present in the index.
 - Gate harness now executes Gates 1–6 via engine primitives rather than
   returning proxy metrics.
 - Gate metrics now capture interference visibility, delay slopes and

--- a/tests/experiments/test_doe_model.py
+++ b/tests/experiments/test_doe_model.py
@@ -12,10 +12,19 @@ def test_doe_promote_uses_run_config(tmp_path, monkeypatch):
     (run_dir / "config.json").write_text(json.dumps({"x": 1.0}))
     monkeypatch.chdir(tmp_path)
     model = DOEModel()
-    model._topk = [{"fitness": 0.0, "path": "runs/2025-01-01/abc"}]
-    model.promote()
+    model._topk = [
+        {
+            "fitness": 0.0,
+            "path": "runs/2025-01-01/abc",
+            "groups": {"x": 1.0},
+            "toggles": {},
+            "seed": 0,
+            "run_id": "abc",
+        }
+    ]
+    model.promote(model._topk[0])
     data = yaml.safe_load((Path("experiments/best_config.yaml")).read_text())
-    assert data == {"x": 1.0}
+    assert data["dimensionless"] == {"x": 1.0}
 
 
 def test_doe_topk_paths_link_runs(tmp_path, monkeypatch) -> None:
@@ -49,3 +58,23 @@ def test_doe_persists_run_once(tmp_path, monkeypatch) -> None:
     data = json.loads((tmp_path / "experiments/top_k.json").read_text())
     path2 = data["rows"][0]["path"]
     assert path1 == path2
+
+
+def test_doe_force_reruns_duplicate(tmp_path: Path, monkeypatch) -> None:
+    from Causal_Web.config import Config
+
+    monkeypatch.chdir(tmp_path)
+    Config.output_dir = str(tmp_path)
+    (tmp_path / "delta_log.jsonl").write_text("{}\n")
+    model = DOEModel()
+    model.runLhs(1)
+    manifests = list((tmp_path / "experiments" / "runs").rglob("manifest.json"))
+    assert len(manifests) == 1
+
+    model.runLhs(1)
+    manifests = list((tmp_path / "experiments" / "runs").rglob("manifest.json"))
+    assert len(manifests) == 1
+
+    model.runLhs(1, True)
+    manifests = list((tmp_path / "experiments" / "runs").rglob("manifest.json"))
+    assert len(manifests) == 2

--- a/tests/experiments/test_queue_manager.py
+++ b/tests/experiments/test_queue_manager.py
@@ -17,7 +17,8 @@ def _base_config():
     }
 
 
-def test_lhs_enqueue_and_run():
+def test_lhs_enqueue_and_run(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
     mgr = DOEQueueManager(_base_config(), [1])
     mgr.enqueue_lhs({"Delta_over_W0": (0.5, 1.0)}, samples=2)
     assert len(mgr.runs) == 2
@@ -27,7 +28,8 @@ def test_lhs_enqueue_and_run():
         assert status.invariants["inv_causality_ok"]
 
 
-def test_grid_enqueue():
+def test_grid_enqueue(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
     mgr = DOEQueueManager(_base_config(), [1])
     mgr.enqueue_grid({"Delta_over_W0": (0.0, 1.0)}, {"Delta_over_W0": 3})
     assert len(mgr.runs) == 3
@@ -41,6 +43,7 @@ def test_queue_manager_duplicate_skip(tmp_path: pathlib.Path, monkeypatch) -> No
 
     mgr2 = DOEQueueManager(_base_config(), [1])
     mgr2.enqueue_lhs({"Delta_over_W0": (0.5, 1.0)}, samples=1)
+    assert len(mgr2.runs) == 0
     mgr2.run_all()
 
     manifests = list((tmp_path / "experiments" / "runs").rglob("manifest.json"))

--- a/ui_new/state/DOE.py
+++ b/ui_new/state/DOE.py
@@ -67,14 +67,23 @@ class DOEModel(QObject):
         self._topk = data.get("rows", [])
 
     # ------------------------------------------------------------------
-    @Slot(int)
-    def runLhs(self, samples: int = 10) -> None:
-        """Generate ``samples`` Latin Hypercube points and evaluate them."""
+    @Slot(int, bool)
+    def runLhs(self, samples: int = 10, force: bool = False) -> None:
+        """Generate ``samples`` LHS points and evaluate them.
+
+        Parameters
+        ----------
+        samples:
+            Number of Latin Hypercube samples to generate.
+        force:
+            When ``True`` re-evaluate configurations even if present in the
+            run index.
+        """
 
         self._mgr = DOEQueueManager(
             self._base, self._gates, self._fitness, client=self._client
         )
-        self._mgr.enqueue_lhs(self._groups, samples)
+        self._mgr.enqueue_lhs(self._groups, samples, force=force)
         self._start_time = time.time()
         self._update_progress()
         if self._client is None:
@@ -89,14 +98,21 @@ class DOEModel(QObject):
             self._ipc_task = asyncio.create_task(_run())
 
     # ------------------------------------------------------------------
-    @Slot()
-    def runGrid(self) -> None:
-        """Execute a grid sweep using the configured ``steps`` per group."""
+    @Slot(bool)
+    def runGrid(self, force: bool = False) -> None:
+        """Execute a grid sweep using the configured ``steps`` per group.
+
+        Parameters
+        ----------
+        force:
+            When ``True`` re-evaluate configurations even if present in the
+            run index.
+        """
 
         self._mgr = DOEQueueManager(
             self._base, self._gates, self._fitness, client=self._client
         )
-        self._mgr.enqueue_grid(self._groups, self._steps)
+        self._mgr.enqueue_grid(self._groups, self._steps, force=force)
         self._start_time = time.time()
         self._update_progress()
         if self._client is None:


### PR DESCRIPTION
## Summary
- add persistent run index at `experiments/runs/index.json`
- compute deterministic run keys and skip duplicate enqueue unless forced
- allow GA and sweep batches to resume from recorded runs
- expose `--force` flags so DOE sweeps and GA runs can re-evaluate cached configurations

## Testing
- `python -m black experiments/ga.py tests/experiments/test_ga.py`
- `python -m compileall Causal_Web experiments tests/experiments/test_ga.py`
- `pytest` *(fails: ImportError: libGL.so.1)*
- `pytest tests/experiments/test_queue_manager.py tests/experiments/test_ga.py tests/experiments/test_doe_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc8298c88325960320cd33347222