### PR TITLE
Improve WebSocket handshake logging

### DIFF
--- a/Causal_Web/engine/stream/server.py
+++ b/Causal_Web/engine/stream/server.py
@@ -184,10 +184,21 @@ async def serve(
 
         async def _close(reason: str) -> None:
             logging.warning("Closing connection %s: %s", ws.remote_address, reason)
-            await ws.close(reason=reason)
+            with contextlib.suppress(Exception):
+                await ws.close(reason=reason)
 
-        raw = await ws.recv()
-        msg = msgpack.unpackb(raw, raw=False)
+        try:
+            raw = await ws.recv()
+        except websockets.exceptions.ConnectionClosed:
+            logging.warning("Connection %s closed during handshake", ws.remote_address)
+            return
+
+        try:
+            msg = msgpack.unpackb(raw, raw=False)
+        except Exception:
+            await _close("invalid handshake")
+            return
+        logging.debug("Handshake message from %s: %s", ws.remote_address, msg)
         if msg.get("type") != "Hello":
             await _close("handshake required")
             return
@@ -199,6 +210,8 @@ async def serve(
         if session_token and token != session_token:
             await _close("unauthorized")
             return
+
+        logging.info("Handshake completed for %s", ws.remote_address)
 
         if primary is None:
             primary = ws


### PR DESCRIPTION
## Summary
- log WebSocket handshake payloads and completions
- handle premature WebSocket disconnects and invalid handshake payloads gracefully

## Testing
- `black Causal_Web cw`
- `python -m compileall Causal_Web cw`
- `pip install --break-system-packages -r requirements.txt`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68aca3e5ee7c8325bad066a81c89d48f