### PR TITLE
feat: add local ablation and telemetry intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ via a Monte-Carlo path sampler over the graph's causal structure.
 - Users can adjust proxy/full frame budgets, promotion thresholds or
   quantiles, and prior bin counts directly in the MCTS panel for
   multi-fidelity searches.
+- A Local Ablation button in the MCTS tab generates 1D and 2D partial
+  dependence slices around the best configuration and renders them in-line,
+  revealing which dimensions influence performance without external plots.
+- Telemetry charts now expose bootstrapped confidence bands to visualise
+  uncertainty around rolling metrics.
 - Regression tests show MCTS-H attains GA-level fitness while using fewer full
   evaluations than the genetic algorithm.
 - ``experiments/calibrate_mcts_h.py`` sweeps ``c_ucb``, ``alpha_pw``, ``k_pw``

--- a/docs/optimizers.md
+++ b/docs/optimizers.md
@@ -51,6 +51,14 @@ Regression tests compare MCTS-H against the genetic algorithm on a toy task,
 demonstrating that MCTS-H reaches comparable fitness with fewer full
 evaluations.
 
+To aid interpretation, ``experiments.ablation.local_ablation`` computes
+partial dependence slices around the best discovered configuration. These
+1D or 2D sweeps highlight which dimensions most influence optimisation near
+the optimum and can be triggered from the MCTS tab via the *Local Ablation*
+button, with the resulting curves and heatmaps rendered directly below the
+controls. Telemetry plots now surface bootstrapped confidence bands on rolling
+metrics so uncertainty is visible directly in the UI.
+
 Leaf evaluations can be processed in parallel via ``OptimizerQueueManager.run_parallel``.
 Passing ``parallel>1`` and ``use_processes=True`` dispatches rollouts to a
 process pool, while ``use_ray=True`` ships evaluations to a Ray cluster.

--- a/experiments/__init__.py
+++ b/experiments/__init__.py
@@ -14,6 +14,7 @@ from .artifacts import (
 )
 from .index import RunIndex, run_key
 from .fitness import scalar_fitness, vector_fitness
+from .ablation import local_ablation
 
 __all__ = [
     "DOEQueueManager",
@@ -33,4 +34,5 @@ __all__ = [
     "run_key",
     "scalar_fitness",
     "vector_fitness",
+    "local_ablation",
 ]

--- a/experiments/ablation.py
+++ b/experiments/ablation.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Utilities for local ablation around MCTS best configurations."""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Sequence
+import numpy as np
+
+
+@dataclass
+class AblationResult:
+    """Store partial dependence results for one or two dimensions."""
+
+    params: Sequence[str]
+    values: Sequence[Sequence[float]]
+    scores: Sequence[Sequence[float]]
+
+
+def local_ablation(
+    best: Dict[str, float],
+    evaluate: Callable[[Dict[str, float]], float],
+    features: Sequence[str],
+    *,
+    span: float = 0.1,
+    steps: int = 20,
+) -> AblationResult:
+    """Compute partial dependence around ``best`` for ``features``.
+
+    Parameters
+    ----------
+    best:
+        Mapping of parameter names to their best discovered values.
+    evaluate:
+        Callable evaluating a configuration and returning a scalar score.
+    features:
+        One or two parameter names to ablate.
+    span:
+        Fractional range to sweep around the best value. A value of ``0.1``
+        explores ``±10%`` around the centre.
+    steps:
+        Number of grid points per dimension.
+
+    Returns
+    -------
+    AblationResult
+        Structure containing sampled parameter values and corresponding
+        scores.
+
+    Notes
+    -----
+    The evaluation function is invoked ``steps`` times for one-dimensional
+    ablations and ``steps**2`` times for two-dimensional slices.
+    """
+
+    if len(features) not in (1, 2):
+        raise ValueError("features must contain one or two entries")
+
+    centre = [best[f] for f in features]
+    grids: List[np.ndarray] = []
+    for c in centre:
+        width = abs(c) * span
+        if width == 0:
+            width = span
+        grids.append(np.linspace(c - width, c + width, steps))
+
+    scores: List[List[float]] = []
+    if len(features) == 1:
+        param = features[0]
+        vals = grids[0]
+        for v in vals:
+            cfg = dict(best)
+            cfg[param] = float(v)
+            scores.append([float(evaluate(cfg))])
+        return AblationResult([param], [vals.tolist()], scores)
+
+    # 2D ablation
+    p1, p2 = features
+    v1, v2 = grids
+    for x in v1:
+        row: List[float] = []
+        for y in v2:
+            cfg = dict(best)
+            cfg[p1] = float(x)
+            cfg[p2] = float(y)
+            row.append(float(evaluate(cfg)))
+        scores.append(row)
+    return AblationResult([p1, p2], [v1.tolist(), v2.tolist()], scores)

--- a/tests/test_local_ablation.py
+++ b/tests/test_local_ablation.py
@@ -1,0 +1,28 @@
+from experiments.ablation import local_ablation
+import pytest
+
+
+def test_local_ablation_1d():
+    best = {"x": 1.0, "y": 2.0}
+
+    def evaluate(cfg):
+        return (cfg["x"] - 1.0) ** 2 + cfg["y"]
+
+    res = local_ablation(best, evaluate, ["x"], span=1.0, steps=3)
+    assert res.params == ["x"]
+    assert res.values[0] == pytest.approx([0.0, 1.0, 2.0])
+    expected = [3.0, 2.0, 3.0]
+    assert [s[0] for s in res.scores] == pytest.approx(expected)
+
+
+def test_local_ablation_2d():
+    best = {"x": 1.0, "y": 2.0}
+
+    def evaluate(cfg):
+        return cfg["x"] + cfg["y"]
+
+    res = local_ablation(best, evaluate, ["x", "y"], span=0.5, steps=2)
+    assert res.params == ["x", "y"]
+    assert res.values[0] == pytest.approx([0.5, 1.5])
+    assert res.values[1] == pytest.approx([1.0, 3.0])
+    assert res.scores == [[1.5, 3.5], [2.5, 4.5]]

--- a/tests/test_mcts_local_ablation.py
+++ b/tests/test_mcts_local_ablation.py
@@ -1,0 +1,29 @@
+import json
+import pytest
+
+pytest.importorskip("PySide6")
+from ui_new.state.MCTS import MCTSModel
+from experiments.ablation import AblationResult
+
+
+def test_local_ablation_writes_file(tmp_path, monkeypatch):
+    model = MCTSModel()
+    monkeypatch.setattr(
+        "ui_new.state.MCTS.load_top_k",
+        lambda path: {"rows": [{"groups": {"a": 1.0, "b": 2.0}}]},
+    )
+    monkeypatch.setattr("ui_new.state.MCTS.run_gates", lambda raw, gates, frames=1: {})
+    calls = []
+
+    def fake_local(best, evaluate, features, span=0.1, steps=20):
+        calls.append(features)
+        return AblationResult(features, [[best[f] for f in features]], [[0.0]])
+
+    monkeypatch.setattr("ui_new.state.MCTS.local_ablation", fake_local)
+    monkeypatch.chdir(tmp_path)
+    model.localAblation()
+    out = tmp_path / "experiments" / "local_ablation.json"
+    data = json.loads(out.read_text())
+    assert len(calls) == 3
+    assert data["ablations"][0]["params"] == calls[0]
+    assert model.ablations[0]["params"] == calls[0]

--- a/tests/test_rolling_telemetry.py
+++ b/tests/test_rolling_telemetry.py
@@ -1,4 +1,6 @@
 from telemetry import RollingTelemetry
+import numpy as np
+import pytest
 
 
 def test_record_caps_length():
@@ -15,3 +17,13 @@ def test_optional_arguments():
     rt.record(invariants={"ok": True})
     assert rt.get_counters()["x"] == [1.0]
     assert rt.get_invariants()["ok"] == [1.0]
+
+
+def test_bootstrap_confidence_intervals():
+    rt = RollingTelemetry(max_points=5)
+    for i in range(5):
+        rt.record({"a": float(i)})
+    ci = rt.get_counter_intervals(n_boot=1000, rng=np.random.default_rng(0))
+    mean, lower, upper = ci["a"]
+    assert pytest.approx(mean) == 2.0
+    assert lower <= mean <= upper

--- a/tests/test_telemetry_model.py
+++ b/tests/test_telemetry_model.py
@@ -2,6 +2,7 @@ import pytest
 
 pytest.importorskip("PySide6")
 from ui_new.state.Telemetry import TelemetryModel
+import pytest
 
 
 def test_record_updates_histories():
@@ -14,3 +15,6 @@ def test_record_updates_histories():
     assert tm.depthLabel == "depth"
     tm.record({"events": 3.0}, {"inv": True}, depth=5, label="frame")
     assert tm.depthLabel == "frame"
+    ci = tm.counterIntervals["events"]
+    assert pytest.approx(ci[0]) == 2.5
+    assert ci[1] <= ci[0] <= ci[2]

--- a/ui_new/panels/AblationHeatmap.qml
+++ b/ui_new/panels/AblationHeatmap.qml
@@ -1,0 +1,34 @@
+import QtQuick 2.15
+
+Canvas {
+    id: canvas
+    property var scores: []
+    onPaint: {
+        var ctx = getContext('2d');
+        ctx.reset();
+        var rows = scores.length;
+        if (rows === 0)
+            return;
+        var cols = scores[0].length;
+        var min = scores[0][0];
+        var max = scores[0][0];
+        for (var i = 0; i < rows; ++i) {
+            for (var j = 0; j < cols; ++j) {
+                var s = scores[i][j];
+                if (s < min) min = s;
+                if (s > max) max = s;
+            }
+        }
+        var w = width / cols;
+        var h = height / rows;
+        for (var i = 0; i < rows; ++i) {
+            for (var j = 0; j < cols; ++j) {
+                var s = scores[i][j];
+                var t = (s - min) / (max - min || 1);
+                ctx.fillStyle = Qt.hsla(0.6 - 0.6 * t, 1, 0.5, 1);
+                ctx.fillRect(j * w, (rows - 1 - i) * h, w, h);
+            }
+        }
+    }
+    onScoresChanged: requestPaint()
+}

--- a/ui_new/panels/MCTS.qml
+++ b/ui_new/panels/MCTS.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import "."
 
 Rectangle {
     id: root
@@ -61,6 +62,7 @@ Rectangle {
             }
             Button { text: "Resume"; onClicked: mctsModel.resume() }
             Button { text: "Promote Baseline"; onClicked: mctsModel.promoteBaseline() }
+            Button { text: "Local Ablation"; onClicked: mctsModel.localAblation() }
         }
         Row {
             spacing: 8
@@ -99,6 +101,30 @@ Rectangle {
                             if (panels && replayIndex >= 0)
                                 panels.currentIndex = replayIndex
                         }
+                    }
+                }
+            }
+        }
+
+        Text { text: "Local Ablations"; color: "white"; visible: mctsModel.ablations.length > 0 }
+        Repeater {
+            model: mctsModel.ablations
+            delegate: Column {
+                width: parent.width
+                spacing: 4
+                Text { text: modelData.params.join(", "); color: "white" }
+                Item {
+                    width: parent.width
+                    height: 100
+                    RollingPlot {
+                        anchors.fill: parent
+                        points: modelData.scores.map(function(row) { return row[0]; })
+                        visible: modelData.params.length === 1
+                    }
+                    AblationHeatmap {
+                        anchors.fill: parent
+                        scores: modelData.scores
+                        visible: modelData.params.length === 2
                     }
                 }
             }

--- a/ui_new/panels/RollingPlot.qml
+++ b/ui_new/panels/RollingPlot.qml
@@ -3,21 +3,31 @@ import QtQuick 2.15
 Canvas {
     id: canvas
     property var points: []
+    property var band: null // [lower, upper]
     onPaint: {
         var ctx = getContext('2d');
         ctx.reset();
+        var pts = points || [];
+        var maxVal = 1;
+        if (pts.length > 0)
+            maxVal = Math.max(maxVal, Math.max.apply(Math, pts));
+        if (band && band.length === 2) {
+            maxVal = Math.max(maxVal, band[1]);
+            var lowerY = height - (band[0] / maxVal) * height;
+            var upperY = height - (band[1] / maxVal) * height;
+            ctx.fillStyle = 'rgba(0,255,0,0.2)';
+            ctx.fillRect(0, upperY, width, lowerY - upperY);
+        }
         ctx.strokeStyle = 'lime';
         ctx.beginPath();
-        var pts = points || [];
         if (pts.length > 0) {
-            var max = Math.max.apply(Math, pts);
-            if (max <= 0) max = 1;
             var step = width / Math.max(1, pts.length - 1);
-            ctx.moveTo(0, height - (pts[0] / max) * height);
+            ctx.moveTo(0, height - (pts[0] / maxVal) * height);
             for (var i = 1; i < pts.length; ++i)
-                ctx.lineTo(i * step, height - (pts[i] / max) * height);
+                ctx.lineTo(i * step, height - (pts[i] / maxVal) * height);
         }
         ctx.stroke();
     }
     onPointsChanged: requestPaint()
+    onBandChanged: requestPaint()
 }

--- a/ui_new/panels/Telemetry.qml
+++ b/ui_new/panels/Telemetry.qml
@@ -32,12 +32,18 @@ Rectangle {
             width: parent.width
             height: 40
             points: telemetryModel.counters["events_per_sec"] || []
+            band: telemetryModel.counterIntervals["events_per_sec"]
+                  ? telemetryModel.counterIntervals["events_per_sec"].slice(1, 3)
+                  : null
         }
         Text { text: "residual"; color: "white" }
         RollingPlot {
             width: parent.width
             height: 40
             points: telemetryModel.invariants["inv_conservation_residual"] || []
+            band: telemetryModel.counterIntervals["inv_conservation_residual"]
+                  ? telemetryModel.counterIntervals["inv_conservation_residual"].slice(1, 3)
+                  : null
         }
     }
 }

--- a/ui_new/state/Telemetry.py
+++ b/ui_new/state/Telemetry.py
@@ -18,6 +18,7 @@ class TelemetryModel(QObject):
     edgeCountChanged = Signal(int)
     countersChanged = Signal(dict)
     invariantsChanged = Signal(dict)
+    counterIntervalsChanged = Signal(dict)
     depthChanged = Signal(int)
     depthLabelChanged = Signal(str)
 
@@ -64,6 +65,14 @@ class TelemetryModel(QObject):
     invariants = Property(dict, _get_invariants, notify=invariantsChanged)
 
     # ------------------------------------------------------------------
+    def _get_counter_intervals(self) -> dict[str, tuple[float, float, float]]:
+        return self._telemetry.get_counter_intervals()
+
+    counterIntervals = Property(
+        dict, _get_counter_intervals, notify=counterIntervalsChanged
+    )
+
+    # ------------------------------------------------------------------
     def record(
         self,
         counters: dict[str, float] | None = None,
@@ -81,6 +90,7 @@ class TelemetryModel(QObject):
         self._telemetry.record(counters, invariants)
         self.countersChanged.emit(self._telemetry.get_counters())
         self.invariantsChanged.emit(self._telemetry.get_invariants())
+        self.counterIntervalsChanged.emit(self._telemetry.get_counter_intervals())
 
     def update_counts(self, nodes: int, edges: int) -> None:
         """Convenience method to update both counts."""


### PR DESCRIPTION
## Summary
- add `experiments.ablation.local_ablation` for 1D/2D partial dependence around best MCTS configs
- expose bootstrap confidence intervals through telemetry and render bands in UI plots
- visualize local ablation results directly in the MCTS panel using line/heatmap components
- document dimension sensitivity and telemetry uncertainty

## Testing
- `black Causal_Web cw ui_new/state/MCTS.py tests/test_mcts_local_ablation.py`
- `python -m compileall Causal_Web cw experiments telemetry ui_new/state tests/test_rolling_telemetry.py tests/test_telemetry_model.py tests/test_local_ablation.py tests/test_mcts_local_ablation.py`
- `pip install --quiet -r requirements.txt`
- `pytest tests/test_rolling_telemetry.py tests/test_telemetry_model.py tests/test_local_ablation.py tests/test_mcts_local_ablation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a909b6cd5c832594f091ae765497ed