### PR TITLE
Resolve startup QML errors and update GraphView material types

### DIFF
--- a/ui_new/graph/GraphView.py
+++ b/ui_new/graph/GraphView.py
@@ -12,6 +12,8 @@ from PySide6.QtQuick import (
     QSGGeometryNode,
     QSGMaterial,
     QSGMaterialShader,
+    QSGMaterialType,
+    QSGRendererInterface,
     QSGNode,
     QSGTextNode,
 )
@@ -24,6 +26,8 @@ QML_IMPORT_MAJOR_VERSION = 1
 class _InstancedMaterial(QSGMaterial):
     """Flat material feeding per-instance attributes to the shader."""
 
+    _TYPE = QSGMaterialType()
+
     def __init__(self) -> None:
         super().__init__()
         # Attribute buffers mirroring geometry instance data
@@ -31,10 +35,12 @@ class _InstancedMaterial(QSGMaterial):
         self.colors: List[QVector4D] = []
         self.flags: List[float] = []
 
-    def type(self) -> int:  # pragma: no cover - Qt binding detail
-        return QSGMaterial.UserType + 1
+    def type(self) -> QSGMaterialType:  # pragma: no cover - Qt binding detail
+        return self._TYPE
 
-    def createShader(self) -> QSGMaterialShader:  # pragma: no cover - Qt binding detail
+    def createShader(
+        self, render_mode: QSGRendererInterface.RenderMode
+    ) -> QSGMaterialShader:  # pragma: no cover - Qt binding detail
         return _InstancedShader()
 
 
@@ -92,16 +98,20 @@ class _InstancedShader(QSGMaterialShader):
 class _EdgeMaterial(QSGMaterial):
     """Material supplying per-edge endpoints via instanced attributes."""
 
+    _TYPE = QSGMaterialType()
+
     def __init__(self) -> None:
         super().__init__()
         self.color = QColor("gray")
         self.starts: List[QVector2D] = []
         self.ends: List[QVector2D] = []
 
-    def type(self) -> int:  # pragma: no cover - Qt binding detail
-        return QSGMaterial.UserType + 2
+    def type(self) -> QSGMaterialType:  # pragma: no cover - Qt binding detail
+        return self._TYPE
 
-    def createShader(self) -> QSGMaterialShader:  # pragma: no cover - Qt binding detail
+    def createShader(
+        self, render_mode: QSGRendererInterface.RenderMode
+    ) -> QSGMaterialShader:  # pragma: no cover - Qt binding detail
         return _EdgeShader()
 
 
@@ -572,6 +582,7 @@ class GraphView(QQuickItem):
             from PySide6.QtGui import QImage  # Local import to avoid GUI deps
             import numpy as np
             import imageio
+
             img = result.image().convertToFormat(QImage.Format_RGBA8888)
             width, height = img.width(), img.height()
             ptr = img.constBits()

--- a/ui_new/main.qml
+++ b/ui_new/main.qml
@@ -220,19 +220,19 @@ Window {
             anchors.bottom: parent.bottom
             currentIndex: tabBar.currentIndex
 
-            Telemetry { anchors.fill: parent; graphView: graphView }
-            Meters { anchors.fill: parent }
-            Experiment { anchors.fill: parent; graphView: graphView }
-            Replay { anchors.fill: parent }
-            Results { anchors.fill: parent }
-            LogExplorer { anchors.fill: parent }
-            Inspector { anchors.fill: parent }
-            Validation { anchors.fill: parent }
-            DOE { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 12 }
-            GA { anchors.fill: parent; panels: panels; replayIndex: 3; compareIndex: 12 }
-            MCTS { anchors.fill: parent; panels: panels; replayIndex: 3 }
-            Policy { anchors.fill: parent }
-            Compare { anchors.fill: parent }
+            Telemetry { Layout.fillWidth: true; Layout.fillHeight: true; graphView: graphView }
+            Meters { Layout.fillWidth: true; Layout.fillHeight: true }
+            Experiment { Layout.fillWidth: true; Layout.fillHeight: true; graphView: graphView }
+            Replay { Layout.fillWidth: true; Layout.fillHeight: true }
+            Results { Layout.fillWidth: true; Layout.fillHeight: true }
+            LogExplorer { Layout.fillWidth: true; Layout.fillHeight: true }
+            Inspector { Layout.fillWidth: true; Layout.fillHeight: true }
+            Validation { Layout.fillWidth: true; Layout.fillHeight: true }
+            DOE { Layout.fillWidth: true; Layout.fillHeight: true; panels: panels; replayIndex: 3; compareIndex: 12 }
+            GA { Layout.fillWidth: true; Layout.fillHeight: true; panels: panels; replayIndex: 3; compareIndex: 12 }
+            MCTS { Layout.fillWidth: true; Layout.fillHeight: true; panels: panels; replayIndex: 3 }
+            Policy { Layout.fillWidth: true; Layout.fillHeight: true }
+            Compare { Layout.fillWidth: true; Layout.fillHeight: true }
         }
     }
 }

--- a/ui_new/panels/Compare.qml
+++ b/ui_new/panels/Compare.qml
@@ -48,22 +48,22 @@ Rectangle {
             Column {
                 spacing: 2
                 Text { text: "Run A"; color: "white" }
-                Image {
-                    id: imgA
-                    source: compareModel.frameA
-                    width: 200; height: 200
-                    fillMode: Image.PreserveAspectFit
-                }
+                  Image {
+                      id: imgA
+                      source: compareModel.frameA || ""
+                      width: 200; height: 200
+                      fillMode: Image.PreserveAspectFit
+                  }
             }
             Column {
                 spacing: 2
                 Text { text: "Run B"; color: "white" }
-                Image {
-                    id: imgB
-                    source: compareModel.frameB
-                    width: 200; height: 200
-                    fillMode: Image.PreserveAspectFit
-                }
+                  Image {
+                      id: imgB
+                      source: compareModel.frameB || ""
+                      width: 200; height: 200
+                      fillMode: Image.PreserveAspectFit
+                  }
             }
             Column {
                 spacing: 2

--- a/ui_new/panels/Inspector.qml
+++ b/ui_new/panels/Inspector.qml
@@ -31,10 +31,10 @@ Item {
             visible: store.selectedEdge >= 0
             property var edge: store.get_edge(store.selectedEdge)
             Text { text: "Edge " + store.selectedEdge }
-            Text { text: edge ? ("from: " + edge.from + " to: " + edge.to) : "" }
+            Text { text: edgeCol.edge ? ("from: " + edgeCol.edge.from + " to: " + edgeCol.edge.to) : "" }
             TextField {
                 id: edgeDelay
-                text: edge && edge.delay !== undefined ? edge.delay : ""
+                text: edgeCol.edge && edgeCol.edge.delay !== undefined ? edgeCol.edge.delay : ""
                 onEditingFinished: {
                     var val = parseInt(text);
                     if (!isNaN(val)) {
@@ -49,15 +49,15 @@ Item {
             spacing: 4
             visible: store.selectedObserver >= 0
             property var obs: store.get_observer(store.selectedObserver)
-            Text { text: obs ? ("Observer " + obs.id) : "" }
+            Text { text: obsCol.obs ? ("Observer " + obsCol.obs.id) : "" }
             TextField {
                 id: obsId
-                text: obs ? obs.id || "" : ""
+                text: obsCol.obs ? obsCol.obs.id || "" : ""
                 onEditingFinished: store.set_observer_id(store.selectedObserver, text)
             }
             TextField {
                 id: obsFreq
-                text: obs && obs.frequency !== undefined ? obs.frequency : ""
+                text: obsCol.obs && obsCol.obs.frequency !== undefined ? obsCol.obs.frequency : ""
                 onEditingFinished: {
                     var freq = parseFloat(text);
                     if (!isNaN(freq)) {
@@ -76,26 +76,26 @@ Item {
             CheckBox {
                 id: entangledBox
                 text: "Entangled"
-                checked: bridge && bridge.is_entangled ? true : false
+                checked: bridgeCol.bridge && bridgeCol.bridge.is_entangled ? true : false
                 onToggled: store.set_bridge_entangled(store.selectedBridge, checked)
             }
         }
     }
     Connections {
         target: store
-        onSelectionChanged: {
+        function onSelectionChanged() {
             nodeLabel.text = store.selectedNode >= 0 ? store.get_node(store.selectedNode).label || "" : ""
         }
-        onEdgeSelectionChanged: {
+        function onEdgeSelectionChanged() {
             edgeCol.edge = store.get_edge(store.selectedEdge)
             edgeDelay.text = edgeCol.edge && edgeCol.edge.delay !== undefined ? edgeCol.edge.delay : ""
         }
-        onObserverSelectionChanged: {
+        function onObserverSelectionChanged() {
             obsCol.obs = store.get_observer(store.selectedObserver)
             obsId.text = obsCol.obs ? obsCol.obs.id || "" : ""
             obsFreq.text = obsCol.obs && obsCol.obs.frequency !== undefined ? obsCol.obs.frequency : ""
         }
-        onBridgeSelectionChanged: {
+        function onBridgeSelectionChanged() {
             bridgeCol.bridge = store.get_bridge(store.selectedBridge)
             entangledBox.checked = bridgeCol.bridge && bridgeCol.bridge.is_entangled ? true : false
         }

--- a/ui_new/panels/LogExplorer.qml
+++ b/ui_new/panels/LogExplorer.qml
@@ -1,11 +1,12 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Rectangle {
     color: "#202020"
     anchors.fill: parent
 
-    Column {
+    ColumnLayout {
         anchors.margins: 8
         anchors.fill: parent
         spacing: 4
@@ -22,7 +23,8 @@ Rectangle {
             }
         }
         ListView {
-            anchors.fill: parent
+            Layout.fillWidth: true
+            Layout.fillHeight: true
             model: logsModel
             delegate: Text {
                 text: modelData

--- a/ui_new/panels/Results.qml
+++ b/ui_new/panels/Results.qml
@@ -1,11 +1,12 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Rectangle {
     color: "#202020"
     anchors.fill: parent
 
-    Column {
+    ColumnLayout {
         anchors.margins: 8
         anchors.fill: parent
         spacing: 4
@@ -46,7 +47,8 @@ Rectangle {
         }
         Button { text: "Refresh"; onClicked: resultsModel.refresh() }
         ListView {
-            anchors.fill: parent
+            Layout.fillWidth: true
+            Layout.fillHeight: true
             model: resultsModel.rows
             delegate: Rectangle {
                 width: parent.width

--- a/ui_new/panels/Validation.qml
+++ b/ui_new/panels/Validation.qml
@@ -1,8 +1,9 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Item {
-    Column {
+    ColumnLayout {
         anchors.fill: parent
         spacing: 4
         Button {
@@ -16,7 +17,8 @@ Item {
             }
         }
         ListView {
-            anchors.fill: parent
+            Layout.fillWidth: true
+            Layout.fillHeight: true
             model: ListModel { id: warningsModel }
             delegate: Text { text: msg }
         }


### PR DESCRIPTION
## Summary
- replace deprecated Connection handlers and fix undefined property use in Inspector
- convert various panels to `ColumnLayout` and adjust StackLayout children to use Layout.fill bindings
- implement proper QSGMaterial types and createShader signatures for custom materials

## Testing
- `python -m compileall Causal_Web cw ui_new/graph/GraphView.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9533c77748325ad646b33d80f9aac