### PR TITLE
Pin numpy dependency for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ imageio
 matplotlib
 msgpack
 networkx
-numpy
+numpy==1.26.4
 pandas
 pydantic
 psycopg2


### PR DESCRIPTION
## Summary
- pin numpy to version 1.26.4 in requirements

## Testing
- `python -m compileall Causal_Web cw`
- `black --check Causal_Web cw`
- `pip install -r requirements.txt`
- `pytest` *(fails: TypeError ufunc 'right_shift' not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a96645f7048325946bfba3034670b5