### PR TITLE
Fix QML path resolution for GUI bundle

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -312,7 +312,11 @@ class MainService:
         ctx.setContextProperty("policyModel", policy_model)
         ctx.setContextProperty("compareModel", compare)
         ctx.setContextProperty("resultsModel", results)
-        qml_path = os.path.join(os.path.dirname(__file__), "..", "ui_new", "main.qml")
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        qml_path = os.path.join(base_dir, "..", "ui_new", "main.qml")
+        if not os.path.exists(qml_path):
+            qml_path = os.path.join(base_dir, "ui_new", "main.qml")
+        qml_path = os.path.abspath(qml_path)
         qml_warnings: list = []
         engine.warnings.connect(lambda w: qml_warnings.extend(w))
         engine.load(qml_path)


### PR DESCRIPTION
## Summary
- robustly resolve main QML path for both source and PyInstaller bundle layouts

## Testing
- `pip install -r requirements.txt`
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aac7b355448325932e83eaf8c133dc