### PR TITLE
Keep GUI running while waiting for engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ python -m Causal_Web.engine.run --session-file <PATH>
 python -m Causal_Web.main
 ```
 
+If the GUI starts before the engine, it remains open and keeps polling
+for a connection. After several failed attempts a dialog prompts to
+retry or quit.
+
 Override discovery via CLI flags or environment variables:
 
 | Setting | CLI flag | Environment |


### PR DESCRIPTION
## Summary
- retry engine discovery and after 20 failures prompt to retry or quit
- document retry-or-quit dialog in two-process mode section

## Testing
- `pip install -r requirements.txt`
- `apt-get update`
- `apt-get install -y libgl1`
- `apt-get install -y libegl1`
- `apt-get install -y libxkbcommon0`
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pytest`
- `python -m Causal_Web.main --no-gui --tick_limit 1`
- `python bundle_run.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab93e6812483258c75878aadc0d2ff