### PR TITLE
feat: add verbose logging flag

### DIFF
--- a/Causal_Web/main.py
+++ b/Causal_Web/main.py
@@ -130,6 +130,10 @@ class MainService:
     def run(self) -> None:
         _configure_logging()
         args, cfg = self._parse_args()
+        if getattr(args, "verbose", False):
+            root = logging.getLogger()
+            root.setLevel(logging.DEBUG)
+            root.addHandler(logging.StreamHandler())
         _apply_overrides(args, cfg)
         self._apply_log_overrides(args)
         Config.profile_output = getattr(args, "profile_output", None)
@@ -231,6 +235,11 @@ class MainService:
             "--disable-events",
             default="",
             help="Comma-separated event types to disable",
+        )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Enable debug logging to console",
         )
         parser.add_argument("--ws-url", default=None, help="WebSocket URL of engine")
         parser.add_argument("--ws-host", default=None, help="Engine host override")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A GPU-accelerated Qt Quick / QML interface lives in `ui_new` and serves as the d
 The GUI writes diagnostic information and uncaught exceptions to `cw_gui.log`
 in the working directory. Connection attempts and handshake events with the
 engine are recorded to aid troubleshooting when the window closes unexpectedly.
+Use `--verbose` to also stream debug logs to the console.
 
 ## Architecture & IPC
 


### PR DESCRIPTION
## Summary
- add `--verbose` CLI flag to stream debug logs to console
- document `--verbose` logging option in README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68abf659c860832581a61ae16371ff91