### PR TITLE
Add hypervolume UCT option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Added a lightweight Genetic Algorithm framework with tournament selection, uniform crossover, Gaussian mutation and elitism along with a GA panel showing a live population table with objectives and per-constraint flags, fitness-history and Pareto-front charts, and promote/export actions.
 - Introduced scalar fitness helpers with hard invariant guardrails and normalised terms, providing a clear objective for optimisation and a path toward multi-objective Pareto support.
 - Added NSGA-II-lite multi-objective capabilities with non-dominated sorting, crowding-distance selection, a persistent Pareto archive and UI promotion of chosen trade-offs.
-- Introduced an experimental MCTS-H optimiser that explores hyperparameter trees with progressive widening, prior-guided rollouts, proxy/full evaluation promotion and a simple transposition cache. Multi-objective runs are scalarised via random Dirichlet weights when ``multi_objective`` or the ``--multi-objective`` flag is enabled.
+ - Introduced an experimental MCTS-H optimiser that explores hyperparameter trees with progressive widening, prior-guided rollouts, proxy/full evaluation promotion and a simple transposition cache. Multi-objective runs default to random Dirichlet scalarisation but may instead use expected hypervolume improvement over an ``hv_box`` reference spanning any number of objectives.
 - Optimiser state can now be saved and reloaded to resume MCTS-H searches.
 - A new ``OptimizerQueueManager`` wires MCTS-H into the existing gate runner and persists Top-K and hall-of-fame artifacts for promoted full evaluations.
 - MCTS-H can route evaluations through an ASHA-style scheduler with configurable rungs (e.g. 20%, 40%, 100% of full frames) to prune weak candidates early, logging promotion fractions, per-rung wall-clock times, and demonstrated wall-clock savings across simulated workloads.
@@ -513,6 +513,10 @@ regression over 5% also opens a GitHub issue so maintainers receive external
 notifications. Both benchmarks record basic hardware metadata for reproducibility. Manual
 GUI frame-rate measurement guidelines remain in `bench/gui_fps.md` for
 scenarios not covered by the automated benchmark.
+
+`bench/hv_vs_scalarization.py` compares EHVI-driven MCTS-H against
+Dirichlet scalarisation on the two-objective Branin–Currin problem and
+prints the resulting hypervolumes as JSON.
 
 The GUI benchmark accepts ``--nodes`` to control graph size and
 ``--aa/--no-aa`` and ``--labels/--no-labels`` flags to toggle

--- a/bench/hv_vs_scalarization.py
+++ b/bench/hv_vs_scalarization.py
@@ -1,0 +1,103 @@
+"""Compare EHVI node values against scalarisation on Branin-Currin.
+
+The benchmark runs MCTS-H with expected hypervolume improvement and with
+Dirichlet scalarisation on the two-objective Branin-Currin function. The
+final dominated hypervolumes are printed as JSON for a single deterministic
+run using ``rng_seed=0``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from math import cos, exp, pi
+from typing import Dict
+
+import numpy as np
+
+from experiments.optim import MCTS_H
+from experiments.optim.priors import DiscretePrior
+
+
+def branin(x: float, y: float) -> float:
+    """Return the Branin function value for ``(x, y)`` in ``[0, 1]^2``."""
+    x1 = x * 15 - 5
+    x2 = y * 15
+    a = 1.0
+    b = 5.1 / (4 * pi**2)
+    c = 5.0 / pi
+    r = 6.0
+    s = 10.0
+    t = 1.0 / (8 * pi)
+    return a * (x2 - b * x1**2 + c * x1 - r) ** 2 + s * (1 - t) * cos(x1) + s
+
+
+def currin(x: float, y: float) -> float:
+    """Return the Currin exponential function value for ``(x, y)``."""
+    if y == 0:
+        y = 1e-7
+    return (1 - exp(-1 / (2 * y))) * (
+        (2300 * x**3 + 1900 * x**2 + 2092 * x + 60)
+        / (100 * x**3 + 500 * x**2 + 4 * x + 20)
+    )
+
+
+def objectives(x: float, y: float) -> Dict[str, float]:
+    return {"branin": branin(x, y), "currin": currin(x, y)}
+
+
+GRID = np.linspace(0.0, 1.0, 21).tolist()
+PRIORS = {
+    "x": DiscretePrior(GRID, [1 / len(GRID)] * len(GRID)),
+    "y": DiscretePrior(GRID, [1 / len(GRID)] * len(GRID)),
+}
+HV_BOX = [[0, 310], [0, 15]]
+
+
+def run(opt: MCTS_H, iters: int) -> float:
+    for _ in range(iters):
+        cfg = opt.suggest(1)[0]
+        opt.observe([{"config": cfg, "objectives": objectives(cfg["x"], cfg["y"])}])
+    return opt._hv
+
+
+def hypervolume_scalarisation(iters: int) -> float:
+    sc = MCTS_H(["x", "y"], PRIORS, {"multi_objective": True, "rng_seed": 0})
+    points = []
+    for _ in range(iters):
+        cfg = sc.suggest(1)[0]
+        objs = objectives(cfg["x"], cfg["y"])
+        sc.observe([{"config": cfg, "objectives": objs}])
+        points.append(np.array(list(objs.values())))
+    sc.hv_box = np.array(HV_BOX, dtype=float)
+    front: list[np.ndarray] = []
+    for p in points:
+        dominated = False
+        for q in front:
+            if np.all(q <= p) and np.any(q < p):
+                dominated = True
+                break
+        if dominated:
+            continue
+        front = [q for q in front if not (np.all(p <= q) and np.any(p < q))]
+        front.append(p)
+    return sc._hv_value(front)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iters", type=int, default=40)
+    args = parser.parse_args()
+
+    hv = MCTS_H(
+        ["x", "y"],
+        PRIORS,
+        {"multi_objective": True, "hv_box": HV_BOX, "rng_seed": 0},
+    )
+    hv_res = run(hv, args.iters)
+    sc_res = hypervolume_scalarisation(args.iters)
+    print(json.dumps({"ehvi": hv_res, "scalarisation": sc_res}))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- enable EHVI-based node values in MCTS_H with configurable `hv_box`
- track hypervolume during search and persist Pareto front state
- extend hypervolume helper to arbitrary objectives and add benchmark against scalarisation
- test hypervolume growth and document hypervolume option
- benchmark EHVI vs scalarisation on Branin–Currin with deterministic seed

## Testing
- `pip install -r requirements.txt`
- `black Causal_Web cw experiments/optim/mcts_h.py tests/experiments/test_mcts_h.py bench/hv_vs_scalarization.py`
- `python -m compileall Causal_Web cw`
- `python -m compileall experiments`
- `python -m compileall bench/hv_vs_scalarization.py`
- `pytest`
- `PYTHONPATH=. python bench/hv_vs_scalarization.py --iters 40`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce53f07483259ef22358c964d8fa