### PR TITLE
Handle PySide6 shader API change

### DIFF
--- a/ui_new/graph/GraphView.py
+++ b/ui_new/graph/GraphView.py
@@ -76,8 +76,18 @@ class _InstancedShader(QSGMaterialShader):
 
     def __init__(self) -> None:  # pragma: no cover - Qt binding detail
         super().__init__()
-        self.setShaderSourceCode(QSGMaterialShader.VertexStage, self.VERTEX)
-        self.setShaderSourceCode(QSGMaterialShader.FragmentStage, self.FRAG)
+        if hasattr(self, "setShaderSourceCode"):
+            self.setShaderSourceCode(QSGMaterialShader.VertexStage, self.VERTEX)
+            self.setShaderSourceCode(QSGMaterialShader.FragmentStage, self.FRAG)
+        else:
+            from tempfile import NamedTemporaryFile
+
+            with NamedTemporaryFile(delete=False, suffix=".vert") as vf:
+                vf.write(self.VERTEX)
+            with NamedTemporaryFile(delete=False, suffix=".frag") as ff:
+                ff.write(self.FRAG)
+            self.setShaderFileName(QSGMaterialShader.VertexStage, vf.name)
+            self.setShaderFileName(QSGMaterialShader.FragmentStage, ff.name)
         self.setAttributeNames([b"aVertex", b"aOffset", b"aColor", b"aFlag"])
 
     def updateState(
@@ -145,8 +155,18 @@ class _EdgeShader(QSGMaterialShader):
 
     def __init__(self) -> None:  # pragma: no cover - Qt binding detail
         super().__init__()
-        self.setShaderSourceCode(QSGMaterialShader.VertexStage, self.VERTEX)
-        self.setShaderSourceCode(QSGMaterialShader.FragmentStage, self.FRAG)
+        if hasattr(self, "setShaderSourceCode"):
+            self.setShaderSourceCode(QSGMaterialShader.VertexStage, self.VERTEX)
+            self.setShaderSourceCode(QSGMaterialShader.FragmentStage, self.FRAG)
+        else:
+            from tempfile import NamedTemporaryFile
+
+            with NamedTemporaryFile(delete=False, suffix=".vert") as vf:
+                vf.write(self.VERTEX)
+            with NamedTemporaryFile(delete=False, suffix=".frag") as ff:
+                ff.write(self.FRAG)
+            self.setShaderFileName(QSGMaterialShader.VertexStage, vf.name)
+            self.setShaderFileName(QSGMaterialShader.FragmentStage, ff.name)
         self.setAttributeNames([b"aVertex", b"aStart", b"aEnd"])
 
     def updateState(

--- a/ui_new/panels/Compare.qml
+++ b/ui_new/panels/Compare.qml
@@ -50,7 +50,7 @@ Rectangle {
                 Text { text: "Run A"; color: "white" }
                   Image {
                       id: imgA
-                      source: compareModel.frameA || ""
+                      source: compareModel.frameA !== undefined ? compareModel.frameA : ""
                       width: 200; height: 200
                       fillMode: Image.PreserveAspectFit
                   }
@@ -60,7 +60,7 @@ Rectangle {
                 Text { text: "Run B"; color: "white" }
                   Image {
                       id: imgB
-                      source: compareModel.frameB || ""
+                      source: compareModel.frameB !== undefined ? compareModel.frameB : ""
                       width: 200; height: 200
                       fillMode: Image.PreserveAspectFit
                   }


### PR DESCRIPTION
## Summary
- Add runtime check for `setShaderSourceCode` and fall back to `setShaderFileName`
- Guard Compare panel image sources against undefined values

## Testing
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pip install -r requirements.txt`
- `pytest`
- `python -m Causal_Web.main` *(fails: Could not load the Qt platform plugin "xcb")*

------
https://chatgpt.com/codex/tasks/task_e_68a954c282d08325bf69d7a81ec76885