### PR TITLE
Wrap panel components to avoid layout anchor conflicts

### DIFF
--- a/ui_new/main.qml
+++ b/ui_new/main.qml
@@ -220,19 +220,71 @@ Window {
             anchors.bottom: parent.bottom
             currentIndex: tabBar.currentIndex
 
-            Telemetry { Layout.fillWidth: true; Layout.fillHeight: true; graphView: graphView }
-            Meters { Layout.fillWidth: true; Layout.fillHeight: true }
-            Experiment { Layout.fillWidth: true; Layout.fillHeight: true; graphView: graphView }
-            Replay { Layout.fillWidth: true; Layout.fillHeight: true }
-            Results { Layout.fillWidth: true; Layout.fillHeight: true }
-            LogExplorer { Layout.fillWidth: true; Layout.fillHeight: true }
-            Inspector { Layout.fillWidth: true; Layout.fillHeight: true }
-            Validation { Layout.fillWidth: true; Layout.fillHeight: true }
-            DOE { Layout.fillWidth: true; Layout.fillHeight: true; panels: panels; replayIndex: 3; compareIndex: 12 }
-            GA { Layout.fillWidth: true; Layout.fillHeight: true; panels: panels; replayIndex: 3; compareIndex: 12 }
-            MCTS { Layout.fillWidth: true; Layout.fillHeight: true; panels: panels; replayIndex: 3 }
-            Policy { Layout.fillWidth: true; Layout.fillHeight: true }
-            Compare { Layout.fillWidth: true; Layout.fillHeight: true }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Telemetry { graphView: graphView }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Meters { }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Experiment { graphView: graphView }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Replay { }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Results { }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                LogExplorer { }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Inspector { }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Validation { }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                DOE { panels: panels; replayIndex: 3; compareIndex: 12 }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                GA { panels: panels; replayIndex: 3; compareIndex: 12 }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                MCTS { panels: panels; replayIndex: 3 }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Policy { }
+            }
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Compare { }
+            }
         }
     }
 }

--- a/ui_new/panels/Compare.qml
+++ b/ui_new/panels/Compare.qml
@@ -71,7 +71,9 @@ Rectangle {
                 Blend {
                     source: imgA
                     foregroundSource: imgB
-                    mode: Blend.Difference
+                    // Qt5Compat.GraphicalEffects expects a string for blend mode.
+                    // Using the literal ensures compatibility across Qt versions.
+                    mode: "difference"
                     width: 200; height: 200
                 }
             }


### PR DESCRIPTION
## Summary
- Wrap each StackLayout panel in an intermediate `Item` to remove anchor/layout conflicts
- Fix Compare panel blend mode assignment for Qt5Compat

## Testing
- `pip install -r requirements.txt`
- `python -m compileall Causal_Web cw`
- `pytest`
- `QT_QPA_PLATFORM=offscreen python -m Causal_Web.main` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a956f0c488832590211af10d5cd144