### PR TITLE
Add msgpack dependency for IPC client

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The bundle will be written to `dist/cw_gui/` and contains an executable that
 launches the engine and Qt Quick interface.
 
 ## Troubleshooting
+- **ModuleNotFoundError: No module named 'msgpack'** → run `pip install -r requirements.txt` to install dependencies.
 - **Disconnected** → token mismatch or single-client limit.
 - **Low FPS** → zoom out, labels auto-hide; disable AA at far zoom.
 - **Invariant failures** → inspect `result.json` for violations.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cupy-cuda12x
 imageio
 matplotlib
+msgpack
 networkx
 numpy
 pandas


### PR DESCRIPTION
## Summary
- add msgpack to default requirements so IPC client imports succeed
- document msgpack troubleshooting step in README

## Testing
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pip install -r requirements.txt`
- `pytest` *(fails: test_bridge_delay_median_used_in_scheduler)*


------
https://chatgpt.com/codex/tasks/task_e_68a9507a3b248325a7e71a1b5ab4a8ec