### PR TITLE
Show QML load errors in GUI startup

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -315,6 +315,12 @@ class MainService:
         qml_path = os.path.join(os.path.dirname(__file__), "..", "ui_new", "main.qml")
         engine.load(qml_path)
         if not engine.rootObjects():
+            errors = "\n".join(str(e) for e in engine.warnings())
+            QMessageBox.critical(
+                None,
+                "UI load error",
+                f"Failed to load QML at {qml_path}:\n{errors}",
+            )
             return
         root = engine.rootObjects()[0]
         view = root.findChild(QQuickItem, "graphView")

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ launches the engine and Qt Quick interface.
 - **Disconnected** → token mismatch or single-client limit.
 - **Low FPS** → zoom out, labels auto-hide; disable AA at far zoom.
 - **Invariant failures** → inspect `result.json` for violations.
+- **GUI doesn't launch** → the application will report missing QML resources or other load errors in a pop-up dialog; ensure the `ui_new` directory is present alongside the executable.
 
 ## Installation
 Clone the repository and install the packages listed in `requirements.txt`. The GUI requires an X11 compatible display.


### PR DESCRIPTION
## Summary
- Alert users when the GUI fails to load its QML files and show the underlying error
- Document missing QML troubleshooting step in README

## Testing
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pip install -r requirements.txt`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaf81dc348325940a6037dbb9c003