### PR TITLE
Fix CI test failure caused by unused pytest-qt plugin

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
-addopts = -ra
+# Disable pytest-qt plugin to avoid PySide6 dependency on libGL
+addopts = -ra -p no:pytestqt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ qasync>=0.24.0
 websockets>=10.4
 pyqtgraph>=0.13.7
 pytest
-pytest-qt
 ruff
 mypy


### PR DESCRIPTION
## Summary
- remove unused `pytest-qt` dependency that pulled in PySide6 and required `libGL.so.1`
- disable pytest-qt plugin via `pytest.ini` to guard against accidental installation

## Testing
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9f00293188325b2905687e0faa1c5