### PR TITLE
Enforce controller/spectator roles on WebSocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ SnapshotDelta = {
 
 The engine prints a random session token at startup. Clients must begin with a
 `Hello` message carrying this token; the server closes connections that omit or
-mismatch it. A single client is accepted by default; set
-`CW_ALLOW_MULTI=1` to allow additional read-only spectator clients. Only the
-first connection retains control. Float32 fields keep payloads lean.
+mismatch it. The first client to complete this handshake becomes the controller.
+Set `CW_ALLOW_MULTI=1` to permit additional spectators. Spectators receive
+read-only updates and any control commands they send are rejected. They may
+issue a request for control which the current controller can grant without
+restarting. Role changes are broadcast so UIs can display a small
+"Controller"/"Spectator" badge. Float32 fields keep payloads lean.
 
 ## Compare panel
 

--- a/ui_new/main.qml
+++ b/ui_new/main.qml
@@ -11,6 +11,8 @@ Window {
     property bool editMode: true
     property string tool: "select"
     property bool controlsEnabled: false
+    property string role: "spectator"
+    property bool controlRequested: false
     width: 800
     height: 600
     visible: true
@@ -126,6 +128,33 @@ Window {
               (telemetryModel.counters["events_per_sec"] ? telemetryModel.counters["events_per_sec"][telemetryModel.counters["events_per_sec"].length - 1].toFixed(1) : 0) +
               " residual: " + experimentModel.residual.toFixed(3)
         z: 10
+    }
+
+    Text {
+        id: roleBadge
+        anchors.right: parent.right
+        anchors.top: parent.top
+        color: "white"
+        text: root.role === "controller" ? "Controller" : "Spectator"
+        z: 10
+    }
+
+    Button {
+        id: requestButton
+        text: "Request control"
+        anchors.right: parent.right
+        anchors.top: roleBadge.bottom
+        visible: root.role === "spectator"
+        onClicked: root.requestControl()
+    }
+
+    Button {
+        id: transferButton
+        text: root.controlRequested ? "Grant control" : "Transfer control"
+        anchors.right: parent.right
+        anchors.top: roleBadge.bottom
+        visible: root.role === "controller"
+        onClicked: root.transferControl()
     }
 
     Item {


### PR DESCRIPTION
## Summary
- designate first handshake as controller and gate subsequent connections to spectator mode
- broadcast role changes to clients and surface a controller/spectator HUD badge
- reject control commands from spectator connections
- allow spectators to request control and controllers to transfer it without restarting

## Testing
- `black Causal_Web cw ui_new/core.py`
- `python -m compileall Causal_Web cw ui_new`
- `pip install -r requirements.txt`
- `pytest`
- `QT_QPA_PLATFORM=offscreen python -m Causal_Web.main` *(fails: libGL.so.1: cannot open shared object file)*
- `python bundle_run.py`

## Notes
- no outstanding spectator/controller features remain


------
https://chatgpt.com/codex/tasks/task_e_68a88c51dfa08325a30b07f0d59fa185