### PR TITLE
Avoid SplitMix64 overflow warnings

### DIFF
--- a/Causal_Web/database/run_meta.py
+++ b/Causal_Web/database/run_meta.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 import psycopg2
@@ -62,7 +62,7 @@ def record_run(
         cfg = json.load(fh)
     data = {
         "run_id": run_id,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "description": cfg.get("description"),
         "seed": cfg.get("random_seed"),
         "tick_limit": cfg.get("tick_limit"),

--- a/Causal_Web/engine/engine_v2/loader.py
+++ b/Causal_Web/engine/engine_v2/loader.py
@@ -111,15 +111,14 @@ def load_graph_arrays(
 
     # Initialise ancestry hashes using SplitMix64 and seed the moment vector.
 
-    def _smix(x: np.uint64) -> np.uint64:
-        x = (x + np.uint64(0x9E3779B97F4A7C15)) & np.uint64(0xFFFFFFFFFFFFFFFF)
-        z = x
-        z = (z ^ (z >> np.uint64(30))) * np.uint64(0xBF58476D1CE4E5B9)
-        z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94D049BB133111EB)
-        return z ^ (z >> np.uint64(31))
+    def _smix(x: int | np.uint64) -> int:
+        z = (int(x) + 0x9E3779B97F4A7C15) & 0xFFFFFFFFFFFFFFFF
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9 & 0xFFFFFFFFFFFFFFFF
+        z = (z ^ (z >> 27)) * 0x94D049BB133111EB & 0xFFFFFFFFFFFFFFFF
+        return (z ^ (z >> 31)) & 0xFFFFFFFFFFFFFFFF
 
     for vid in range(n_vert):
-        h = _smix(np.uint64(vid))
+        h = _smix(vid)
         vertices["h0"][vid] = h
         h = _smix(h)
         vertices["h1"][vid] = h

--- a/Causal_Web/ingest/service.py
+++ b/Causal_Web/ingest/service.py
@@ -6,7 +6,7 @@ import asyncio
 import io
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterable
 
 import psycopg2
@@ -145,7 +145,7 @@ async def ingest_run(run_dir: str) -> None:
         await asyncio.gather(*tasks)
 
     manifest[run_id] = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "status": "ingested",
     }
     _save_manifest(manifest_path, manifest)

--- a/experiments/artifacts.py
+++ b/experiments/artifacts.py
@@ -10,7 +10,7 @@ and allow users to replay or promote configurations.
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import secrets
 import yaml
@@ -186,7 +186,7 @@ def allocate_run_dir(root: Path = Path("experiments")) -> Tuple[str, Path, str]:
         artifact records.
     """
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     token = secrets.token_hex(3)
     date = now.strftime("%Y-%m-%d")
     run_id = f"{now.strftime('%Y-%m-%dT%H-%M-%SZ')}-{token}"

--- a/telemetry/metrics.py
+++ b/telemetry/metrics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import csv
 import json
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import subprocess
 from typing import Dict, Iterable, List
@@ -51,7 +51,7 @@ class MetricsLogger:
             "sample": sample,
             "seed": seed,
             "git": _GIT,
-            "ts": datetime.utcnow().isoformat() + "Z",
+            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             **groups,
             **{f"raw_{k}": v for k, v in raw.items()},
             **gate_metrics,

--- a/tests/experiments/test_ga.py
+++ b/tests/experiments/test_ga.py
@@ -397,7 +397,10 @@ def test_checkpoint_persists_pending(tmp_path: pathlib.Path) -> None:
         ga._async_eval_genome(genome, ga._seed_for_genome(genome)), loop
     )
 
-    time.sleep(0.01)
+    for _ in range(100):
+        if client.sent:
+            break
+        time.sleep(0.01)
     ckpt = tmp_path / "ga.pkl"
     ga.save_checkpoint(ckpt)
 


### PR DESCRIPTION
## Summary
- remove NumPy reduction from bell helper to keep SplitMix64 seeding in pure Python
- apply SplitMix64 fix across engine helpers for consistent hashing
- replace `datetime.utcnow()` with `datetime.now(timezone.utc)` across metrics and run logging for RFC3339 timestamps
- make GA checkpoint test wait for initial evaluation to avoid race flakiness
- compute adapter ancestry hash via Python integers to eliminate potential NumPy overflow warnings
- drop deprecated temp token file in websocket server and record session token in bundle

## Testing
- `python -m compileall Causal_Web cw`
- `pytest`
- `pytest tests/test_gui_discovery.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab28d9229c8325a2acff8bdc7a28bd