### PR TITLE
feat: add results panel query with replay filters

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -269,6 +269,7 @@ class MainService:
             GAModel,
             MCTSModel,
             CompareModel,
+            ResultsModel,
         )
         from ui_new.graph import GraphView  # noqa: F401  # register QML module
 
@@ -284,6 +285,7 @@ class MainService:
         ga_model = GAModel()
         mcts_model = MCTSModel()
         compare = CompareModel()
+        results = ResultsModel()
         ctx = engine.rootContext()
         ctx.setContextProperty("telemetryModel", telemetry)
         ctx.setContextProperty("metersModel", meters)
@@ -295,6 +297,7 @@ class MainService:
         ctx.setContextProperty("gaModel", ga_model)
         ctx.setContextProperty("mctsModel", mcts_model)
         ctx.setContextProperty("compareModel", compare)
+        ctx.setContextProperty("resultsModel", results)
         qml_path = os.path.join(os.path.dirname(__file__), "..", "ui_new", "main.qml")
         engine.load(qml_path)
         if not engine.rootObjects():

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ via a Monte-Carlo path sampler over the graph's causal structure.
   - ``hall_of_fame.json`` archives per-generation GA champions.
   - ``best_config.yaml`` captures the promoted configuration for quick reuse.
   - run directories under ``experiments/runs/<date>/<id>/`` hold per-run ``config.json``, ``result.json`` and ``delta_log.jsonl`` for replay.
+- a lightweight SQLite results registry at ``experiments/results.db`` tracks run metadata and MCTS statistics (nodes expanded, promotions, bins, frontier and parameters) for fast ad-hoc queries.
+- a "Results" panel surfaces these runs with optimizer, promotion-rate and proxy↔full correlation filters and supports click-to-replay.
 - GA evaluation can dispatch genomes to the engine via IPC, with engine-side handling of ``ExperimentControl`` messages for ``run`` requests.
 - GA panel evaluations now use the shared IPC loop so genomes are executed on the engine during interactive runs.
 - GA runs can be checkpointed and later resumed from disk—including any in-flight evaluations—to support reproducible interrupted searches.

--- a/experiments/results_registry.py
+++ b/experiments/results_registry.py
@@ -1,0 +1,124 @@
+"""Local results registry backed by SQLite.
+
+This module offers a lightweight interface for storing and querying
+experiment results.  The registry keeps generic run metadata alongside
+optional internal statistics emitted by the MCTS-H optimizer.  Results
+are stored in a single SQLite database so thousands of runs can be mined
+quickly without scanning individual JSON files.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Optional
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS results (
+    run_id TEXT PRIMARY KEY,
+    optimizer TEXT,
+    promotion_rate REAL,
+    residual REAL,
+    proxy_full_corr REAL,
+    mcts_nodes_expanded INTEGER,
+    mcts_promotions INTEGER,
+    mcts_bins_created INTEGER,
+    mcts_frontier INTEGER,
+    mcts_params TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_results_optimizer ON results (optimizer);
+CREATE INDEX IF NOT EXISTS idx_results_promotion ON results (promotion_rate);
+CREATE INDEX IF NOT EXISTS idx_results_residual ON results (residual);
+"""
+
+
+# ---------------------------------------------------------------------------
+
+
+def connect(path: Path) -> sqlite3.Connection:
+    """Return a connection to ``path`` initialising the schema if required."""
+
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.executescript(SCHEMA)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+
+
+def insert(
+    conn: sqlite3.Connection,
+    run_id: str,
+    optimizer: str,
+    promotion_rate: float,
+    residual: float,
+    proxy_full_corr: float,
+    *,
+    mcts_nodes_expanded: int = 0,
+    mcts_promotions: int = 0,
+    mcts_bins_created: int = 0,
+    mcts_frontier: int = 0,
+    mcts_params: Optional[dict[str, Any]] = None,
+) -> None:
+    """Insert a run result into the registry."""
+
+    data = {
+        "run_id": run_id,
+        "optimizer": optimizer,
+        "promotion_rate": float(promotion_rate),
+        "residual": float(residual),
+        "proxy_full_corr": float(proxy_full_corr),
+        "mcts_nodes_expanded": int(mcts_nodes_expanded),
+        "mcts_promotions": int(mcts_promotions),
+        "mcts_bins_created": int(mcts_bins_created),
+        "mcts_frontier": int(mcts_frontier),
+        "mcts_params": json.dumps(mcts_params or {}),
+    }
+    cols = ",".join(data.keys())
+    placeholders = ":" + ",:".join(data.keys())
+    conn.execute(
+        f"INSERT OR REPLACE INTO results ({cols}) VALUES ({placeholders})", data
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+
+
+def query(
+    conn: sqlite3.Connection,
+    *,
+    optimizer: Optional[str] = None,
+    promotion_min: Optional[float] = None,
+    promotion_max: Optional[float] = None,
+    residual_max: Optional[float] = None,
+    proxy_full_corr_min: Optional[float] = None,
+) -> list[sqlite3.Row]:
+    """Return rows matching the supplied filters."""
+
+    clauses: list[str] = []
+    params: list[Any] = []
+    if optimizer:
+        clauses.append("optimizer = ?")
+        params.append(optimizer)
+    if promotion_min is not None:
+        clauses.append("promotion_rate >= ?")
+        params.append(float(promotion_min))
+    if promotion_max is not None:
+        clauses.append("promotion_rate <= ?")
+        params.append(float(promotion_max))
+    if residual_max is not None:
+        clauses.append("residual < ?")
+        params.append(float(residual_max))
+    if proxy_full_corr_min is not None:
+        clauses.append("proxy_full_corr >= ?")
+        params.append(float(proxy_full_corr_min))
+    where = " WHERE " + " AND ".join(clauses) if clauses else ""
+    q = f"SELECT * FROM results{where}"
+    conn.row_factory = sqlite3.Row
+    return list(conn.execute(q, params))
+
+
+__all__ = ["connect", "insert", "query"]

--- a/tests/test_results_registry.py
+++ b/tests/test_results_registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from experiments import results_registry as rr
+
+
+def test_query_filters(tmp_path: Path) -> None:
+    db = tmp_path / "results.db"
+    conn = rr.connect(db)
+    rr.insert(
+        conn,
+        run_id="run1",
+        optimizer="mcts_h",
+        promotion_rate=0.5,
+        residual=0.01,
+        proxy_full_corr=0.9,
+        mcts_nodes_expanded=10,
+        mcts_promotions=2,
+        mcts_bins_created=3,
+        mcts_frontier=4,
+        mcts_params={"c_ucb": 1.0},
+    )
+    rr.insert(
+        conn,
+        run_id="run2",
+        optimizer="other",
+        promotion_rate=0.1,
+        residual=0.05,
+        proxy_full_corr=0.1,
+    )
+    t0 = time.perf_counter()
+    rows = rr.query(
+        conn,
+        optimizer="mcts_h",
+        promotion_min=0.3,
+        residual_max=0.02,
+        proxy_full_corr_min=0.5,
+    )
+    elapsed = time.perf_counter() - t0
+    assert len(rows) == 1
+    assert rows[0]["run_id"] == "run1"
+    # expect query to complete quickly (<0.2s)
+    assert elapsed < 0.2

--- a/ui_new/main.qml
+++ b/ui_new/main.qml
@@ -173,6 +173,7 @@ Window {
             TabButton { text: "Meters" }
             TabButton { text: "Experiment" }
             TabButton { text: "Replay" }
+            TabButton { text: "Results" }
             TabButton { text: "Logs" }
             TabButton { text: "Inspector" }
             TabButton { text: "Validation" }
@@ -194,11 +195,12 @@ Window {
             Meters { anchors.fill: parent }
             Experiment { anchors.fill: parent; graphView: graphView }
             Replay { anchors.fill: parent }
+            Results { anchors.fill: parent }
             LogExplorer { anchors.fill: parent }
             Inspector { anchors.fill: parent }
             Validation { anchors.fill: parent }
-            DOE { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 10 }
-            GA { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 10 }
+            DOE { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 11 }
+            GA { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 11 }
             MCTS { anchors.fill: parent; panels: panels; replayIndex: 3 }
             Compare { anchors.fill: parent }
         }

--- a/ui_new/panels/Results.qml
+++ b/ui_new/panels/Results.qml
@@ -1,0 +1,68 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    color: "#202020"
+    anchors.fill: parent
+
+    Column {
+        anchors.margins: 8
+        anchors.fill: parent
+        spacing: 4
+        Text { text: "Results"; color: "white" }
+        Row {
+            spacing: 4
+            Text { text: "Optimizer"; color: "white" }
+            ComboBox {
+                id: optBox
+                model: ["", "mcts_h"]
+                currentIndex: 1
+                onActivated: resultsModel.optimizer = optBox.currentText
+            }
+        }
+        Row {
+            spacing: 4
+            Text { text: "Promotion"; color: "white" }
+            Slider {
+                id: promoSlider
+                width: 120
+                from: 0
+                to: 1
+                value: resultsModel.promotionMin
+                onValueChanged: resultsModel.promotionMin = value
+            }
+        }
+        Row {
+            spacing: 4
+            Text { text: "Corr"; color: "white" }
+            Slider {
+                id: corrSlider
+                width: 120
+                from: 0
+                to: 1
+                value: resultsModel.proxyFullCorrMin
+                onValueChanged: resultsModel.proxyFullCorrMin = value
+            }
+        }
+        Button { text: "Refresh"; onClicked: resultsModel.refresh() }
+        ListView {
+            anchors.fill: parent
+            model: resultsModel.rows
+            delegate: Rectangle {
+                width: parent.width
+                height: 24
+                color: index % 2 === 0 ? "#202020" : "#303030"
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: "white"
+                    text: model.run_id + " | " + model.promotion_rate.toFixed(2) + " | " + model.residual.toFixed(3)
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: resultsModel.openReplay(model.run_id)
+                }
+            }
+        }
+        Component.onCompleted: resultsModel.refresh()
+    }
+}

--- a/ui_new/state/Results.py
+++ b/ui_new/state/Results.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Expose results registry queries to QML panels."""
+
+import asyncio
+from pathlib import Path
+from typing import List, Dict, Any
+
+from PySide6.QtCore import QObject, Property, Signal, Slot
+
+from experiments import results_registry as rr
+from .Replay import open_replay
+
+
+class ResultsModel(QObject):
+    """Filter and retrieve experiment results for display."""
+
+    rowsChanged = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        db_path = Path("experiments/results.db")
+        self._conn = rr.connect(db_path)
+        self._optimizer = "mcts_h"
+        self._promotion = 0.0
+        self._corr = 0.0
+        self._rows: List[Dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    def _get_optimizer(self) -> str:
+        return self._optimizer
+
+    def _set_optimizer(self, val: str) -> None:
+        self._optimizer = val
+        self.refresh()
+
+    optimizer = Property(str, _get_optimizer, _set_optimizer)
+
+    def _get_promotion(self) -> float:
+        return self._promotion
+
+    def _set_promotion(self, val: float) -> None:
+        self._promotion = float(val)
+        self.refresh()
+
+    promotionMin = Property(float, _get_promotion, _set_promotion)
+
+    def _get_corr(self) -> float:
+        return self._corr
+
+    def _set_corr(self, val: float) -> None:
+        self._corr = float(val)
+        self.refresh()
+
+    proxyFullCorrMin = Property(float, _get_corr, _set_corr)
+
+    def _get_rows(self) -> List[Dict[str, Any]]:
+        return self._rows
+
+    rows = Property("QVariant", _get_rows, notify=rowsChanged)
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def refresh(self) -> None:
+        """Query the registry with current filters."""
+
+        rows = rr.query(
+            self._conn,
+            optimizer=self._optimizer or None,
+            promotion_min=self._promotion,
+            proxy_full_corr_min=self._corr,
+        )
+        self._rows = [dict(r) for r in rows]
+        self.rowsChanged.emit()
+
+    # ------------------------------------------------------------------
+    @Slot(str)
+    def openReplay(self, run_id: str) -> None:
+        """Load ``run_id`` into the Replay panel and start playback."""
+
+        asyncio.create_task(open_replay(run_id))

--- a/ui_new/state/__init__.py
+++ b/ui_new/state/__init__.py
@@ -10,6 +10,7 @@ from .DOE import DOEModel
 from .GA import GAModel
 from .Compare import CompareModel
 from .MCTS import MCTSModel
+from .Results import ResultsModel
 
 __all__ = [
     "Store",
@@ -22,4 +23,5 @@ __all__ = [
     "GAModel",
     "MCTSModel",
     "CompareModel",
+    "ResultsModel",
 ]


### PR DESCRIPTION
## Summary
- hook ResultsModel into the GUI and expose it via a new Results panel
- allow filtering by optimizer, promotion rate and proxy↔full correlation with row click-to-replay
- extend registry tests to cover correlation filtering

## Testing
- `black Causal_Web cw ui_new/state/Results.py ui_new/state/__init__.py tests/test_results_registry.py`
- `python -m compileall Causal_Web cw ui_new/state/Results.py ui_new/state/__init__.py tests/test_results_registry.py experiments/results_registry.py`
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a500414c83258225602a5428d31e