### PR TITLE
Add notify signals for QML models

### DIFF
--- a/ui_new/state/GA.py
+++ b/ui_new/state/GA.py
@@ -26,6 +26,7 @@ class GAModel(QObject):
     objectiveCountChanged = Signal()
     objectiveNamesChanged = Signal()
     statsChanged = Signal()
+    paramsChanged = Signal()
 
     def __init__(self) -> None:
         super().__init__()
@@ -323,48 +324,64 @@ class GAModel(QObject):
 
     def _set_population_size(self, val: int) -> None:
         self._population_size = int(val)
+        self.paramsChanged.emit()
 
-    populationSize = Property(int, _get_population_size, _set_population_size)
+    populationSize = Property(
+        int, _get_population_size, _set_population_size, notify=paramsChanged
+    )
 
     def _get_mutation_rate(self) -> float:
         return self._mutation_rate
 
     def _set_mutation_rate(self, val: float) -> None:
         self._mutation_rate = float(val)
+        self.paramsChanged.emit()
 
-    mutationRate = Property(float, _get_mutation_rate, _set_mutation_rate)
+    mutationRate = Property(
+        float, _get_mutation_rate, _set_mutation_rate, notify=paramsChanged
+    )
 
     def _get_crossover_rate(self) -> float:
         return self._crossover_rate
 
     def _set_crossover_rate(self, val: float) -> None:
         self._crossover_rate = float(val)
+        self.paramsChanged.emit()
 
-    crossoverRate = Property(float, _get_crossover_rate, _set_crossover_rate)
+    crossoverRate = Property(
+        float, _get_crossover_rate, _set_crossover_rate, notify=paramsChanged
+    )
 
     def _get_elitism(self) -> int:
         return self._elitism
 
     def _set_elitism(self, val: int) -> None:
         self._elitism = int(val)
+        self.paramsChanged.emit()
 
-    elitism = Property(int, _get_elitism, _set_elitism)
+    elitism = Property(int, _get_elitism, _set_elitism, notify=paramsChanged)
 
     def _get_max_generations(self) -> int:
         return self._max_generations
 
     def _set_max_generations(self, val: int) -> None:
         self._max_generations = int(val)
+        self.paramsChanged.emit()
 
-    maxGenerations = Property(int, _get_max_generations, _set_max_generations)
+    maxGenerations = Property(
+        int, _get_max_generations, _set_max_generations, notify=paramsChanged
+    )
 
     def _get_multi_objective(self) -> bool:
         return self._multi_objective
 
     def _set_multi_objective(self, val: bool) -> None:
         self._multi_objective = bool(val)
+        self.paramsChanged.emit()
 
-    multiObjective = Property(bool, _get_multi_objective, _set_multi_objective)
+    multiObjective = Property(
+        bool, _get_multi_objective, _set_multi_objective, notify=paramsChanged
+    )
 
     def _get_running(self) -> bool:
         return self._running

--- a/ui_new/state/MCTS.py
+++ b/ui_new/state/MCTS.py
@@ -25,6 +25,7 @@ class MCTSModel(QObject):
     baselinePromoted = Signal(str)
     statsChanged = Signal()
     ablationsChanged = Signal()
+    paramsChanged = Signal()
 
     def __init__(self) -> None:
         super().__init__()
@@ -280,88 +281,105 @@ class MCTSModel(QObject):
 
     def _set_c_ucb(self, val: float) -> None:
         self._c_ucb = float(val)
+        self.paramsChanged.emit()
 
-    cUcb = Property(float, _get_c_ucb, _set_c_ucb)
+    cUcb = Property(float, _get_c_ucb, _set_c_ucb, notify=paramsChanged)
 
     def _get_alpha_pw(self) -> float:
         return self._alpha_pw
 
     def _set_alpha_pw(self, val: float) -> None:
         self._alpha_pw = float(val)
+        self.paramsChanged.emit()
 
-    alphaPw = Property(float, _get_alpha_pw, _set_alpha_pw)
+    alphaPw = Property(float, _get_alpha_pw, _set_alpha_pw, notify=paramsChanged)
 
     def _get_k_pw(self) -> float:
         return self._k_pw
 
     def _set_k_pw(self, val: float) -> None:
         self._k_pw = float(val)
+        self.paramsChanged.emit()
 
-    kPw = Property(float, _get_k_pw, _set_k_pw)
+    kPw = Property(float, _get_k_pw, _set_k_pw, notify=paramsChanged)
 
     def _get_promote(self) -> float:
         return self._promote
 
     def _set_promote(self, val: float) -> None:
         self._promote = float(val)
+        self.paramsChanged.emit()
 
-    promoteThreshold = Property(float, _get_promote, _set_promote)
+    promoteThreshold = Property(float, _get_promote, _set_promote, notify=paramsChanged)
 
     def _get_promote_q(self) -> float:
         return self._promote_q
 
     def _set_promote_q(self, val: float) -> None:
         self._promote_q = float(val)
+        self.paramsChanged.emit()
 
-    promoteQuantile = Property(float, _get_promote_q, _set_promote_q)
+    promoteQuantile = Property(
+        float, _get_promote_q, _set_promote_q, notify=paramsChanged
+    )
 
     def _get_promote_w(self) -> float:
         return self._promote_w
 
     def _set_promote_w(self, val: float) -> None:
         self._promote_w = float(val)
+        self.paramsChanged.emit()
 
-    promoteWindow = Property(float, _get_promote_w, _set_promote_w)
+    promoteWindow = Property(
+        float, _get_promote_w, _set_promote_w, notify=paramsChanged
+    )
 
     def _get_max_nodes(self) -> int:
         return self._max_nodes
 
     def _set_max_nodes(self, val: int) -> None:
         self._max_nodes = int(val)
+        self.paramsChanged.emit()
 
-    maxNodes = Property(int, _get_max_nodes, _set_max_nodes)
+    maxNodes = Property(int, _get_max_nodes, _set_max_nodes, notify=paramsChanged)
 
     def _get_proxy_frames(self) -> int:
         return self._proxy_frames
 
     def _set_proxy_frames(self, val: int) -> None:
         self._proxy_frames = int(val)
+        self.paramsChanged.emit()
 
-    proxyFrames = Property(int, _get_proxy_frames, _set_proxy_frames)
+    proxyFrames = Property(
+        int, _get_proxy_frames, _set_proxy_frames, notify=paramsChanged
+    )
 
     def _get_full_frames(self) -> int:
         return self._full_frames
 
     def _set_full_frames(self, val: int) -> None:
         self._full_frames = int(val)
+        self.paramsChanged.emit()
 
-    fullFrames = Property(int, _get_full_frames, _set_full_frames)
+    fullFrames = Property(int, _get_full_frames, _set_full_frames, notify=paramsChanged)
 
     def _get_bins(self) -> int:
         return self._bins
 
     def _set_bins(self, val: int) -> None:
         self._bins = int(val)
+        self.paramsChanged.emit()
 
-    bins = Property(int, _get_bins, _set_bins)
+    bins = Property(int, _get_bins, _set_bins, notify=paramsChanged)
 
     def _get_multi(self) -> bool:
         return self._multi_objective
 
     def _set_multi(self, val: bool) -> None:
         self._multi_objective = bool(val)
+        self.paramsChanged.emit()
 
-    multiObjective = Property(bool, _get_multi, _set_multi)
+    multiObjective = Property(bool, _get_multi, _set_multi, notify=paramsChanged)
 
     def _get_node_count(self) -> int:
         return self._node_count

--- a/ui_new/state/Results.py
+++ b/ui_new/state/Results.py
@@ -16,6 +16,7 @@ class ResultsModel(QObject):
     """Filter and retrieve experiment results for display."""
 
     rowsChanged = Signal()
+    filtersChanged = Signal()
 
     def __init__(self) -> None:
         super().__init__()
@@ -33,8 +34,9 @@ class ResultsModel(QObject):
     def _set_optimizer(self, val: str) -> None:
         self._optimizer = val
         self.refresh()
+        self.filtersChanged.emit()
 
-    optimizer = Property(str, _get_optimizer, _set_optimizer)
+    optimizer = Property(str, _get_optimizer, _set_optimizer, notify=filtersChanged)
 
     def _get_promotion(self) -> float:
         return self._promotion
@@ -42,8 +44,11 @@ class ResultsModel(QObject):
     def _set_promotion(self, val: float) -> None:
         self._promotion = float(val)
         self.refresh()
+        self.filtersChanged.emit()
 
-    promotionMin = Property(float, _get_promotion, _set_promotion)
+    promotionMin = Property(
+        float, _get_promotion, _set_promotion, notify=filtersChanged
+    )
 
     def _get_corr(self) -> float:
         return self._corr
@@ -51,8 +56,9 @@ class ResultsModel(QObject):
     def _set_corr(self, val: float) -> None:
         self._corr = float(val)
         self.refresh()
+        self.filtersChanged.emit()
 
-    proxyFullCorrMin = Property(float, _get_corr, _set_corr)
+    proxyFullCorrMin = Property(float, _get_corr, _set_corr, notify=filtersChanged)
 
     def _get_rows(self) -> List[Dict[str, Any]]:
         return self._rows


### PR DESCRIPTION
## Summary
- add `paramsChanged` signal to GA and MCTS models and emit it from parameter setters
- expose `filtersChanged` in Results model and use it for filter properties
- emit signals to make properties bindable in QML

## Testing
- `black Causal_Web cw ui_new/state/MCTS.py ui_new/state/GA.py ui_new/state/Results.py`
- `python -m compileall Causal_Web cw ui_new/state`
- `pip install -r requirements.txt`
- `pytest`
- `python -m Causal_Web.main` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a952094918832593a60cfa3b7f7cb6