### PR TITLE
Skip GUI-dependent tests when PySide6 is unavailable

### DIFF
--- a/tests/experiments/test_doe_model.py
+++ b/tests/experiments/test_doe_model.py
@@ -1,8 +1,10 @@
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 
+pytest.importorskip("PySide6")
 from ui_new.state.DOE import DOEModel
 
 

--- a/tests/test_experiment_model.py
+++ b/tests/test_experiment_model.py
@@ -1,5 +1,7 @@
 import asyncio
+import pytest
 
+pytest.importorskip("PySide6")
 from ui_new.state.Experiment import ExperimentModel
 
 

--- a/tests/test_graph_view_instancing.py
+++ b/tests/test_graph_view_instancing.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 
+pytest.importorskip("PySide6.QtGui")
+pytest.importorskip("PySide6.QtQuick")
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PySide6.QtGui import QGuiApplication

--- a/tests/test_telemetry_model.py
+++ b/tests/test_telemetry_model.py
@@ -1,3 +1,6 @@
+import pytest
+
+pytest.importorskip("PySide6")
 from ui_new.state.Telemetry import TelemetryModel
 
 


### PR DESCRIPTION
## Summary
- Skip GUI-oriented tests when `PySide6` (and thus `libGL`) isn't available

## Testing
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pip install -r requirements.txt`
- `pytest` *(fails: tests/experiments/test_ga.py::test_ga_artifacts_link_runs, tests/test_engine_adapter_api.py::test_step_returns_telemetry_frame, tests/test_soak_memory.py::test_soak_memory_growth_under_threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68a75cac7334832581671d8d593a67df