### PR TITLE
Remove DeltaReady and document push SnapshotDelta streaming

### DIFF
--- a/ui_new/core.py
+++ b/ui_new/core.py
@@ -67,14 +67,6 @@ async def run(
                 flags = static.get("node_flags")
                 view.set_graph(nodes, edges, labels, colors, flags)
                 telemetry.update_counts(len(nodes), len(edges))
-                await client.send({"cmd": "pull"})
-                continue
-
-            if mtype == "DeltaReady":
-                await asyncio.sleep(1 / 60)
-                await client.drop_pending("DeltaReady")
-                await client.drop_pending("SnapshotDelta")
-                await client.send({"cmd": "pull"})
                 continue
             if mtype == "SnapshotDelta":
                 delta = {k: v for k, v in msg.items() if k not in {"type", "v"}}


### PR DESCRIPTION
## Summary
- drop `DeltaReady` handling in the Qt client and rely on pushed `SnapshotDelta` frames
- clarify session-token handshake and push-based stream in Architecture & IPC docs

## Testing
- `pip install -r requirements.txt`
- `black Causal_Web cw ui_new`
- `python -m compileall Causal_Web cw ui_new`
- `pytest` *(fails: tests/test_engine_adapter_api.py::test_step_returns_telemetry_frame, tests/test_soak_memory.py::test_soak_memory_growth_under_threshold)*
- `python -m Causal_Web.main` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `python bundle_run.py`

## Notes
- No outstanding items from request.


------
https://chatgpt.com/codex/tasks/task_e_68a764badca88325bbc478a78dd89788