### PR TITLE
feat: add session bundle handoff

### DIFF
--- a/Causal_Web/engine/run.py
+++ b/Causal_Web/engine/run.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""CLI entrypoint to run the engine WebSocket server."""
+
+import argparse
+import asyncio
+
+from ..config import Config, load_config
+from .engine_v2 import adapter as eng
+from .stream.server import DeltaBus, serve
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the engine server."""
+
+    parser = argparse.ArgumentParser(description="Run Causal Web engine")
+    parser.add_argument(
+        "--config", default=Config.input_path("config.json"), help="Config JSON file"
+    )
+    parser.add_argument("--graph", default=Config.graph_file, help="Graph JSON file")
+    parser.add_argument("--host", default="127.0.0.1", help="WebSocket host")
+    parser.add_argument("--port", type=int, default=8765, help="WebSocket port")
+    parser.add_argument(
+        "--session-file", default=None, help="Path to session bundle JSON"
+    )
+    parser.add_argument("--session-token", default=None, help="Explicit session token")
+    parser.add_argument(
+        "--session-ttl", type=int, default=3600, help="Token lifetime in seconds"
+    )
+    return parser.parse_args(argv)
+
+
+async def _serve(args: argparse.Namespace) -> None:
+    """Launch the WebSocket server with the configured adapter."""
+
+    adapter = eng.get_engine()
+    bus = DeltaBus()
+    await serve(
+        bus,
+        adapter,
+        host=args.host,
+        port=args.port,
+        session_token=args.session_token,
+        session_file=args.session_file,
+        session_ttl=args.session_ttl,
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the engine server with the provided arguments."""
+
+    args = _parse_args(argv)
+    load_config(args.config)
+    Config.graph_file = args.graph
+    eng.build_graph(args.graph)
+    with Config.state_lock:
+        Config.is_running = True
+    eng.simulation_loop()
+    try:
+        asyncio.run(_serve(args))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/Causal_Web/engine/stream/auth.py
+++ b/Causal_Web/engine/stream/auth.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+
+def default_session_file() -> Path:
+    """Return the platform-appropriate default session file path."""
+    if os.name == "nt":
+        base = os.getenv("LOCALAPPDATA") or Path.home() / "AppData" / "Local"
+        return Path(base) / "CausalWeb" / "sessions" / "current.json"
+    base = (
+        os.getenv("XDG_RUNTIME_DIR")
+        or os.getenv("XDG_CACHE_HOME")
+        or Path.home() / ".cache"
+    )
+    return Path(base) / "causalweb" / "session.json"
+
+
+def write_session_bundle(
+    host: str,
+    port: int,
+    token: str,
+    ttl: int,
+    path: str | os.PathLike[str] | None = None,
+) -> Tuple[Dict[str, Any], Path]:
+    """Write the session bundle JSON with best-effort 0600 perms."""
+    issued = int(time.time())
+    bundle = {
+        "v": 1,
+        "host": host,
+        "port": port,
+        "token": token,
+        "issued_at": issued,
+        "expires_at": issued + ttl,
+    }
+    dest = Path(path) if path else default_session_file()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    data = json.dumps(bundle)
+    if os.name == "nt":
+        tmp.write_text(data)
+        os.replace(tmp, dest)
+    else:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            f.write(data)
+        os.replace(tmp, dest)
+    return bundle, dest

--- a/README.md
+++ b/README.md
@@ -30,14 +30,35 @@ SnapshotDelta = {
 }
 ```
 
-The engine prints a random session token at startup. Clients must begin with a
-`Hello` message carrying this token; the server closes connections that omit or
-mismatch it. The first client to complete this handshake becomes the controller.
-Set `CW_ALLOW_MULTI=1` to permit additional spectators. Spectators receive
-read-only updates and any control commands they send are rejected. They may
-issue a request for control which the current controller can grant without
+The engine writes a session bundle containing host, port and a random token to a
+per-user path at startup. Clients must begin with a `Hello` message carrying
+this token; the server closes connections that omit, mismatch or use an expired
+token. Set `CW_ALLOW_MULTI=1` to permit additional spectators. Spectators
+receive read-only updates and any control commands they send are rejected. They
+may issue a request for control which the current controller can grant without
 restarting. Role changes are broadcast so UIs can display a small
 "Controller"/"Spectator" badge. Float32 fields keep payloads lean.
+
+## Two-process mode
+
+Run the engine and GUI as separate processes. The engine writes a session
+bundle to a per-user path and the GUI discovers it automatically:
+
+```bash
+python -m Causal_Web.engine.run --session-file <PATH>
+python -m Causal_Web.main
+```
+
+Override discovery via CLI flags or environment variables:
+
+| Setting | CLI flag | Environment |
+| --- | --- | --- |
+| WebSocket URL | `--ws-url` | `CW_WS_URL` |
+| Host | `--ws-host` / `--host` | `CW_WS_HOST` |
+| Port | `--ws-port` / `--port` | `CW_WS_PORT` |
+| Token | `--token` / `--session-token` | `CW_SESSION_TOKEN` |
+| Session file | `--token-file` / `--session-file` | `CW_SESSION_FILE` |
+| Session TTL | `--session-ttl` | `CW_SESSION_TTL` |
 
 ## Compare panel
 

--- a/tests/test_gui_discovery.py
+++ b/tests/test_gui_discovery.py
@@ -1,0 +1,86 @@
+import asyncio
+import threading
+import time
+
+from Causal_Web.engine.stream.server import DeltaBus, serve
+from ui_new import core
+from ui_new.auth import resolve_connection_info
+from ui_new.state import (
+    Store,
+    TelemetryModel,
+    ExperimentModel,
+    ReplayModel,
+    LogsModel,
+    DOEModel,
+    GAModel,
+    MCTSModel,
+    PolicyModel,
+)
+
+
+class View:
+    def set_graph(self, *args, **kwargs):
+        pass
+
+    def apply_delta(self, *args, **kwargs):
+        pass
+
+
+class Window:
+    controlsEnabled = False
+
+
+def _start_loop(loop):
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+class Adapter:
+    def graph_static(self):
+        return {"node_positions": [], "edges": []}
+
+
+def test_gui_reads_bundle_and_receives_graph(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    bus = DeltaBus()
+    bus.put({"frame": 0})
+    adapter = Adapter()
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=_start_loop, args=(loop,), daemon=True)
+    thread.start()
+    server_future = asyncio.run_coroutine_threadsafe(serve(bus, adapter), loop)
+    time.sleep(0.1)
+    url, token = resolve_connection_info()
+    telemetry = TelemetryModel()
+    experiment = ExperimentModel()
+    replay = ReplayModel()
+    logs = LogsModel()
+    store = Store()
+    doe = DOEModel()
+    ga = GAModel()
+    mcts = MCTSModel()
+    policy = PolicyModel()
+    gui_future = asyncio.run_coroutine_threadsafe(
+        core.run(
+            url,
+            View(),
+            telemetry,
+            experiment,
+            replay,
+            logs,
+            store,
+            doe,
+            ga,
+            mcts,
+            policy,
+            Window(),
+            token=token,
+        ),
+        loop,
+    )
+    time.sleep(0.5)
+    assert store.graph_static
+    gui_future.cancel()
+    server_future.cancel()
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=1)

--- a/tests/test_gui_retry.py
+++ b/tests/test_gui_retry.py
@@ -1,0 +1,95 @@
+import asyncio
+import threading
+import time
+
+from Causal_Web.engine.stream.server import DeltaBus, serve
+from ui_new import core
+from ui_new.auth import resolve_connection_info
+from ui_new.ipc import ConnectError
+from ui_new.state import (
+    Store,
+    TelemetryModel,
+    ExperimentModel,
+    ReplayModel,
+    LogsModel,
+    DOEModel,
+    GAModel,
+    MCTSModel,
+    PolicyModel,
+)
+
+
+class View:
+    def set_graph(self, *args, **kwargs):
+        pass
+
+    def apply_delta(self, *args, **kwargs):
+        pass
+
+
+class Window:
+    controlsEnabled = False
+
+
+def _start_loop(loop):
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+class Adapter:
+    def graph_static(self):
+        return {"node_positions": [], "edges": []}
+
+
+def test_gui_starts_before_engine_then_connects(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=_start_loop, args=(loop,), daemon=True)
+    thread.start()
+
+    telemetry = TelemetryModel()
+    experiment = ExperimentModel()
+    replay = ReplayModel()
+    logs = LogsModel()
+    store = Store()
+    doe = DOEModel()
+    ga = GAModel()
+    mcts = MCTSModel()
+    policy = PolicyModel()
+
+    async def gui():
+        for _ in range(10):
+            try:
+                url, token = resolve_connection_info()
+                await core.run(
+                    url,
+                    View(),
+                    telemetry,
+                    experiment,
+                    replay,
+                    logs,
+                    store,
+                    doe,
+                    ga,
+                    mcts,
+                    policy,
+                    Window(),
+                    token=token,
+                )
+                return
+            except (FileNotFoundError, ConnectError):
+                await asyncio.sleep(0.3)
+        raise RuntimeError("Could not connect")
+
+    gui_future = asyncio.run_coroutine_threadsafe(gui(), loop)
+    time.sleep(0.5)
+    bus = DeltaBus()
+    bus.put({"frame": 0})
+    adapter = Adapter()
+    server_future = asyncio.run_coroutine_threadsafe(serve(bus, adapter), loop)
+    time.sleep(0.5)
+    assert store.graph_static
+    gui_future.cancel()
+    server_future.cancel()
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=1)

--- a/tests/test_invalid_token.py
+++ b/tests/test_invalid_token.py
@@ -1,0 +1,50 @@
+import asyncio
+import threading
+import time
+
+import pytest
+
+from Causal_Web.engine.stream.server import DeltaBus, serve
+from ui_new.ipc import Client, ConnectError
+
+
+class View:
+    def set_graph(self, *args, **kwargs):
+        pass
+
+    def apply_delta(self, *args, **kwargs):
+        pass
+
+
+class Window:
+    controlsEnabled = False
+
+
+def _start_loop(loop):
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+class Adapter:
+    def graph_static(self):
+        return {"node_positions": [], "edges": []}
+
+
+def test_gui_rejects_wrong_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    bus = DeltaBus()
+    bus.put({"frame": 0})
+    adapter = Adapter()
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=_start_loop, args=(loop,), daemon=True)
+    thread.start()
+    server_future = asyncio.run_coroutine_threadsafe(
+        serve(bus, adapter, session_token="right"), loop
+    )
+    time.sleep(0.1)
+    client = Client("ws://127.0.0.1:8765", token="wrong")
+    with pytest.raises(ConnectError):
+        asyncio.run(client.connect())
+    server_future.cancel()
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=1)

--- a/tests/test_session_bundle.py
+++ b/tests/test_session_bundle.py
@@ -1,0 +1,19 @@
+import json
+import os
+import stat
+
+from Causal_Web.engine.stream.auth import default_session_file, write_session_bundle
+
+
+def test_bundle_written_with_defaults(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    expected = default_session_file()
+    bundle, path = write_session_bundle("127.0.0.1", 8765, "tok", 60)
+    assert path == expected
+    data = json.loads(path.read_text())
+    assert data["host"] == "127.0.0.1"
+    assert data["port"] == 8765
+    assert data["token"] == "tok"
+    if os.name != "nt":
+        mode = path.stat().st_mode & 0o777
+        assert mode == 0o600

--- a/ui_new/auth.py
+++ b/ui_new/auth.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Tuple
+
+from Causal_Web.engine.stream.auth import default_session_file
+
+
+def load_session_bundle(path: str | os.PathLike[str]) -> dict:
+    """Return the parsed JSON session bundle at ``path``."""
+
+    with open(path) as f:
+        return json.load(f)
+
+
+def resolve_connection_info(
+    ws_url: str | None = None,
+    token: str | None = None,
+    token_file: str | None = None,
+    ws_host: str | None = None,
+    ws_port: int | None = None,
+) -> Tuple[str, str]:
+    """Resolve WebSocket URL and token using CLI/env precedence."""
+    ws_url = ws_url or os.getenv("CW_WS_URL")
+    token = token or os.getenv("CW_SESSION_TOKEN")
+    token_file = token_file or os.getenv("CW_SESSION_FILE")
+    ws_host = ws_host or os.getenv("CW_WS_HOST", "127.0.0.1")
+    ws_port = int(os.getenv("CW_WS_PORT", str(ws_port or 8765)))
+
+    if ws_url:
+        if token is None and token_file:
+            bundle = load_session_bundle(token_file)
+            token = bundle.get("token", "")
+        return ws_url, token or ""
+
+    if token:
+        return f"ws://{ws_host}:{ws_port}", token
+
+    bundle_path = token_file or default_session_file()
+    bundle = load_session_bundle(bundle_path)
+    url = f"ws://{bundle['host']}:{bundle['port']}"
+    return url, bundle.get("token", "")

--- a/ui_new/ipc/__init__.py
+++ b/ui_new/ipc/__init__.py
@@ -1,5 +1,5 @@
 """IPC package for new UI."""
 
-from .Client import Client
+from .Client import Client, ConnectError
 
-__all__ = ["Client"]
+__all__ = ["Client", "ConnectError"]


### PR DESCRIPTION
## Summary
- write JSON session bundle for engine-GUI handoff
- let GUI auto-discover bundle, retry until engine is ready, and surface failures
- add standalone engine run entrypoint and document discovery flags

## Testing
- `pip install -r requirements.txt`
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pytest tests/test_session_bundle.py tests/test_gui_discovery.py tests/test_gui_retry.py tests/test_invalid_token.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa2558eabc83259ab72051c6f7826f