### PR TITLE
Add GUI bundle spec and smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,22 @@ jobs:
       - name: Run tests
         run: pytest
 
+  gui-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-gui.txt
+      - name: Run GUI smoke test
+        env:
+          CW_GUI_SMOKE: '1'
+        run: pytest tests/test_gui_smoke.py
+
   golden-replay:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -188,12 +188,26 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 
 ## Quick Start
 ```bash
-pip install -r requirements.txt
-cw run             # GUI
-cw run --no-gui    # headless
-cw sweep --lhs ... # DOE
-cw ga --config ... # GA
+pip install -r requirements-gui.txt
+pyinstaller cw_gui.spec   # build bundle
+./dist/cw_gui/cw_gui      # run GUI bundle
+cw run --no-gui           # headless
+cw sweep --lhs ...        # DOE
+cw ga --config ...        # GA
 ```
+
+### cw gui bundles
+
+Use the provided `cw_gui.spec` with PyInstaller to create a standalone GUI
+application:
+
+```bash
+pip install -r requirements-gui.txt
+pyinstaller cw_gui.spec
+```
+
+The bundle will be written to `dist/cw_gui/` and contains an executable that
+launches the engine and Qt Quick interface.
 
 ## Troubleshooting
 - **Disconnected** → token mismatch or single-client limit.

--- a/cw_gui.spec
+++ b/cw_gui.spec
@@ -1,0 +1,46 @@
+# PyInstaller spec for bundling the Causal Web GUI
+block_cipher = None
+
+
+a = Analysis(
+    ['Causal_Web/main.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[('ui_new', 'ui_new')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='cw_gui',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    console=False,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='cw_gui',
+)

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pyinstaller

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -1,0 +1,93 @@
+import os
+import asyncio
+import threading
+import time
+
+import pytest
+
+
+@pytest.mark.skipif(not os.getenv("CW_GUI_SMOKE"), reason="CW_GUI_SMOKE not set")
+def test_engine_gui_smoke():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    from PySide6.QtGui import QGuiApplication
+    from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+    from Causal_Web.engine.stream.server import DeltaBus, serve
+    from ui_new import core
+    from ui_new.state import (
+        Store,
+        TelemetryModel,
+        MetersModel,
+        ExperimentModel,
+        ReplayModel,
+        LogsModel,
+        DOEModel,
+        GAModel,
+        CompareModel,
+    )
+
+    app = QGuiApplication([])
+
+    adapter = EngineAdapter()
+    graph = {"params": {"W0": 2}, "nodes": [{"id": "0", "rho_mean": 0.0}], "edges": []}
+    adapter.build_graph(graph)
+
+    bus = DeltaBus()
+    bus.put({"frame": 0})
+
+    loop = asyncio.new_event_loop()
+
+    def run_loop() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    thread = threading.Thread(target=run_loop, daemon=True)
+    thread.start()
+
+    server_future = asyncio.run_coroutine_threadsafe(serve(bus, adapter), loop)
+
+    telemetry = TelemetryModel()
+    meters = MetersModel()
+    experiment = ExperimentModel()
+    replay = ReplayModel()
+    logs = LogsModel()
+    store = Store()
+    doe = DOEModel()
+    ga = GAModel()
+    compare = CompareModel()
+
+    class View:
+        def set_graph(self, *args, **kwargs):
+            pass
+
+        def apply_delta(self, *args, **kwargs):
+            pass
+
+    class Window:
+        controlsEnabled = False
+
+    gui_future = asyncio.run_coroutine_threadsafe(
+        core.run(
+            "ws://127.0.0.1:8765",
+            View(),
+            telemetry,
+            experiment,
+            replay,
+            logs,
+            store,
+            doe,
+            ga,
+            Window(),
+            token=None,
+        ),
+        loop,
+    )
+
+    time.sleep(0.5)
+    assert "nodes" in store.graph_static, "Did not receive graph data"
+
+    gui_future.cancel()
+    server_future.cancel()
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=1)
+    app.quit()


### PR DESCRIPTION
## Summary
- add `cw_gui.spec` and `requirements-gui.txt` for building platform bundles
- document GUI bundling and updated quick start instructions
- add optional GUI smoke test and enable it in CI

## Testing
- `python -m black Causal_Web cw tests/test_gui_smoke.py`
- `python -m compileall Causal_Web cw`
- `pip install -r requirements.txt`
- `pip install -r requirements-gui.txt`
- `pytest` *(fails: tests/test_soak_memory.py::test_soak_memory_growth_under_threshold)*
- `CW_GUI_SMOKE=1 pytest tests/test_gui_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7934ba9188325ada8e6ce599251fa