### PR TITLE
Normalize and persist multi-objective GA state

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Added a lightweight Genetic Algorithm framework with tournament selection, uniform crossover, Gaussian mutation and elitism along with a GA panel showing a live population table with objectives and per-constraint flags, fitness-history and Pareto-front charts, and promote/export actions.
 - Introduced scalar fitness helpers with hard invariant guardrails and normalised terms, providing a clear objective for optimisation and a path toward multi-objective Pareto support.
 - Added NSGA-II-lite multi-objective capabilities with non-dominated sorting, crowding-distance selection, a persistent Pareto archive and UI promotion of chosen trade-offs.
+- Multi-objective runs now normalise objectives per generation using running median±MAD baselines, exclude infeasible genomes before sorting, cap the Pareto archive via ε-dominance or crowding-distance pruning, and checkpoint RNG state and population for deterministic restarts.
 - GA panel now offers a multi-objective toggle, Pareto scatter with selectable objectives, descriptive axis labels, and a table showing rank and crowding distance with a promotion dialog.
 - DOE and GA batches now persist summaries under ``experiments/``:
   - ``top_k.json`` records the best runs and is consumed by the Top-K UI table.


### PR DESCRIPTION
## Summary
- Normalize objectives each generation using running median and MAD baselines
- Exclude infeasible genomes from Pareto sorting and persist archive/checkpoint state
- Document GA improvements and add test for infeasible filtering
- Introduce optional ε-dominance pruning for the Pareto archive and persist its configuration

## Testing
- `pip install -r requirements.txt`
- `python -m black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `python -m Causal_Web.main --help`
- `pytest` *(fails: tests/test_engine_adapter_api.py::test_step_returns_telemetry_frame, tests/test_soak_memory.py::test_soak_memory_growth_under_threshold)*
- `pytest tests/test_engine_adapter_api.py::test_step_returns_telemetry_frame`
- `pytest tests/test_soak_memory.py::test_soak_memory_growth_under_threshold`

## Notes
- None


------
https://chatgpt.com/codex/tasks/task_e_68a7aaf7c1488325a1b33804d50f75ee