### PR TITLE
Add GUI apply_delta smoke benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
           pip install -r requirements.txt
       - name: Run engine benchmark
         run: |
-          python bench/engine_bench.py --output engine_bench.json
+          PYTHONPATH=. python bench/engine_bench.py --output engine_bench.json
       - name: Compare to baseline
         id: compare
         run: |
@@ -86,7 +86,23 @@ PY
         env:
           QT_QPA_PLATFORM: offscreen
         run: |
-          xvfb-run -s "-screen 0 1024x768x24" python bench/gui_bench.py --output gui_bench.json
+          PYTHONPATH=. xvfb-run -s "-screen 0 1024x768x24" python bench/gui_bench.py --output gui_bench.json
+      - name: Run GUI apply_delta smoke
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          PYTHONPATH=. xvfb-run -s "-screen 0 1024x768x24" python bench/gui_smoke.py --output gui_smoke.json
+      - name: Check apply_delta threshold
+        run: |
+          python - <<'PY'
+import json, pathlib, sys
+data = json.loads(pathlib.Path('gui_smoke.json').read_text())
+ms = data['apply_delta_ms']
+print(f"apply_delta {ms:.2f} ms")
+if ms > 10.0:
+    print('::error::apply_delta exceeds 10ms')
+    sys.exit(1)
+PY
       - name: Compare to baseline
         id: compare
         run: |
@@ -135,3 +151,8 @@ PY
         with:
           name: gui-bench
           path: gui_bench.json
+      - name: Upload GUI smoke artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: gui-smoke
+          path: gui_smoke.json

--- a/README.md
+++ b/README.md
@@ -460,7 +460,9 @@ delivery avoids redundant exponentials.
 `bench/engine_bench.py` measures engine step throughput while
 `bench/gui_bench.py` records GUI frame rate using an offscreen Qt
 renderer. Both benchmarks run nightly in CI, comparing results against
-checked-in baselines and uploading JSON artifacts. Regressions greater than
+checked-in baselines and uploading JSON artifacts. A lightweight
+`bench/gui_smoke.py` also runs offscreen, timing a 5k node
+``GraphView.apply_delta`` call and failing if it exceeds 10 ms. Regressions greater than
 5% generate workflow warnings while slowdowns beyond 10% fail the job. Any
 regression over 5% also opens a GitHub issue so maintainers receive external
 notifications. Both benchmarks record basic hardware metadata for reproducibility. Manual

--- a/bench/gui_smoke.py
+++ b/bench/gui_smoke.py
@@ -1,0 +1,62 @@
+"""Lightweight GUI apply_delta performance smoke test."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+from PySide6.QtGui import QGuiApplication
+
+from ui_new.graph.GraphView import GraphView
+from machine import machine_info
+
+
+def _sample_graph(
+    n_nodes: int,
+) -> tuple[list[tuple[float, float]], list[tuple[int, int]]]:
+    """Return simple cyclic graph of ``n_nodes`` positions and edges."""
+
+    nodes = [(float(i), 0.0) for i in range(n_nodes)]
+    edges = [(i, (i + 1) % n_nodes) for i in range(n_nodes)]
+    return nodes, edges
+
+
+def bench_apply_delta(n_nodes: int = 5000) -> dict[str, float | int]:
+    """Measure time to apply a delta update for ``n_nodes`` nodes."""
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QGuiApplication.instance() or QGuiApplication([])
+    view = GraphView()
+    nodes, edges = _sample_graph(n_nodes)
+    view.set_graph(nodes, edges)
+    delta = {"node_positions": {i: (x + 1.0, 0.0) for i, (x, _) in enumerate(nodes)}}
+    # Warm up and measure multiple times, keeping the fastest sample.
+    timings = []
+    for _ in range(3):
+        t0 = time.perf_counter()
+        view.apply_delta(delta)
+        t1 = time.perf_counter()
+        timings.append((t1 - t0) * 1000.0)
+    app.quit()
+    return {"nodes": n_nodes, "apply_delta_ms": min(timings)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--nodes", type=int, default=5000)
+    parser.add_argument(
+        "--output", type=Path, help="Optional path to write JSON results."
+    )
+    args = parser.parse_args()
+    result = bench_apply_delta(args.nodes)
+    result["machine"] = machine_info()
+    if args.output:
+        args.output.write_text(json.dumps(result))
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add bench/gui_smoke.py to time GraphView.apply_delta on 5k nodes
- run GUI apply_delta smoke and engine micro-bench in nightly workflow with JSON artifacts
- document lightweight GUI smoke in README

## Testing
- `python -m compileall Causal_Web cw`
- `pytest` *(fails: tests/test_soak_memory.py::test_soak_memory_growth_under_threshold)*


------
https://chatgpt.com/codex/tasks/task_e_68a79ba8fc888325861c75c935e2080c