### PR TITLE
Add MCTS-C policy planner and Policy UI panel

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -268,6 +268,7 @@ class MainService:
             DOEModel,
             GAModel,
             MCTSModel,
+            PolicyModel,
             CompareModel,
             ResultsModel,
         )
@@ -284,6 +285,7 @@ class MainService:
         doe = DOEModel()
         ga_model = GAModel()
         mcts_model = MCTSModel()
+        policy_model = PolicyModel()
         compare = CompareModel()
         results = ResultsModel()
         ctx = engine.rootContext()
@@ -296,6 +298,7 @@ class MainService:
         ctx.setContextProperty("doeModel", doe)
         ctx.setContextProperty("gaModel", ga_model)
         ctx.setContextProperty("mctsModel", mcts_model)
+        ctx.setContextProperty("policyModel", policy_model)
         ctx.setContextProperty("compareModel", compare)
         ctx.setContextProperty("resultsModel", results)
         qml_path = os.path.join(os.path.dirname(__file__), "..", "ui_new", "main.qml")
@@ -326,6 +329,7 @@ class MainService:
                 doe,
                 ga_model,
                 mcts_model,
+                policy_model,
                 root,
                 token=token,
             ),

--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ via a Monte-Carlo path sampler over the graph's causal structure.
   past wins and evaluation rates, and writes per-task and aggregate reports
   to ``bench/optim``.
 - The Qt Quick interface now exposes an ``MCTS`` tab so tree search runs alongside existing DOE and GA panels.
+- A new ``Policy`` tab hosts an MCTS-C planner over safe engine toggles,
+  supports horizons of 2–5 windows with ``γ≈0.95`` and renders icon
+  overlays of the planned action sequence along the timeline. Planned
+  actions can now be dispatched to the running engine, which adjusts its
+  internal toggles rather than mutating the residual directly.
 - The DOE, GA, and MCTS tabs report live node and frontier counts and expansion/promotion gauges during a search.
 - Users can adjust proxy/full frame budgets, promotion thresholds or
   quantiles, and prior bin counts directly in the MCTS panel for

--- a/experiments/__init__.py
+++ b/experiments/__init__.py
@@ -3,6 +3,7 @@
 from .queue import DOEQueueManager, OptimizerQueueManager
 from .ga import GeneticAlgorithm
 from .optim import MCTS_H, build_priors
+from .policy import MCTS_C, ACTION_SET
 from .artifacts import (
     TopKEntry,
     update_top_k,
@@ -19,7 +20,9 @@ __all__ = [
     "OptimizerQueueManager",
     "GeneticAlgorithm",
     "MCTS_H",
+    "MCTS_C",
     "build_priors",
+    "ACTION_SET",
     "TopKEntry",
     "update_top_k",
     "load_top_k",

--- a/experiments/policy/__init__.py
+++ b/experiments/policy/__init__.py
@@ -1,0 +1,23 @@
+"""Policy planning utilities."""
+
+from .actions import (
+    ACTION_ICONS,
+    ACTION_SET,
+    Action,
+    boost_eps_emit,
+    clamp_Wmax,
+    flip_MI_mode,
+    toggle_theta_reset,
+)
+from .mcts_c import MCTS_C
+
+__all__ = [
+    "ACTION_SET",
+    "ACTION_ICONS",
+    "Action",
+    "MCTS_C",
+    "toggle_theta_reset",
+    "boost_eps_emit",
+    "clamp_Wmax",
+    "flip_MI_mode",
+]

--- a/experiments/policy/actions.py
+++ b/experiments/policy/actions.py
@@ -1,0 +1,71 @@
+"""Discrete engine intervention actions for policy planning.
+
+Each action mutates simple engine flags instead of touching the residual
+directly. The engine is then responsible for recomputing the residual based
+on the updated state.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Protocol
+
+
+class Env(Protocol):
+    """Minimal environment protocol for policy actions."""
+
+    theta_reset: bool
+    eps_emit: float
+    Wmax: float
+    MI_mode: bool
+
+
+Action = Callable[[Env], None]
+
+
+def toggle_theta_reset(env: Env) -> None:
+    """Toggle the ``theta_reset`` flag."""
+
+    env.theta_reset = not env.theta_reset
+
+
+def boost_eps_emit(env: Env) -> None:
+    """Increase the ``eps_emit`` boost by one unit."""
+
+    env.eps_emit += 1.0
+
+
+def clamp_Wmax(env: Env) -> None:
+    """Reduce the ``Wmax`` limit by two units."""
+
+    env.Wmax = max(env.Wmax - 2.0, 0.0)
+
+
+def flip_MI_mode(env: Env) -> None:
+    """Toggle the adversarial ``MI_mode`` flag."""
+
+    env.MI_mode = not env.MI_mode
+
+
+ACTION_SET: dict[str, Action] = {
+    "toggle_theta_reset": toggle_theta_reset,
+    "boost_eps_emit": boost_eps_emit,
+    "clamp_Wmax": clamp_Wmax,
+    "flip_MI_mode": flip_MI_mode,
+}
+
+# Simplified visual identifiers for timeline overlays.
+ACTION_ICONS: dict[str, str] = {
+    "toggle_theta_reset": "θ",
+    "boost_eps_emit": "ε",
+    "clamp_Wmax": "W",
+    "flip_MI_mode": "MI",
+}
+
+__all__ = [
+    "ACTION_SET",
+    "ACTION_ICONS",
+    "toggle_theta_reset",
+    "boost_eps_emit",
+    "clamp_Wmax",
+    "flip_MI_mode",
+]

--- a/experiments/policy/mcts_c.py
+++ b/experiments/policy/mcts_c.py
@@ -1,0 +1,124 @@
+"""Receding-horizon policy planner using Monte Carlo Tree Search."""
+
+from __future__ import annotations
+
+import copy
+import math
+import random
+from dataclasses import dataclass, field
+from typing import List, Sequence
+
+from .actions import ACTION_SET, Action
+
+
+@dataclass
+class Node:
+    """Tree node holding state statistics."""
+
+    state: object
+    depth: int
+    parent: "Node | None" = None
+    action: Action | None = None
+    value: float = 0.0
+    visits: int = 0
+    children: dict[str, "Node"] = field(default_factory=dict)
+
+
+class MCTS_C:
+    """Plan sequences of interventions with progressive widening."""
+
+    def __init__(
+        self,
+        actions: Sequence[Action] | None = None,
+        horizon: int = 2,
+        gamma: float = 0.95,
+        iterations: int = 100,
+        c_ucb: float = 1.0,
+        alpha_pw: float = 0.5,
+        k_pw: float = 1.0,
+    ) -> None:
+        self.actions = (
+            list(actions) if actions is not None else list(ACTION_SET.values())
+        )
+        self.horizon = max(2, min(5, horizon))
+        self.gamma = gamma
+        self.iterations = iterations
+        self.c_ucb = c_ucb
+        self.alpha_pw = alpha_pw
+        self.k_pw = k_pw
+
+    # ------------------------------------------------------------------
+    def plan(self, env: object) -> List[Action]:
+        """Run a tree search from ``env`` and return an action sequence."""
+
+        root = Node(copy.deepcopy(env), depth=0)
+        for _ in range(self.iterations):
+            leaf, state = self._select(root)
+            reward = self._rollout(state, leaf.depth)
+            self._backpropagate(leaf, reward)
+        return self._best_plan(root)
+
+    # ------------------------------------------------------------------
+    def _select(self, node: Node) -> tuple[Node, object]:
+        """Descend the tree applying UCB and progressive widening."""
+
+        state = copy.deepcopy(node.state)
+        while node.depth < self.horizon:
+            limit = max(1, int(self.k_pw * (node.visits**self.alpha_pw)))
+            if len(node.children) < min(limit, len(self.actions)):
+                action = random.choice(
+                    [a for a in self.actions if a.__name__ not in node.children]
+                )
+                new_state = copy.deepcopy(state)
+                action(new_state)
+                child = Node(new_state, node.depth + 1, node, action)
+                node.children[action.__name__] = child
+                return child, new_state
+            if not node.children:
+                break
+            node = max(
+                node.children.values(),
+                key=lambda n: n.value / (n.visits or 1)
+                + self.c_ucb * math.sqrt(math.log(node.visits + 1) / (n.visits + 1)),
+            )
+            state = copy.deepcopy(node.state)
+        return node, state
+
+    # ------------------------------------------------------------------
+    def _rollout(self, env: object, depth: int) -> float:
+        """Sample a trajectory from ``env`` to the planning horizon."""
+
+        total = 0.0
+        discount = 1.0
+        for _ in range(depth, self.horizon):
+            total += discount * (-getattr(env, "residual", 0.0))
+            action = random.choice(self.actions)
+            action(env)
+            discount *= self.gamma
+        return total
+
+    # ------------------------------------------------------------------
+    def _backpropagate(self, node: Node, reward: float) -> None:
+        """Propagate ``reward`` up to the root."""
+
+        while node is not None:
+            node.visits += 1
+            node.value += reward
+            node = node.parent
+            reward *= self.gamma
+
+    # ------------------------------------------------------------------
+    def _best_plan(self, root: Node) -> List[Action]:
+        """Extract the best action sequence from the search tree."""
+
+        plan: List[Action] = []
+        node = root
+        while node.children and len(plan) < self.horizon:
+            node = max(node.children.values(), key=lambda n: n.visits)
+            if node.action is None:
+                break
+            plan.append(node.action)
+        return plan
+
+
+__all__ = ["MCTS_C"]

--- a/tests/engine/test_policy_control.py
+++ b/tests/engine/test_policy_control.py
@@ -1,0 +1,23 @@
+"""Tests for PolicyControl integration with the engine runtime."""
+
+from Causal_Web.engine.engine_v2.adapter import EngineAdapter
+
+
+def test_policy_control_applies_actions() -> None:
+    engine = EngineAdapter()
+    engine.residual = 10.0
+
+    # Single action via "action"
+    engine.handle_control({"PolicyControl": {"action": "toggle_theta_reset"}})
+    assert engine.theta_reset is True
+    status = engine.experiment_status()
+    assert status and status["residual"] == 5.0
+
+    # Multiple actions via "actions"
+    engine.handle_control(
+        {"PolicyControl": {"actions": ["boost_eps_emit", "clamp_Wmax"]}}
+    )
+    assert engine.eps_emit == 1.0
+    assert engine.Wmax == 62.0
+    status = engine.experiment_status()
+    assert status and status["residual"] == 0.0

--- a/tests/experiments/test_mcts_c.py
+++ b/tests/experiments/test_mcts_c.py
@@ -1,0 +1,67 @@
+"""Verify the MCTS-C policy planner outperforms simple baselines."""
+
+import random
+
+from experiments.policy import (
+    MCTS_C,
+    boost_eps_emit,
+    clamp_Wmax,
+    flip_MI_mode,
+    toggle_theta_reset,
+)
+
+
+class ToyEnv:
+    """Minimal environment exposing policy flags and a residual."""
+
+    def __init__(self, base: float = 10.0) -> None:
+        self._base = base
+        self.theta_reset = False
+        self.eps_emit = 0.0
+        self.Wmax = 64.0
+        self.MI_mode = False
+
+    @property
+    def residual(self) -> float:
+        res = self._base
+        if self.theta_reset:
+            res *= 0.5
+        res = max(res - self.eps_emit, 0.0)
+        res = max(res - max(0.0, 64.0 - self.Wmax), 0.0)
+        if self.MI_mode:
+            res += 4.0
+        return res
+
+    def clone(self) -> "ToyEnv":
+        clone = ToyEnv(self._base)
+        clone.theta_reset = self.theta_reset
+        clone.eps_emit = self.eps_emit
+        clone.Wmax = self.Wmax
+        clone.MI_mode = self.MI_mode
+        return clone
+
+
+def _run_plan(env: ToyEnv, plan):
+    for act in plan:
+        act(env)
+    return env.residual
+
+
+def test_mcts_c_beats_baselines() -> None:
+    random.seed(2)
+    actions = [toggle_theta_reset, boost_eps_emit, clamp_Wmax, flip_MI_mode]
+    planner = MCTS_C(actions=actions, horizon=3, iterations=200)
+    env0 = ToyEnv(10.0)
+
+    baseline = _run_plan(env0.clone(), [])
+
+    heur_env = env0.clone()
+    for _ in range(3):
+        clamp_Wmax(heur_env)
+    heuristic = heur_env.residual
+
+    plan = planner.plan(env0.clone())
+    mcts_env = env0.clone()
+    residual = _run_plan(mcts_env, plan)
+
+    assert residual < heuristic < baseline

--- a/tests/ui_new/test_policy_model.py
+++ b/tests/ui_new/test_policy_model.py
@@ -1,0 +1,12 @@
+"""Tests for the PolicyModel icon overlays."""
+
+from ui_new.state.Policy import PolicyModel
+from experiments.policy.actions import ACTION_ICONS
+
+
+def test_plan_icons_align_with_steps() -> None:
+    model = PolicyModel()
+    model.plan()
+    assert len(model.planIcons) == len(model.planSteps)
+    for name, icon in zip(model.planSteps, model.planIcons):
+        assert ACTION_ICONS[name] == icon

--- a/ui_new/core.py
+++ b/ui_new/core.py
@@ -15,6 +15,7 @@ from .state import (
     DOEModel,
     GAModel,
     MCTSModel,
+    PolicyModel,
 )
 
 
@@ -29,6 +30,7 @@ async def run(
     doe: DOEModel,
     ga: GAModel,
     mcts: MCTSModel,
+    policy: PolicyModel,
     window: Any,
     token: str | None = None,
 ) -> None:
@@ -56,6 +58,7 @@ async def run(
     doe.set_client(client)
     ga.set_client(client, loop)
     mcts.set_client(client, loop)
+    policy.set_client(client)
     window.requestControl = lambda: asyncio.create_task(
         client.send({"type": "RequestControl", "v": 1})
     )

--- a/ui_new/main.qml
+++ b/ui_new/main.qml
@@ -157,6 +157,34 @@ Window {
         onClicked: root.transferControl()
     }
 
+    Row {
+        id: planOverlay
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        spacing: 4
+        visible: policyModel.planIcons.length > 0
+        Repeater {
+            model: policyModel.planIcons
+            delegate: Rectangle {
+                width: 24
+                height: 24
+                color: "#404040"
+                border.color: "white"
+                Text { anchors.centerIn: parent; color: "white"; text: modelData }
+                property bool hovering: false
+                MouseArea {
+                    id: ma
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: parent.hovering = true
+                    onExited: parent.hovering = false
+                }
+                ToolTip.visible: hovering
+                ToolTip.text: policyModel.planSteps[index]
+            }
+        }
+    }
+
     Item {
         id: panels
         width: 250
@@ -180,6 +208,7 @@ Window {
             TabButton { text: "DOE" }
             TabButton { text: "GA" }
             TabButton { text: "MCTS" }
+            TabButton { text: "Policy" }
             TabButton { text: "Compare" }
         }
 
@@ -199,9 +228,10 @@ Window {
             LogExplorer { anchors.fill: parent }
             Inspector { anchors.fill: parent }
             Validation { anchors.fill: parent }
-            DOE { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 11 }
-            GA { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 11 }
+            DOE { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 12 }
+            GA { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 12 }
             MCTS { anchors.fill: parent; panels: panels; replayIndex: 3 }
+            Policy { anchors.fill: parent }
             Compare { anchors.fill: parent }
         }
     }

--- a/ui_new/panels/Policy.qml
+++ b/ui_new/panels/Policy.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    id: root
+    color: "#202020"
+    anchors.fill: parent
+
+    Column {
+        anchors.margins: 8
+        spacing: 4
+        Repeater {
+            model: policyModel.actionNames
+            delegate: Row {
+                spacing: 4
+                CheckBox {
+                    checked: true
+                    onToggled: policyModel.setActionEnabled(modelData, checked)
+                }
+                Text { text: modelData; color: "white" }
+            }
+        }
+        Row {
+            spacing: 4
+            Text { text: "Horizon"; color: "white" }
+            SpinBox {
+                from: 2
+                to: 5
+                value: policyModel.horizon
+                onValueChanged: policyModel.horizon = value
+            }
+        }
+        Row {
+            spacing: 4
+            Button { text: "Plan"; onClicked: policyModel.plan() }
+            Button { text: "Apply"; onClicked: policyModel.apply() }
+        }
+        Text { text: "Plan: " + policyModel.planSummary; color: "white" }
+    }
+}

--- a/ui_new/state/Policy.py
+++ b/ui_new/state/Policy.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+"""Expose the MCTS-C policy planner to QML panels."""
+
+import asyncio
+from typing import Dict, List, Optional
+
+from PySide6.QtCore import QObject, Property, Signal, Slot
+
+from experiments.policy import ACTION_ICONS, ACTION_SET, MCTS_C
+from ..ipc import Client
+
+
+class _Env:
+    """Toy environment with policy flags and a residual signal."""
+
+    def __init__(self, base: float = 10.0) -> None:
+        self._base = base
+        self.theta_reset = False
+        self.eps_emit = 0.0
+        self.Wmax = 64.0
+        self.MI_mode = False
+
+    @property
+    def residual(self) -> float:
+        res = self._base
+        if self.theta_reset:
+            res *= 0.5
+        res = max(res - self.eps_emit, 0.0)
+        res = max(res - max(0.0, 64.0 - self.Wmax), 0.0)
+        if self.MI_mode:
+            res += 4.0
+        return res
+
+    def clone(self) -> "_Env":
+        clone = _Env(self._base)
+        clone.theta_reset = self.theta_reset
+        clone.eps_emit = self.eps_emit
+        clone.Wmax = self.Wmax
+        clone.MI_mode = self.MI_mode
+        return clone
+
+
+class PolicyModel(QObject):
+    """Run receding-horizon plans over discrete engine toggles."""
+
+    planChanged = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._horizon = 2
+        self._enabled: Dict[str, bool] = {name: True for name in ACTION_SET}
+        self._plan: List[str] = []
+        self._client: Optional[Client] = None
+
+    # ------------------------------------------------------------------
+    @Property("QStringList", constant=True)
+    def actionNames(self) -> List[str]:
+        return list(ACTION_SET.keys())
+
+    # ------------------------------------------------------------------
+    @Property(int, notify=planChanged)
+    def horizon(self) -> int:
+        return self._horizon
+
+    @horizon.setter
+    def horizon(self, value: int) -> None:
+        value = int(max(2, min(5, value)))
+        if value != self._horizon:
+            self._horizon = value
+            self.planChanged.emit()
+
+    # ------------------------------------------------------------------
+    @Property(str, notify=planChanged)
+    def planSummary(self) -> str:
+        """Return the planned sequence as a human-readable string."""
+
+        return ", ".join(self._plan)
+
+    # ------------------------------------------------------------------
+    @Property("QStringList", notify=planChanged)
+    def planSteps(self) -> List[str]:
+        """Expose the raw action names for timeline overlays."""
+
+        return list(self._plan)
+
+    # ------------------------------------------------------------------
+    @Property("QStringList", notify=planChanged)
+    def planIcons(self) -> List[str]:
+        """Return a list of icon codes matching ``planSteps``."""
+
+        return [ACTION_ICONS.get(name, "") for name in self._plan]
+
+    # ------------------------------------------------------------------
+    @Slot(str, bool)
+    def setActionEnabled(self, name: str, enabled: bool) -> None:
+        if name in self._enabled:
+            self._enabled[name] = enabled
+
+    # ------------------------------------------------------------------
+    @Slot(str, result=str)
+    def iconFor(self, name: str) -> str:
+        """Lookup an icon for ``name`` to use in delegates."""
+
+        return ACTION_ICONS.get(name, "")
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def plan(self) -> None:
+        actions = [ACTION_SET[n] for n, e in self._enabled.items() if e]
+        env = _Env()
+        planner = MCTS_C(actions=actions, horizon=self._horizon, iterations=200)
+        seq = planner.plan(env)
+        self._plan = [a.__name__ for a in seq]
+        self.planChanged.emit()
+
+    # ------------------------------------------------------------------
+    def set_client(self, client: Optional[Client]) -> None:
+        """Attach a WebSocket ``client`` for dispatching actions."""
+
+        self._client = client
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def apply(self) -> None:
+        """Send the planned action sequence to the engine runtime."""
+
+        if self._client and self._plan:
+            asyncio.create_task(
+                self._client.send({"PolicyControl": {"actions": self._plan}})
+            )

--- a/ui_new/state/__init__.py
+++ b/ui_new/state/__init__.py
@@ -10,6 +10,7 @@ from .DOE import DOEModel
 from .GA import GAModel
 from .Compare import CompareModel
 from .MCTS import MCTSModel
+from .Policy import PolicyModel
 from .Results import ResultsModel
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "DOEModel",
     "GAModel",
     "MCTSModel",
+    "PolicyModel",
     "CompareModel",
     "ResultsModel",
 ]


### PR DESCRIPTION
## Summary
- Allow engine to process PolicyControl messages by mapping action names to implementations and exposing residual metric
- Wire PolicyModel to send planned action sequences to the engine and expose an Apply button in the Policy panel
- Document dispatching planned actions and add tests covering PolicyControl handling
- Route policy actions through dedicated engine state toggles and recompute residuals via `_apply_policy_effects`

## Testing
- `pip install -r requirements.txt`
- `black Causal_Web/engine/engine_v2/adapter.py experiments/policy/actions.py tests/engine/test_policy_control.py tests/experiments/test_mcts_c.py ui_new/state/Policy.py`
- `python -m compileall Causal_Web cw`
- `pytest`
- `python -m Causal_Web.main` *(fails: libGL.so.1: cannot open shared object file)*
- `python bundle_run.py`

## Notes
- All requested features from the policy planner integration have been implemented.


------
https://chatgpt.com/codex/tasks/task_e_68a8b614dfe4832594418a6f064b6023