### PR TITLE
Capture QML warnings during GUI load

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -313,9 +313,11 @@ class MainService:
         ctx.setContextProperty("compareModel", compare)
         ctx.setContextProperty("resultsModel", results)
         qml_path = os.path.join(os.path.dirname(__file__), "..", "ui_new", "main.qml")
+        qml_warnings: list = []
+        engine.warnings.connect(lambda w: qml_warnings.extend(w))
         engine.load(qml_path)
         if not engine.rootObjects():
-            errors = "\n".join(str(e) for e in engine.warnings())
+            errors = "\n".join(str(e) for e in qml_warnings)
             QMessageBox.critical(
                 None,
                 "UI load error",


### PR DESCRIPTION
## Summary
- capture QML engine warnings emitted during GUI initialization

## Testing
- `pip install -r requirements.txt`
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68aab6f687208325aad4023db60202ea