### PR TITLE
Add process pool support for parallel MCTS rollouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Full evaluation manifests now record ``mcts_run_id`` so each run can be traced back to the MCTS search session.
 - Multi-objective MCTS runs now write results to the shared Pareto archive as ``origin: "mcts"``, allowing the GA panel to replay tree-search trade-offs.
 - GA panel automatically refreshes to surface new MCTS Pareto points without manual reload.
+- Leaf evaluations can now be dispatched in parallel via ``OptimizerQueueManager.run_parallel`` using thread or process pools or a Ray cluster, preserving deterministic seed streams and honouring ASHA rung scheduling.
 - ``cw optim`` now exposes ``--proxy-frames`` and ``--full-frames`` to control
   the frame budgets for proxy and promoted evaluations, ``--bins`` to set
   quantile bins for priors, ``--promote-quantile`` for percentile-based

--- a/docs/optimizers.md
+++ b/docs/optimizers.md
@@ -51,6 +51,12 @@ Regression tests compare MCTS-H against the genetic algorithm on a toy task,
 demonstrating that MCTS-H reaches comparable fitness with fewer full
 evaluations.
 
+Leaf evaluations can be processed in parallel via ``OptimizerQueueManager.run_parallel``.
+Passing ``parallel>1`` and ``use_processes=True`` dispatches rollouts to a
+process pool, while ``use_ray=True`` ships evaluations to a Ray cluster.
+Both modes retain deterministic seed streams and honour ASHA rung scheduling
+when configured.
+
 The ``experiments/calibrate_mcts_h.py`` helper sweeps ``c_ucb``, ``alpha_pw``,
 ``k_pw`` and initial prior bins over a canonical single-node graph. The sweep
 now explores bins ``{3,5,7}`` to provide deeper insight into prior


### PR DESCRIPTION
## Summary
- add `use_ray` option to `OptimizerQueueManager.run_parallel` and support ASHA rungs
- document Ray-based cluster execution and rung scheduling
- extend regression tests for Ray and ASHA-parallel determinism

## Testing
- `python -m compileall Causal_Web cw`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c79692bc8325b00bfe75709f0c9a