### PR TITLE
Handle WebSocket connection timeouts in client

### DIFF
--- a/ui_new/ipc/Client.py
+++ b/ui_new/ipc/Client.py
@@ -46,7 +46,13 @@ class Client:
         self._logger = logging.getLogger(__name__)
 
     async def connect(self) -> None:
-        """Open the WebSocket connection and perform the hello handshake."""
+        """Open the WebSocket connection and perform the hello handshake.
+
+        Raises
+        ------
+        ConnectError
+            If the connection attempt fails or times out.
+        """
         try:
             self._logger.info("Connecting to %s", self.url)
             self.connection = await websockets.connect(self.url)
@@ -57,7 +63,7 @@ class Client:
             self._logger.debug("Received handshake response: %s", msg)
             if msg.get("type") != "Hello":
                 raise ConnectError("handshake failed")
-        except (OSError, ConnectionClosedError) as e:
+        except (asyncio.TimeoutError, OSError, ConnectionClosedError) as e:
             self._logger.exception("Connection to %s failed", self.url)
             if self.connection is not None:
                 await self.connection.close()


### PR DESCRIPTION
## Summary
- handle asyncio.TimeoutError in WebSocket Client.connect
- document connection failure behavior

## Testing
- `pip install -r requirements.txt`
- `black Causal_Web cw ui_new/ipc/Client.py`
- `python -m compileall Causal_Web cw ui_new/ipc/Client.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68acaa42263c8325ad81b29ff64ef588