### PR TITLE
chore(ci): retry apt operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
           python-version: '3.11'
       - name: Install system libraries
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0
+          until sudo apt-get update; do sleep 5; done
+          until sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0; do sleep 5; done
       - name: Install dependencies
         run: pip install -r requirements.txt -c constraints.txt
       - name: Guard environment
@@ -32,8 +32,8 @@ jobs:
           python-version: '3.11'
       - name: Install system libraries
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0
+          until sudo apt-get update; do sleep 5; done
+          until sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0; do sleep 5; done
       - name: Install dependencies
         run: |
           pip install -r requirements.txt -c constraints.txt
@@ -58,8 +58,8 @@ jobs:
           python-version: '3.11'
       - name: Install system libraries
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0
+          until sudo apt-get update; do sleep 5; done
+          until sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0; do sleep 5; done
       - name: Install dependencies
         run: pip install -r requirements.txt -c constraints.txt
       - name: Guard environment


### PR DESCRIPTION
## Summary
- retry apt update and install in CI to avoid dpkg lock failures

## Testing
- `python -m compileall Causal_Web cw`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab4c5dce908325a783b99ac173b05a